### PR TITLE
[Fix]: Make available_size() and available blocks count correctly

### DIFF
--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -63,7 +63,9 @@ class KVCacheManager:
             cell_size: Size of each cell in bytes.
             num_layers: Number of layers.
             async_sched: Whether asynchronous scheduling is enabled.
-            reserve_null_block: Whether to reserve the first block as null block for padding tokens. This is required by SGLang which assumes the first block is always reserved as padded tokens.
+            reserve_null_block: Whether to reserve the first block as null block
+                for padding tokens. This is required by SGLang which assumes the
+                first block is always reserved as padded tokens.
         """
         self.num_blocks = num_blocks
         self.block_mem_size = block_size * cell_size
@@ -84,13 +86,12 @@ class KVCacheManager:
         self.full_pages: Dict[int, Page] = {}
 
         self.reserved_blocks: List[int] = []
+        self.null_block: Optional[list[int]] = None
 
         self.in_shrink: bool = False
         self.target_num_blocks: Optional[int] = None
         # NOTE: we use a no-op lock for sync scheduling to avoid overhead
         self._lock = threading.RLock() if async_sched else NoOpLock()
-
-        self.null_block: Optional[list[int]] = None
 
         # Event used to signal that _post_init() has finished.
         self._post_init_done = threading.Event()
@@ -181,34 +182,30 @@ class KVCacheManager:
 
         remaining_need = need_size
 
-        if self.reserved_blocks:
-            if len(self.reserved_blocks) >= remaining_need:
-                ret_index = self.reserved_blocks[:remaining_need]
-                self.reserved_blocks = self.reserved_blocks[remaining_need:]
-                remaining_need = 0
-            else:
-                ret_index = self.reserved_blocks
-                remaining_need -= len(self.reserved_blocks)
-                self.reserved_blocks = []
+        if self.reserved_blocks:  # Try to allocate from reserved blocks first
+            num_from_reserved = min(len(self.reserved_blocks), remaining_need)
+            # ret_index is empty before so we directly assign it
+            ret_index = self.reserved_blocks[:num_from_reserved]
+            self.reserved_blocks = self.reserved_blocks[num_from_reserved:]
+            remaining_need -= num_from_reserved
 
-        while remaining_need > 0:
+        while remaining_need > 0:  # Allocate the remaining blocks from pages
             if not self.avail_pages:
                 page = self.page_allocator.alloc_page()
                 page.init(self.block_mem_size)
                 self.num_avail_blocks += page.num_free_blocks()
             else:
                 _, page = self.avail_pages.popitem()
-            num_to_alloc_from_page = min(page.num_free_blocks(),
-                                         remaining_need)
-            alloced_index = page.alloc(num_to_alloc_from_page)
+            num_from_page = min(page.num_free_blocks(), remaining_need)
+            alloced_index = page.alloc(num_from_page)
             ret_index.extend(alloced_index)
             if page.full():
                 self.full_pages[page.page_id] = page
             else:
                 self.avail_pages[page.page_id] = page
 
-            self.num_avail_blocks -= num_to_alloc_from_page
-            remaining_need -= num_to_alloc_from_page
+            self.num_avail_blocks -= num_from_page
+            remaining_need -= num_from_page
 
         with RwLockedShm(self.ipc_name, MemInfoStruct.SHM_SIZE,
                          RwLockedShm.WLOCK) as mm:
@@ -232,6 +229,7 @@ class KVCacheManager:
                     raise ValueError(f"Freed index {idx} is in "
                                      " reserved_blocks, which is not allowed.")
 
+        # Group indices by page_id
         idx_dict = defaultdict(list)
         for idx in indices:
             page_id = self.page_allocator.get_page_id(idx, self.block_mem_size)
@@ -319,8 +317,8 @@ class KVCacheManager:
         # Failed to resize due to too many in-use blocks.
         assert (len(self.reserved_blocks) == 0
                 ), "Reserved blocks must be freed before resizing."
-        # NOTE: we can support resizing with reserved blocks, but we want to enforce
-        # this check for now to ensure correctness.
+        # NOTE: we can support resizing with reserved blocks, but we want to
+        # enforce this check for now to ensure correctness.
         self.in_shrink = True
         self.target_num_blocks = new_mem_size // self.block_mem_size
         self.free_reserved()

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -335,7 +335,10 @@ class KVCacheManager:
         # Blocks from fully allocated pages
         blocks_from_full_pages = len(self.full_pages) * Page.get_num_blocks(
             self.page_size, self.block_mem_size)
-        # Blocks from partially allocated pages
+        # Blocks from partially allocated pages. num_avail_blocks is the number
+        # of free blocks in the partially allocated pages so the number of
+        # allocated blocks is the total number of blocks in the partially
+        # allocated pages minus the number of free blocks.
         blocks_from_avail_pages = len(self.avail_pages) * Page.get_num_blocks(
             self.page_size, self.block_mem_size) - self.num_avail_blocks
         # Blocks from reserved blocks

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -368,19 +368,20 @@ class KVCacheManager:
     def _get_used_size(self) -> int:
         # Memory actively used by allocations (excludes preallocated pages)
         return (self.page_allocator.get_num_inuse_pages() * self.num_layers *
-                PAGE_SIZE * 2)
+                self.page_size * 2)
 
     @synchronized
     def _get_prealloc_size(self) -> int:
         # Memory held by preallocated pages that are not yet actively used
         return (self.page_allocator.get_num_reserved_pages() *
-                self.num_layers * PAGE_SIZE * 2)
+                self.num_layers * self.page_size * 2)
 
     @synchronized
     def _physical_free_size(self) -> int:
         avail_phy_pages = self.page_allocator.get_avail_physical_pages()
         # Use the page allocator's method to get accurate block count per page
-        blocks_per_page = Page.get_num_blocks(PAGE_SIZE, self.block_mem_size)
+        blocks_per_page = Page.get_num_blocks(self.page_size,
+                                              self.block_mem_size)
         avail_phy_blocks = avail_phy_pages * blocks_per_page
         return avail_phy_blocks
 

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -226,15 +226,14 @@ class KVCacheManager:
         if len(indices) == 0:
             return  # Nothing to free
 
-        unique_indices = set(indices)
-        if self.reserved_blocks:
-            self.reserved_blocks = [
-                idx for idx in self.reserved_blocks
-                if idx not in unique_indices
-            ]
+        if SANITY_CHECK:
+            for idx in indices:
+                if idx in self.reserved_blocks:
+                    raise ValueError(f"Freed index {idx} is in "
+                                     " reserved_blocks, which is not allowed.")
 
         idx_dict = defaultdict(list)
-        for idx in unique_indices:
+        for idx in indices:
             page_id = self.page_allocator.get_page_id(idx, self.block_mem_size)
             idx_dict[page_id].append(idx)
 

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -297,17 +297,17 @@ class KVCacheManager:
 
     @synchronized
     def available_size(self) -> int:
-        avail_size = self.num_avail_blocks + len(self.reserved_blocks)
+        avail_blocks = self.num_avail_blocks + len(self.reserved_blocks)
         if self.in_shrink:
-            free_size = 0
+            blocks_from_free_pages = 0
         else:
             virtual_free_pages = self.page_allocator.get_num_free_pages()
             physical_free_pages = self.page_allocator.get_avail_physical_pages(
             ) + self.page_allocator.get_num_reserved_pages()
             free_pages = min(virtual_free_pages, physical_free_pages)
-            free_size = free_pages * Page.get_num_blocks(
+            blocks_from_free_pages = free_pages * Page.get_num_blocks(
                 self.page_size, self.block_mem_size)
-        return avail_size + free_size
+        return avail_blocks + blocks_from_free_pages
 
     @synchronized
     def get_mapped_memory_size(self, unit='bytes') -> float:

--- a/kvcached/mem_info_tracker.py
+++ b/kvcached/mem_info_tracker.py
@@ -16,8 +16,7 @@ class MemInfoTracker:
     def __init__(self, total_mem_size: int):
         """
         Args:
-            ipc_name: IPC name for shared memory
-            total_mem_size: Total memory size to initialize with
+            total_mem_size: Total memory size to initialize shared memory with
         """
         self.ipc_name = get_ipc_name(DEFAULT_IPC_NAME)
         init_kv_cache_limit(self.ipc_name, total_mem_size)

--- a/kvcached/mem_info_tracker.py
+++ b/kvcached/mem_info_tracker.py
@@ -1,0 +1,83 @@
+import atexit
+import os
+import signal
+from typing import Optional
+
+import posix_ipc
+
+from kvcached.cli.utils import (MemInfoStruct, RwLockedShm, get_ipc_name,
+                                get_ipc_path, init_kv_cache_limit)
+from kvcached.utils import DEFAULT_IPC_NAME
+
+
+class MemInfoTracker:
+    """Tracks memory usage information through shared memory."""
+
+    def __init__(self, total_mem_size: int):
+        """
+        Args:
+            ipc_name: IPC name for shared memory
+            total_mem_size: Total memory size to initialize with
+        """
+        self.ipc_name = get_ipc_name(DEFAULT_IPC_NAME)
+        init_kv_cache_limit(self.ipc_name, total_mem_size)
+        self._register_cleanup()
+
+    def check_and_get_resize_target(self, current_mem_size: int,
+                                    num_layers: int) -> Optional[int]:
+        """
+        Check if memory size has changed and return new target size if needed.
+
+        Returns:
+            New memory size if resize is needed, None otherwise
+        """
+        with RwLockedShm(self.ipc_name, MemInfoStruct.SHM_SIZE,
+                         RwLockedShm.RLOCK) as mm:
+            mem_info = MemInfoStruct.from_buffer(mm)
+            new_mem_size = mem_info.total_size // num_layers // 2
+            if new_mem_size != current_mem_size:
+                return new_mem_size
+        return None
+
+    def update_memory_usage(self, used_size: int, prealloc_size: int):
+        """Update the memory usage information in shared memory."""
+        with RwLockedShm(self.ipc_name, MemInfoStruct.SHM_SIZE,
+                         RwLockedShm.WLOCK) as mm:
+            mem_info = MemInfoStruct.from_buffer(mm)
+            mem_info.used_size = used_size
+            mem_info.prealloc_size = prealloc_size
+            mem_info.write_to_buffer(mm)
+
+    def cleanup(self, *args):
+        """Remove the POSIX shared-memory segment and its backing file."""
+        try:
+            # Unlink the POSIX shared memory object (no-op if already removed)
+            posix_ipc.unlink_shared_memory(self.ipc_name)
+        except Exception:
+            pass
+
+        # Also attempt to remove the backing file in /dev/shm (created by RwLockedShm)
+        try:
+            os.unlink(get_ipc_path(self.ipc_name))
+        except FileNotFoundError:
+            pass
+
+        # If invoked as a signal handler, re-raise the default behaviour so the
+        # process exits with the expected status code.
+        if args and isinstance(args[0], int):
+            signum = args[0]
+            signal.signal(signum, signal.SIG_DFL)
+            os.kill(os.getpid(), signum)
+
+    def _register_cleanup(self):
+        """Register atexit and signal handlers for shared-memory cleanup."""
+        # Run on normal interpreter shutdown
+        atexit.register(self.cleanup)
+
+        # Handle common termination signals (e.g., Ctrl-C or docker stop)
+        for _sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP,
+                     signal.SIGQUIT):
+            try:
+                signal.signal(_sig, self.cleanup)
+            except Exception:
+                pass

--- a/kvcached/page_allocator.py
+++ b/kvcached/page_allocator.py
@@ -1,5 +1,4 @@
 import threading
-from abc import ABC, abstractmethod
 from collections import deque
 from typing import List, Optional, Tuple, cast
 
@@ -121,34 +120,7 @@ class Page:
         return page_size // block_mem_size
 
 
-class PageAllocatorBase(ABC):
-
-    @abstractmethod
-    def __init__(self, total_mem_size: int, page_size: int):
-        pass
-
-    @abstractmethod
-    def alloc_page(self) -> Page:
-        pass
-
-    @abstractmethod
-    def free_page(self, page_id: int) -> None:
-        pass
-
-    @abstractmethod
-    def free_pages(self, page_ids: List[int]) -> None:
-        pass
-
-    @abstractmethod
-    def get_num_free_pages(self) -> int:
-        pass
-
-    @abstractmethod
-    def get_num_total_pages(self) -> int:
-        pass
-
-
-class PageAllocator(PageAllocatorBase):
+class PageAllocator:
 
     def __init__(self,
                  total_mem_size: int,

--- a/kvcached/page_allocator.py
+++ b/kvcached/page_allocator.py
@@ -374,18 +374,6 @@ class PageAllocator:
     def get_page_id(self, block_id: int, block_mem_size: int) -> int:
         return block_id * block_mem_size // self.page_size
 
-    def get_num_free_blocks(self, block_mem_size: int) -> int:
-        return self.get_num_free_pages() * Page.get_num_blocks(
-            self.page_size, block_mem_size)
-
-    def get_num_inuse_blocks(self, block_mem_size: int) -> int:
-        return self.get_num_inuse_pages() * Page.get_num_blocks(
-            self.page_size, block_mem_size)
-
-    def get_num_total_blocks(self, block_mem_size: int) -> int:
-        return self.get_num_total_pages() * Page.get_num_blocks(
-            self.page_size, block_mem_size)
-
     # Private methods
     def _prealloc_worker(self):
         """Worker thread that preallocates and maps physical pages."""


### PR DESCRIPTION
This PR:
1. Correctly count allocated blocks with consideration for partially allocated pages and reserved blocks
2. Correct available_size() with consideration for reserved pages
3. Extracted embedded shared memory update logic from KVCacheManager into a separate MemInfoTracker class and moved it to PageAllocator to improve code organization and eliminate coupling.

Memory tracking now accurately reflects physical memory allocation/deallocation.
There are no functional changes to external APIs.
