### PR TITLE
[Feat] kvcached enable/disable flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ python setup.py build_ext --inplace
 
 ## Testing
 
-To verify the successful installation and benchmark the performance of vLLM/SGLang with kvcached, run:
+kvcached can be enabled or disabled by `export ENABLE_KVCACHED=true` or `false`. To verify the successful installation and benchmark the performance of vLLM/SGLang with kvcached, run:
 
 ```bash
 cd engine_integration/benchmark
@@ -55,7 +55,7 @@ cd engine_integration/benchmark
 ./start_client.sh [vllm|sgl]
 ```
 
-Please refer to each script for instructions on how to run vLLM/SGLang with kvcached.
+The benchmark scripts automatically set `ENABLE_KVCACHED=true`. Please refer to each script for instructions on how to run vLLM/SGLang with kvcached.
 
 ## Known issues
 

--- a/engine_integration/benchmark/start_server.sh
+++ b/engine_integration/benchmark/start_server.sh
@@ -16,10 +16,12 @@ if [ "$op" == "vllm" ]; then
     export PYTHONPATH="$KVCACHED_DIR:$PYTHONPATH"
     export VLLM_USE_V1=1
     export VLLM_ATTENTION_BACKEND=FLASH_ATTN
+    export ENABLE_KVCACHED=true
     vllm serve "$MODEL" --disable-log-requests --no-enable-prefix-caching --port="$VLLM_PORT"
 elif [ "$op" == "sgl" -o "$op" == "sglang" ]; then
     source "$ENGINE_DIR/sglang-v0.4.6.post2/.venv/bin/activate"
     export PYTHONPATH="$KVCACHED_DIR:$PYTHONPATH"
+    export ENABLE_KVCACHED=true
     python -m sglang.launch_server --model "$MODEL" --disable-radix-cache --disable-overlap-schedule --trust-remote-code --port "$SGL_PORT"
 else
     echo "Invalid option: $op"

--- a/engine_integration/scripts/kvcached-sglang-v0.4.6.post2.patch
+++ b/engine_integration/scripts/kvcached-sglang-v0.4.6.post2.patch
@@ -1,60 +1,63 @@
 diff --git a/python/sglang/srt/mem_cache/memory_pool.py b/python/sglang/srt/mem_cache/memory_pool.py
-index f7eef212..90f10996 100644
+index f7eef212..3b24790f 100644
 --- a/python/sglang/srt/mem_cache/memory_pool.py
 +++ b/python/sglang/srt/mem_cache/memory_pool.py
-@@ -154,14 +154,25 @@ class TokenToKVPoolAllocator:
+@@ -154,14 +154,26 @@ class TokenToKVPoolAllocator:
          self.clear()
-
+ 
          self._kvcache = kvcache
-+        self.use_kvcached = (hasattr(kvcache, "use_kvcached") and
-+                             kvcache.use_kvcached)
-+        if self.use_kvcached:
++        self.enable_kvcached = (
++            hasattr(kvcache, "enable_kvcached") and kvcache.enable_kvcached
++        )
++        if self.enable_kvcached:
 +            self.kv_allocator = kvcache.kv_allocator
-
+ 
      def available_size(self):
-+        if self.use_kvcached:
++        if self.enable_kvcached:
 +            return self.kv_allocator.available_size()
          return len(self.free_slots)
-
+ 
      def get_kvcache(self):
          return self._kvcache
-
+ 
      def alloc(self, need_size: int):
-+        if self.use_kvcached:
++        if self.enable_kvcached:
 +            indices = self.kv_allocator.alloc(need_size)
 +            indices = torch.tensor(indices, dtype=torch.int32, device="cuda")
 +            return indices
 +
          if need_size > len(self.free_slots):
              return None
-
-@@ -174,6 +185,8 @@ class TokenToKVPoolAllocator:
+ 
+@@ -174,6 +186,8 @@ class TokenToKVPoolAllocator:
              return
-
+ 
          if self.is_not_in_free_group:
-+            if self.use_kvcached:
++            if self.enable_kvcached:
 +                return self.kv_allocator.free(free_index.cpu().numpy())
              self.free_slots = torch.cat((self.free_slots, free_index))
          else:
              self.free_group.append(free_index)
-@@ -194,6 +207,10 @@ class TokenToKVPoolAllocator:
+@@ -194,6 +208,10 @@ class TokenToKVPoolAllocator:
          self.free_slots = free_slots
-
+ 
      def clear(self):
-+        if hasattr(self, "use_kvcached") and self.use_kvcached:
++        if hasattr(self, "enable_kvcached") and self.enable_kvcached:
 +            self.kv_allocator.clear()
 +            return
 +
          # The padded slot 0 is used for writing dummy outputs from padded tokens.
          self.free_slots = torch.arange(
              1, self.size + 1, dtype=torch.int64, device=self.device
-@@ -233,6 +250,27 @@ class MHATokenToKVPool(KVCache):
+@@ -233,6 +251,31 @@ class MHATokenToKVPool(KVCache):
          self.head_num = head_num
          self.head_dim = head_dim
          self.layer_num = layer_num
 +
-+        self.use_kvcached = True
-+        if self.use_kvcached:
++        import os
++
++        self.enable_kvcached = os.getenv("ENABLE_KVCACHED", "false").lower() == "true"
++        if self.enable_kvcached:
 +            try:
 +                from kvcached import ops as kvcached_ops
 +                from kvcached.slab_allocator import KVCacheManager
@@ -71,24 +74,26 @@ index f7eef212..90f10996 100644
 +                    num_layers=end_layer - start_layer + 1,
 +                )
 +            except ImportError as e:
-+                raise ImportError("kvcached is not found. Please install it for elastic memory.") from e
++                raise ImportError(
++                    "kvcached is not found. Please install it for elastic memory."
++                ) from e
 +
          self._create_buffers()
          self.start_layer = start_layer or 0
          self.end_layer = end_layer or layer_num - 1
-@@ -247,7 +285,29 @@ class MHATokenToKVPool(KVCache):
+@@ -247,7 +290,29 @@ class MHATokenToKVPool(KVCache):
              f"KV Cache is allocated. #tokens: {size}, K size: {k_size / GB:.2f} GB, V size: {v_size / GB:.2f} GB"
          )
-
+ 
 +    def __del__(self):
-+        if self.use_kvcached and self.kv_allocator is not None:
++        if self.enable_kvcached and self.kv_allocator is not None:
 +            self.kvcached_ops.shutdown_kvcached()
 +            del self.kv_allocator
 +            self.k_buffer = None
 +            self.v_buffer = None
 +
      def _create_buffers(self):
-+        if self.use_kvcached:
++        if self.enable_kvcached:
 +            assert self.page_size == 1, "kvcached only supports page_size = 1 for SGL"
 +            k_buffer, v_buffer = self.kvcached_ops.sgl_alloc_kv_cache(
 +                self.size,
@@ -106,4 +111,3 @@ index f7eef212..90f10996 100644
          with self.memory_saver_adapter.region():
              # [size, head_num, head_dim] for each layer
              # The padded slot 0 is used for writing dummy outputs from padded tokens.
-

--- a/engine_integration/scripts/kvcached-vllm-v0.8.4.patch
+++ b/engine_integration/scripts/kvcached-vllm-v0.8.4.patch
@@ -95,33 +95,36 @@ index 74f3f7852..3f402d16b 100644
 +        """
 +        return 1.0 - (self.get_num_free_blocks() / self.num_gpu_blocks)
 diff --git a/vllm/v1/core/kv_cache_manager.py b/vllm/v1/core/kv_cache_manager.py
-index 33761cf7f..13ba583c2 100644
+index 33761cf7f..bc6f0fd84 100644
 --- a/vllm/v1/core/kv_cache_manager.py
 +++ b/vllm/v1/core/kv_cache_manager.py
-@@ -55,7 +55,21 @@ class KVCacheManager:
+@@ -55,7 +55,24 @@ class KVCacheManager:
          self.num_preallocate_blocks = cdiv(num_preallocate_tokens,
                                             self.block_size)
  
 -        self.block_pool = BlockPool(self.num_gpu_blocks, enable_caching)
-+        self.use_kvcached = True
-+        if self.use_kvcached:
-+            from vllm.v1.core.block_pool import ElasticBlockPool  # type: ignore
++        import os
++        self.enable_kvcached = os.getenv("ENABLE_KVCACHED",
++                                         "false").lower() == "true"
++        if self.enable_kvcached:
++            from vllm.v1.core.block_pool import (
++                ElasticBlockPool)  # type: ignore
 +            if self.enable_caching:
 +                raise ValueError("Caching is not supported for kvcached")
 +            # cell_size is the size of the k/v cache tensor for a single token.
 +            cell_size = kv_cache_spec.page_size_bytes // self.block_size // 2
-+            self.block_pool = ElasticBlockPool(
-+                self.num_gpu_blocks,
-+                self.block_size,
-+                cell_size=cell_size,
-+                num_layers=len(kv_cache_config.tensors),
-+                enable_caching=enable_caching)
++            self.block_pool = ElasticBlockPool(self.num_gpu_blocks,
++                                               self.block_size,
++                                               cell_size=cell_size,
++                                               num_layers=len(
++                                                   kv_cache_config.tensors),
++                                               enable_caching=enable_caching)
 +        else:
 +            self.block_pool = BlockPool(self.num_gpu_blocks, enable_caching)
  
          self.specialized_manager = get_specialized_manager(
              kv_cache_spec=kv_cache_spec,
-@@ -176,7 +190,7 @@ class KVCacheManager:
+@@ -176,7 +193,7 @@ class KVCacheManager:
              new_computed_blocks: A list of new computed blocks just hitting the
                  prefix caching.
              num_lookahead_tokens: The number of speculative tokens to allocate.
@@ -131,15 +134,17 @@ index 33761cf7f..13ba583c2 100644
  
          Blocks layout:
 diff --git a/vllm/v1/worker/gpu_model_runner.py b/vllm/v1/worker/gpu_model_runner.py
-index 70e8bd75e..f55254429 100644
+index 70e8bd75e..794465606 100644
 --- a/vllm/v1/worker/gpu_model_runner.py
 +++ b/vllm/v1/worker/gpu_model_runner.py
-@@ -272,6 +272,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+@@ -272,6 +272,14 @@ class GPUModelRunner(LoRAModelRunnerMixin):
                                          pin_memory=self.pin_memory)
          self.seq_lens_np = self.seq_lens_cpu.numpy()
  
-+        self.use_kvcached = True
-+        if self.use_kvcached:
++        import os
++        self.enable_kvcached = os.getenv("ENABLE_KVCACHED",
++                                         "false").lower() == "true"
++        if self.enable_kvcached:
 +            import kvcached.ops as kvcached_ops
 +            kvcached_ops.init_kvcached()
 +            self.kvcached_ops = kvcached_ops
@@ -147,11 +152,11 @@ index 70e8bd75e..f55254429 100644
      def _update_states(self, scheduler_output: "SchedulerOutput") -> None:
          """Update the cached states and the persistent batch with the scheduler
          output.
-@@ -1640,6 +1646,45 @@ class GPUModelRunner(LoRAModelRunnerMixin):
+@@ -1640,6 +1648,45 @@ class GPUModelRunner(LoRAModelRunnerMixin):
  
          kv_caches: dict[str, torch.Tensor] = {}
  
-+        if self.use_kvcached:
++        if self.enable_kvcached:
 +            for kv_cache_group in kv_cache_config.kv_cache_groups:
 +                kv_cache_spec = kv_cache_group.kv_cache_spec
 +                for layer_name in kv_cache_group.layer_names:


### PR DESCRIPTION
# Add environment variable for kvcached enable/disable

This PR introduces an environment variable `ENABLE_KVCACHED`  to enable/disable kvcached in vLLM and SGLang.

## Key Changes
- vLLM and SGLang integeration (their patches)
- Server launch script
- Update README

## Usage Examples

```bash
export ENABLE_KVCACHED=true
vllm serve meta-llama/Llama-3.2-1B --disable-log-requests --no-enable-prefix-caching --port=12346
# or
python -m sglang.launch_server --model meta-llama/Llama-3.2-1B --disable-radix-cache --disable-overlap-schedule --trust-remote-code --port 30000
```