### PR TITLE
[Bugfix] fix a warning condition for update_kv_cache_limit()

### DIFF
--- a/kvcached/controller/cli.py
+++ b/kvcached/controller/cli.py
@@ -39,9 +39,9 @@ def update_kv_cache_limit(ipc_name: str, kv_cache_limit: int):
             mem_info = np.ndarray((2, ), dtype=np.int64, buffer=mm)
             delta = kv_cache_limit - mem_info[0]
             if delta < 0:
-                if mem_info[1] + delta < 0:
+                if mem_info[0] - mem_info[1] + delta < 0:
                     logger.warning(
-                        f"kv_cache_limit is less than in_use for {ipc_name}")
+                        f"No enough free space to decrease for the new kv_cache_limit for {ipc_name}")
             mem_info[0] = kv_cache_limit
             return mem_info
     except FileNotFoundError:

--- a/kvcached/controller/cli.py
+++ b/kvcached/controller/cli.py
@@ -41,7 +41,8 @@ def update_kv_cache_limit(ipc_name: str, kv_cache_limit: int):
             if delta < 0:
                 if mem_info[0] - mem_info[1] + delta < 0:
                     logger.warning(
-                        f"No enough free space to decrease for the new kv_cache_limit for {ipc_name}")
+                        f"No enough free space to decrease for the new kv_cache_limit for {ipc_name}"
+                    )
             mem_info[0] = kv_cache_limit
             return mem_info
     except FileNotFoundError:


### PR DESCRIPTION
- Fixes a logging condition that previously was `mem_info[1] + delta < 0`.
- Replaced with a more accurate condition: `mem_info[0] - mem_info[1] + delta < 0`.
- This ensures that the warning is logged only when the decreased kv_cache_limit is smaller than current kv cache volume.