### PR TITLE
fix [setup]: build with `--no-build-isolation` to find and use the correct pytorch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ This will compile and install kvcached. If you have the right versions of vLLM a
 
 NOTE: `--no-build-isolation` is required for kvcached to find the right PyTorch in the current virtual environment.
 
-
 ## Testing
 
 To verify the successful installation and benchmark the performance of vLLM/SGLang with kvcached, run:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ kvcached is a KV cache management system for serving multiple Large Language Mod
 ## Prerequisites
 
 * Python (tested with 3.11)
+* PyTorch (tested with 2.6.0 and 2.7.0)
 * Virtual environment tools (scripts are provided for uv==0.7.12)
 
 **Important Note:** The scripts will create separate virtual environments using `uv` for vLLM and sglang.
@@ -27,25 +28,13 @@ This script will download the specified versions of vLLM and SGLang, create sepa
 If you want to install kvcached on your own, you can install it from source, run the following command:
 
 ```bash
-pip install -e .
+pip install -e . --no-build-isolation
 ```
 
 This will compile and install kvcached. If you have the right versions of vLLM and SGLang, you can apply the patches in `engine_integration/scripts`, and it should work.
 
+NOTE: `--no-build-isolation` is required for kvcached to find the right PyTorch in the current virtual environment.
 
-## Manual Compilation
-
-kvcached includes a CPP-based library called `vmm_ops` for managing low-level CUDA virtual memory operations. This library is typically built and installed automatically during the kvcached installation process. However, in some cases, the installation may not complete successfully, resulting in an import error when attempting to use kvcached. For example, you might encounter an error similar to this:
-
-```txt
-ImportError: /data/yifanqiao/code/kvcached/kvcached/vmm_ops.cpython-311-x86_64-linux-gnu.so: undefined symbol: _ZNK2at10TensorBase4nameB5cxx11Ev
-```
-
-To resolve this issue, one can rebuild the `vmm_ops` library locally by running:
-
-```python
-python setup.py build_ext --inplace
-```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,21 @@ This script will download the specified versions of vLLM and SGLang, create sepa
 If you want to install kvcached on your own, you can install it from source, run the following command:
 
 ```bash
+pip install -r requirements.txt # install build dependencies
 pip install -e . --no-build-isolation
 ```
 
 This will compile and install kvcached. If you have the right versions of vLLM and SGLang, you can apply the patches in `engine_integration/scripts`, and it should work.
 
 NOTE: `--no-build-isolation` is required for kvcached to find the right PyTorch in the current virtual environment.
+
+### Manual Compilation
+
+kvcached includes a CPP-based library called `vmm_ops` for managing low-level CUDA virtual memory operations. This library is typically built and installed automatically during the kvcached installation process. However, one can rebuild the `vmm_ops` library locally by running:
+
+```python
+python setup.py build_ext --inplace
+```
 
 ## Testing
 

--- a/engine_integration/scripts/setup.sh
+++ b/engine_integration/scripts/setup.sh
@@ -21,19 +21,17 @@ setup_vllm() {
 
     uv venv --python=python3.11
     source .venv/bin/activate
-
     uv pip install --upgrade pip
-    pushd "$KVCACHED_DIR"
-    uv pip install -e .
-    popd
 
     VLLM_USE_PRECOMPILED=1 uv pip install --editable .
     git apply "$SCRIPT_DIR/kvcached-vllm-v0.8.4.patch"
 
     pushd "$KVCACHED_DIR"
-    python setup.py build_ext --inplace # build again to avoid .so missing issue
+    uv pip install -e . --no-build-isolation
+    popd
 
     deactivate
+    popd
 }
 
 setup_sgl() {
@@ -44,20 +42,18 @@ setup_sgl() {
 
     uv venv --python=python3.11
     source .venv/bin/activate
-
     uv pip install --upgrade pip
-    pushd "$KVCACHED_DIR"
-    uv pip install -e .
-    popd
 
     uv pip install -e "python[all]"
     git apply "$SCRIPT_DIR/kvcached-sglang-v0.4.6.post2.patch"
 
     pushd "$KVCACHED_DIR"
-    python setup.py build_ext --inplace # build again to avoid .so missing issue
+    uv pip install -e . --no-build-isolation
+    popd
+
 
     deactivate
-    pushd "$SCRIPT_DIR"
+    popd
 }
 
 # Check for uv before proceeding

--- a/engine_integration/scripts/setup.sh
+++ b/engine_integration/scripts/setup.sh
@@ -13,6 +13,12 @@ check_uv() {
     fi
 }
 
+install_requirements() {
+    pushd "$KVCACHED_DIR"
+    uv pip install -r requirements.txt
+    popd
+}
+
 setup_vllm() {
     pushd "$ENGINE_DIR"
 
@@ -23,9 +29,13 @@ setup_vllm() {
     source .venv/bin/activate
     uv pip install --upgrade pip
 
+    # Install requirements for kvcached first to avoid overwriting vLLM's requirements
+    install_requirements
+
     VLLM_USE_PRECOMPILED=1 uv pip install --editable .
     git apply "$SCRIPT_DIR/kvcached-vllm-v0.8.4.patch"
 
+    # Install kvcached after installing VLLM to find the correct torch version
     pushd "$KVCACHED_DIR"
     uv pip install -e . --no-build-isolation
     popd
@@ -44,9 +54,13 @@ setup_sgl() {
     source .venv/bin/activate
     uv pip install --upgrade pip
 
+    # Install requirements for kvcached first to avoid overwriting sglang's requirements
+    install_requirements
+
     uv pip install -e "python[all]"
     git apply "$SCRIPT_DIR/kvcached-sglang-v0.4.6.post2.patch"
 
+    # Install kvcached after install sglang to find the correct torch version
     pushd "$KVCACHED_DIR"
     uv pip install -e . --no-build-isolation
     popd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "wheel", "torch>=2.4.0"]
+requires = ["setuptools>=64", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,6 @@ name = "kvcached"
 version = "0.1.0"
 readme = "README.md"
 dependencies = [
-    "torch>=2.4.0",
     "numpy>=1.26.0",
 ]
 requires-python = ">=3.9,<3.12"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Should be mirrored in pyproject.toml
+setuptools>=64
+wheel

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,9 @@ from pathlib import Path
 from typing import List
 
 from setuptools import setup
+
 try:
-    from torch.utils.cpp_extension import (CUDAExtension, BuildExtension,
+    from torch.utils.cpp_extension import (BuildExtension, CUDAExtension,
                                            include_paths, library_paths)
 except ImportError:
     raise ImportError("Torch not found, please install torch>=2.6.0 first.")

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,11 @@ from pathlib import Path
 from typing import List
 
 from setuptools import setup
+try:
+    from torch.utils.cpp_extension import (CUDAExtension, BuildExtension,
+                                           include_paths, library_paths)
+except ImportError:
+    raise ImportError("Torch not found, please install torch>=2.6.0 first.")
 
 SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 ROOT_PATH = SCRIPT_PATH
@@ -19,9 +24,6 @@ def get_csrc_files(path) -> List[str]:
 
 
 def get_extensions():
-    from torch.utils.cpp_extension import (CUDAExtension, BuildExtension,
-                                           include_paths, library_paths)
-
     csrc_files = get_csrc_files(CSRC_PATH)
 
     vmm_ops_module = CUDAExtension(
@@ -29,7 +31,7 @@ def get_extensions():
         csrc_files,
         include_dirs=include_paths() + [os.path.join(CSRC_PATH, "inc")],
         library_dirs=library_paths(),
-        libraries=["c10", "torch", "torch_cpu", "torch_python", "cuda"],
+        libraries=["torch", "torch_cpu", "torch_python", "cuda"],
     )
     return [vmm_ops_module], {"build_ext": BuildExtension}
 
@@ -41,7 +43,4 @@ setup(
     version="0.1.0",
     ext_modules=ext_modules,
     cmdclass=cmdclass,
-    install_requires=[
-        "torch",
-    ],
 )


### PR DESCRIPTION
To solve the problem of  ```ImportError: /data/yifanqiao/code/kvcached/kvcached/vmm_ops.cpython-311-x86_64-linux-gnu.so: undefined symbol: _ZNK2at10TensorBase4nameB5cxx11Ev```.