### PR TITLE
fix [csrc]: make FTensorAllocator thread safe for overlap scheduling

### DIFF
--- a/csrc/allocator.cpp
+++ b/csrc/allocator.cpp
@@ -1,5 +1,7 @@
 #include <memory>
+#include <mutex>
 #include <torch/extension.h>
+#include <unordered_map>
 
 #include "allocator.hpp"
 #include "constants.hpp"
@@ -10,6 +12,7 @@
 
 namespace kvcached {
 std::unique_ptr<FTensorAllocator> FTensorAllocator::g_allocator_;
+std::mutex FTensorAllocator::g_allocator_mutex_;
 
 static inline std::shared_ptr<Page> make_shared_page(const torch::Device &dev,
                                                      page_id_t page_id) {
@@ -38,8 +41,8 @@ void FTensorAllocator::destroy() {
   zero_page_.reset();
 }
 
-/* FIXME (YIFAN): this is not thread safe. */
 void FTensorAllocator::init(const std::string &dev_str) {
+  std::lock_guard<std::mutex> lock(g_allocator_mutex_);
   if (g_allocator_) {
     LOGE("FTensorAllocator has been initialized. Re-initializing...")
     g_allocator_.reset();
@@ -50,52 +53,32 @@ void FTensorAllocator::init(const std::string &dev_str) {
 }
 
 FTensorAllocator *FTensorAllocator::global_allocator() {
+  std::lock_guard<std::mutex> lock(g_allocator_mutex_);
   assert(g_allocator_);
   return g_allocator_.get();
 }
 
 void FTensorAllocator::shutdown() {
+  std::lock_guard<std::mutex> lock(g_allocator_mutex_);
   if (g_allocator_) {
     g_allocator_.reset();
   }
-}
-
-torch::Tensor FTensorAllocator::create_ftensor(size_t size, torch::Dtype dtype,
-                                               const std::string &dev_str,
-                                               std::string name) {
-  if (name.empty())
-    name = get_anon_tensor_name_();
-
-  if (ftensors_.find(name) != ftensors_.end()) {
-    auto tensor = ftensors_[name].get()->get_tensor();
-    assert(tensor.numel() * tensor.element_size() == size);
-    assert(tensor.device() == torch::Device(dev_str));
-    return tensor;
-  }
-  // Create a new FTensor.
-  ftensors_[name] =
-      std::make_unique<FTensor>(name, size, dtype, dev_, zero_page_);
-  return ftensors_[name]->get_tensor();
-}
-
-void FTensorAllocator::free_ftensor(torch::Tensor &ftensor) {
-  auto name = ftensor.name();
-  if (ftensors_.find(name) == ftensors_.end()) {
-    return;
-  }
-  ftensors_.erase(name);
 }
 
 std::vector<torch::Tensor>
 FTensorAllocator::create_kv_tensors(size_t size, torch::Dtype dtype,
                                     const std::string &dev_str,
                                     int64_t num_layers) {
+  std::lock_guard<std::mutex> lock(mtx_);
+
   assert(num_layers_ == 0 || num_layers_ == num_layers);
   num_layers_ = num_layers;
   return create_kv_tensors_impl_(kv_prefix, size, dtype, dev_str, num_layers);
 }
 
 bool FTensorAllocator::map_to_kv_tensors(const std::vector<offset_t> &offsets) {
+  std::lock_guard<std::mutex> lock(mtx_);
+
   for (int64_t i = 0; i < num_layers_; i++) {
     auto kv_name = std::string(kv_prefix) + std::to_string(i);
     auto ftensor = ftensors_[kv_name].get();
@@ -118,6 +101,8 @@ bool FTensorAllocator::map_to_kv_tensors(const std::vector<offset_t> &offsets) {
 
 bool FTensorAllocator::unmap_from_kv_tensors(
     const std::vector<offset_t> &offsets) {
+  std::lock_guard<std::mutex> lock(mtx_);
+
   for (int64_t i = 0; i < num_layers_; i++) {
     auto kv_name = std::string(kv_prefix) + std::to_string(i);
     auto ftensor = ftensors_[kv_name].get();
@@ -148,10 +133,36 @@ std::vector<torch::Tensor> FTensorAllocator::create_kv_tensors_impl_(
   std::vector<torch::Tensor> ftensors;
   for (int64_t i = 0; i < num_layers; i++) {
     auto name = std::string(prefix) + std::to_string(i);
-    auto tensor = create_ftensor(size, dtype, dev_str, name);
+    auto tensor = create_ftensor_(size, dtype, dev_str, name);
     ftensors.push_back(tensor);
   }
   return ftensors;
+}
+
+torch::Tensor FTensorAllocator::create_ftensor_(size_t size, torch::Dtype dtype,
+                                                const std::string &dev_str,
+                                                std::string name) {
+  if (name.empty())
+    name = get_anon_tensor_name_();
+
+  if (ftensors_.find(name) != ftensors_.end()) {
+    auto tensor = ftensors_[name].get()->get_tensor();
+    assert(tensor.numel() * tensor.element_size() == size);
+    assert(tensor.device() == torch::Device(dev_str));
+    return tensor;
+  }
+  // Create a new FTensor.
+  ftensors_[name] =
+      std::make_unique<FTensor>(name, size, dtype, dev_, zero_page_);
+  return ftensors_[name]->get_tensor();
+}
+
+void FTensorAllocator::free_ftensor_(torch::Tensor &ftensor) {
+  auto name = ftensor.name();
+  if (ftensors_.find(name) == ftensors_.end()) {
+    return;
+  }
+  ftensors_.erase(name);
 }
 
 void FTensorAllocator::init_cuda_() {

--- a/csrc/inc/allocator.hpp
+++ b/csrc/inc/allocator.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <cuda_runtime.h>
@@ -20,13 +21,6 @@ public:
   FTensorAllocator(const torch::Device &device);
   ~FTensorAllocator();
 
-  // Raw FTensor interfaces.
-  torch::Tensor create_ftensor(size_t size, torch::Dtype dtype,
-                               const std::string &dev_str,
-                               std::string name = "");
-  void free_ftensor(torch::Tensor &ftensor);
-  void destroy();
-
   // KV cache interfaces.
   std::vector<torch::Tensor> create_kv_tensors(size_t size, torch::Dtype dtype,
                                                const std::string &dev_str,
@@ -38,18 +32,26 @@ public:
   static void init(const std::string &dev_str);
   static void shutdown();
   static FTensorAllocator *global_allocator();
+  void destroy();
 
 private:
+  // Raw FTensor interfaces. Must call with lock.
   static std::string get_anon_tensor_name_();
   std::vector<torch::Tensor> create_kv_tensors_impl_(std::string_view prefix,
                                                      size_t size,
                                                      torch::Dtype dtype,
                                                      const std::string &dev_str,
                                                      int64_t num_layers);
+  torch::Tensor create_ftensor_(size_t size, torch::Dtype dtype,
+                                const std::string &dev_str,
+                                std::string name = "");
+  void free_ftensor_(torch::Tensor &ftensor);
 
+  // CUDA util functions.
   void init_cuda_();
 
   static std::unique_ptr<FTensorAllocator> g_allocator_;
+  static std::mutex g_allocator_mutex_;
 
   torch::Device dev_;
 

--- a/csrc/inc/ftensor.hpp
+++ b/csrc/inc/ftensor.hpp
@@ -10,7 +10,7 @@
 
 namespace kvcached {
 
-/* NOTE: currently FTensor is not thread-safe. */
+/* NOTE: FTensorAllocator is thread-safe but FTensor is not. */
 class FTensor {
 public:
   FTensor(const std::string &name, size_t size, torch::Dtype dtype,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -9,20 +9,33 @@
 
 namespace kvcached {
 
+void init_kvcached(const std::string &dev_str) {
+  py::gil_scoped_release release;
+  FTensorAllocator::init(dev_str);
+}
+
+void shutdown_kvcached() {
+  py::gil_scoped_release release;
+  FTensorAllocator::shutdown();
+}
+
 std::vector<torch::Tensor> create_kv_tensors(size_t size, size_t dtype_size,
                                              const std::string &dev_str,
                                              int64_t num_layers) {
+  py::gil_scoped_release release;
   auto allocator = FTensorAllocator::global_allocator();
   auto dtype_ = torch_dtype_from_size(dtype_size);
   return allocator->create_kv_tensors(size, dtype_, dev_str, num_layers);
 }
 
 bool map_to_kv_tensors(const std::vector<offset_t> &offsets) {
+  py::gil_scoped_release release;
   auto allocator = FTensorAllocator::global_allocator();
   return allocator->map_to_kv_tensors(offsets);
 }
 
 bool unmap_from_kv_tensors(const std::vector<offset_t> &offsets) {
+  py::gil_scoped_release release;
   auto allocator = FTensorAllocator::global_allocator();
   return allocator->unmap_from_kv_tensors(offsets);
 }
@@ -31,12 +44,8 @@ bool unmap_from_kv_tensors(const std::vector<offset_t> &offsets) {
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.doc() = "kvcached VMM plugin";
 
-  m.def("init_kvcached", &kvcached::FTensorAllocator::init,
-        "Initialize kvcached");
-  m.def("shutdown_kvcached", &kvcached::FTensorAllocator::shutdown,
-        "Shutdown kvcached");
-  // m.def("create_ktensors", &kvcached::create_ktensors, "create_ktensors");
-  // m.def("create_vtensors", &kvcached::create_vtensors, "create_vtensors");
+  m.def("init_kvcached", &kvcached::init_kvcached, "Initialize kvcached");
+  m.def("shutdown_kvcached", &kvcached::shutdown_kvcached, "Shutdown kvcached");
   m.def("create_kv_tensors", &kvcached::create_kv_tensors, "create_kv_tensors");
   m.def("map_to_kv_tensors", &kvcached::map_to_kv_tensors, "map_to_kv_tensors");
   m.def("unmap_from_kv_tensors", &kvcached::unmap_from_kv_tensors,

--- a/engine_integration/benchmark/start_server.sh
+++ b/engine_integration/benchmark/start_server.sh
@@ -22,7 +22,7 @@ elif [ "$op" == "sgl" -o "$op" == "sglang" ]; then
     source "$ENGINE_DIR/sglang-v0.4.6.post2/.venv/bin/activate"
     export PYTHONPATH="$KVCACHED_DIR:$PYTHONPATH"
     export ENABLE_KVCACHED=true
-    python -m sglang.launch_server --model "$MODEL" --disable-radix-cache --disable-overlap-schedule --trust-remote-code --port "$SGL_PORT"
+    python -m sglang.launch_server --model "$MODEL" --disable-radix-cache --trust-remote-code --port "$SGL_PORT"
 else
     echo "Invalid option: $op"
     exit 1


### PR DESCRIPTION
This PR aims to address issue #5 

1. Release Python GIL in C++ code to avoid kvcached vmm operations blocking other threads.
2. Protect FTensorAllocator with a mutex to make it thread safe when sglang overlap scheduling is enabled.

I have tested it about 10 times, and it does not crash. Need more testing.