### PR TITLE
[Release] Bump up version to 0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,6 @@ git apply /path/to/kvcached/engine_integration/scripts/kvcached-sglang-v0.4.6.po
 # For vLLM v0.9.2
 cd /path/to/your/vllm-v0.9.2
 git apply /path/to/kvcached/engine_integration/scripts/kvcached-vllm-v0.9.2.patch
-
-# For vLLM v0.8.4
-cd /path/to/your/vllm-v0.8.4
-git apply /path/to/kvcached/engine_integration/scripts/kvcached-vllm-v0.8.4.patch
 ```
 
 ## All-in-One Installation (Recommended for Development)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ kvcached can be installed as simple as
 pip install kvcached --no-build-isolation
 ```
 
-> ⚠️ Version `0.0.1` is broken. Please use `0.0.1.post1` or later.
-
 Note that `--no-build-isolation` is required for kvcached to find the right PyTorch in the current virtual environment. If PyTorch is re-installed or upgraded, kvcached also needs re-installation.
 
 kvcached now supports both **SGLang** and **vLLM**. While we are in the process of upstreaming the integration interfaces, we provide temporary support via code patches.
@@ -26,8 +24,21 @@ kvcached now supports both **SGLang** and **vLLM**. While we are in the process 
 To apply a patch:
 
 ```bash
-cd <path to the installed engine (e.g,. SGLang or vLLM) source code directory>
-git apply <kvcached directory>/engine_integration/scripts/[patch_for_engine]
+cd $PATH_TO_ENGINE_SRC # Where the source code of installed SGLang or vLLM is
+git apply $PATH_TO_KVCACHED/engine_integration/scripts/$PATCH_FILE
+
+# Examples:
+# For SGLang v0.4.6.post2
+cd /path/to/your/sglang-v0.4.6.post2
+git apply /path/to/kvcached/engine_integration/scripts/kvcached-sglang-v0.4.6.post2.patch
+
+# For vLLM v0.9.2
+cd /path/to/your/vllm-v0.9.2
+git apply /path/to/kvcached/engine_integration/scripts/kvcached-vllm-v0.9.2.patch
+
+# For vLLM v0.8.4
+cd /path/to/your/vllm-v0.8.4
+git apply /path/to/kvcached/engine_integration/scripts/kvcached-vllm-v0.8.4.patch
 ```
 
 ## All-in-One Installation (Recommended for Development)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ kvcached is compatible with popular LLM serving engines, including SGLang and vL
 * Python (tested with 3.11)
 * PyTorch (tested with 2.6.0 and 2.7.0)
 
+> ⚠️ Version `0.0.1` is broken. Please use `0.0.1.post1` or later.
+
 kvcached can be installed as simple as
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ kvcached is compatible with popular LLM serving engines, including SGLang and vL
 * Python (tested with 3.11)
 * PyTorch (tested with 2.6.0 and 2.7.0)
 
-> ⚠️ Version `0.0.1` is broken. Please use `0.0.1.post1` or later.
-
 kvcached can be installed as simple as
 
 ```bash
 pip install kvcached --no-build-isolation
 ```
+
+> ⚠️ Version `0.0.1` is broken. Please use `0.0.1.post1` or later.
 
 Note that `--no-build-isolation` is required for kvcached to find the right PyTorch in the current virtual environment. If PyTorch is re-installed or upgraded, kvcached also needs re-installation.
 
@@ -26,8 +26,8 @@ kvcached now supports both **SGLang** and **vLLM**. While we are in the process 
 To apply a patch:
 
 ```bash
-cd engine_integration/scripts
-git apply [patch_name][engine_code_path]
+cd <path to the installed engine (e.g,. SGLang or vLLM) source code directory>
+git apply <kvcached directory>/engine_integration/scripts/[patch_for_engine]
 ```
 
 ## All-in-One Installation (Recommended for Development)

--- a/README.md
+++ b/README.md
@@ -26,15 +26,6 @@ To apply a patch:
 ```bash
 cd $PATH_TO_ENGINE_SRC # Where the source code of installed SGLang or vLLM is
 git apply $PATH_TO_KVCACHED/engine_integration/scripts/$PATCH_FILE
-
-# Examples:
-# For SGLang v0.4.6.post2
-cd /path/to/your/sglang-v0.4.6.post2
-git apply /path/to/kvcached/engine_integration/scripts/kvcached-sglang-v0.4.6.post2.patch
-
-# For vLLM v0.9.2
-cd /path/to/your/vllm-v0.9.2
-git apply /path/to/kvcached/engine_integration/scripts/kvcached-vllm-v0.9.2.patch
 ```
 
 ## All-in-One Installation (Recommended for Development)

--- a/engine_integration/scripts/setup.sh
+++ b/engine_integration/scripts/setup.sh
@@ -5,7 +5,6 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 ENGINE_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 KVCACHED_DIR=$(cd "$ENGINE_DIR/.." && pwd)
 DEV_MODE=true  # Set to false to use the released kvcached package
-KVCACHED_VERSION=0.0.1
 
 check_uv() {
     if ! command -v uv &> /dev/null; then
@@ -100,6 +99,8 @@ setup_vllm() {
 
     # Install requirements for kvcached first to avoid overwriting vLLM's requirements
     install_requirements
+    # vLLM-v0.9.2 requires transformers>=4.51.1 but not too new.
+    uv pip install transformers==4.51.1
 
     VLLM_USE_PRECOMPILED=1 uv pip install --editable .
     git apply "$SCRIPT_DIR/kvcached-vllm-v0.9.2.patch"
@@ -108,8 +109,7 @@ setup_vllm() {
     if [ "$DEV_MODE" = true ]; then
         install_kvcached_editable
     else
-        uv pip install kvcached==$KVCACHED_VERSION \
-        --no-build-isolation --no-cache-dir
+        uv pip install kvcached --no-build-isolation --no-cache-dir
     fi
 
     deactivate
@@ -136,8 +136,7 @@ setup_sglang() {
     if [ "$DEV_MODE" = true ]; then
         install_kvcached_editable
     else
-        uv pip install kvcached==$KVCACHED_VERSION \
-        --no-build-isolation --no-cache-dir
+        uv pip install kvcached --no-build-isolation --no-cache-dir
     fi
 
 

--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -68,7 +68,7 @@ def alloc_kv_cache(
     if kv_layout != "NHD":
         raise ValueError(f"KV layout {kv_layout} is not supported.")
 
-    if len(kvcache_shape) <= 2 or kvcache_shape[0] != 2:
+    if len(kvcache_shape) <= 2:
         raise ValueError(f"Unsupported kv cache shape: {kvcache_shape}")
 
     assert torch.cuda.is_available(), "CUDA is not available."

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -69,7 +69,7 @@ def alloc_kv_cache(
     if kv_layout != "NHD":
         raise ValueError(f"KV layout {kv_layout} is not supported.")
 
-    if len(kvcache_shape) != 4 or kvcache_shape[0] != 2:
+    if len(kvcache_shape) <= 3 or kvcache_shape[0] != 2:
         raise ValueError(f"Unsupported kv cache shape: {kvcache_shape}")
 
     assert torch.cuda.is_available(), "CUDA is not available."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kvcached"
-version = "0.0.1"
+version = "0.0.1.post1"
 authors = [
     {name = "The kvcached team"}
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kvcached"
-version = "0.0.1.post1"
+version = "0.0.2"
 authors = [
     {name = "The kvcached team"}
 ]


### PR DESCRIPTION
An important fix for the correct KV cache shape check in SGLang and vLLM integration.
Updated `setup.sh` for engine integration and README.