### PR TITLE
fix [integration/sglang-v0.4.6]: correct num_layers calculation

### DIFF
--- a/engine_integration/scripts/kvcached-sglang-v0.4.6.post2.patch
+++ b/engine_integration/scripts/kvcached-sglang-v0.4.6.post2.patch
@@ -13,7 +13,7 @@ index 8891115c1..34099c61e 100644
                  "token_to_kv_pool_allocator memory leak detected! "
                  f"{available_size=}, {protected_size=}, {self.max_total_num_tokens=}\n"
 diff --git a/python/sglang/srt/mem_cache/memory_pool.py b/python/sglang/srt/mem_cache/memory_pool.py
-index f7eef2120..fe22d41f1 100644
+index f7eef2120..7a6a341fe 100644
 --- a/python/sglang/srt/mem_cache/memory_pool.py
 +++ b/python/sglang/srt/mem_cache/memory_pool.py
 @@ -154,14 +154,26 @@ class TokenToKVPoolAllocator:
@@ -85,7 +85,7 @@ index f7eef2120..fe22d41f1 100644
 +                    self.size + self.page_size,
 +                    self.page_size,
 +                    self.cell_size,
-+                    num_layers=end_layer - start_layer + 1,
++                    num_layers=layer_num,
 +                )
 +            except ImportError as e:
 +                raise ImportError(


### PR DESCRIPTION
Should use `layer_num` rather than `end_layer - start_layer + 1`. The latter one counts one more layer.