### PR TITLE
fix [sglang-integration]: disable overlap schedule for SGLang server launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ cd engine_integration/benchmark
 
 Please refer to each script for instructions on how to run vLLM/SGLang with kvcached.
 
+## Known issues
+
+If you observe the SGLang server crashing after the benchmark client finishes, please refer to [this issue](https://github.com/ovg-project/kvcached/issues/5) for a detailed explanation of the root cause and solutions.
+
 ## Contributing
 
 We are grateful for and open to contributions and collaborations of any kind.

--- a/engine_integration/benchmark/start_server.sh
+++ b/engine_integration/benchmark/start_server.sh
@@ -20,7 +20,7 @@ if [ "$op" == "vllm" ]; then
 elif [ "$op" == "sgl" -o "$op" == "sglang" ]; then
     source "$ENGINE_DIR/sglang-v0.4.6.post2/.venv/bin/activate"
     export PYTHONPATH="$KVCACHED_DIR:$PYTHONPATH"
-    python -m sglang.launch_server --model "$MODEL" --disable-radix-cache --trust-remote-code --port "$SGL_PORT"
+    python -m sglang.launch_server --model "$MODEL" --disable-radix-cache --disable-overlap-schedule --trust-remote-code --port "$SGL_PORT"
 else
     echo "Invalid option: $op"
     exit 1


### PR DESCRIPTION
Disable overlap schedule using `--disable-overlap-schedule` in the benchmark scripts for SGLang server launch. This prevents SGLang server from crashing during benchmarking. See [this issue](https://github.com/ovg-project/kvcached/issues/5) for more details.