### PR TITLE
[Feat] Contiguous KV tensor layout

### DIFF
--- a/csrc/inc/allocator.hpp
+++ b/csrc/inc/allocator.hpp
@@ -30,7 +30,7 @@ public:
   bool unmap_from_kv_tensors(const std::vector<offset_t> &offsets);
 
   // Global status interfaces.
-  static void init(const std::string &dev_str);
+  static void init(const std::string &dev_str, size_t page_size = 0);
   static void shutdown();
   static FTensorAllocator *global_allocator();
   void destroy();

--- a/csrc/inc/allocator.hpp
+++ b/csrc/inc/allocator.hpp
@@ -18,7 +18,7 @@ namespace kvcached {
 
 class FTensorAllocator {
 public:
-  FTensorAllocator(const torch::Device &device);
+  FTensorAllocator(const torch::Device &device, bool contiguous_layout);
   ~FTensorAllocator();
 
   // KV cache interfaces.
@@ -30,7 +30,8 @@ public:
   bool unmap_from_kv_tensors(const std::vector<offset_t> &offsets);
 
   // Global status interfaces.
-  static void init(const std::string &dev_str, size_t page_size = 0);
+  static void init(const std::string &dev_str, size_t page_size = 0,
+                   bool contiguous_layout = false);
   static void shutdown();
   static FTensorAllocator *global_allocator();
   void destroy();
@@ -38,11 +39,13 @@ public:
 private:
   // Raw FTensor interfaces. Must call with lock.
   static std::string get_anon_tensor_name_();
-  std::vector<torch::Tensor> create_kv_tensors_impl_(std::string_view prefix,
-                                                     size_t size,
-                                                     torch::Dtype dtype,
-                                                     const std::string &dev_str,
-                                                     int64_t num_layers);
+  std::vector<torch::Tensor>
+  create_kv_tensors_per_layer_(std::string_view prefix, size_t size,
+                               torch::Dtype dtype, const std::string &dev_str,
+                               int64_t num_layers);
+  std::vector<torch::Tensor>
+  create_kv_tensors_contiguous_(size_t size, torch::Dtype dtype,
+                                const std::string &dev_str, int64_t num_layers);
   torch::Tensor create_ftensor_(size_t size, torch::Dtype dtype,
                                 const std::string &dev_str,
                                 std::string name = "");
@@ -57,9 +60,14 @@ private:
   torch::Device dev_;
 
   int64_t num_layers_;
+  bool contiguous_layout_;
+  size_t kv_tensor_size_per_layer_;
 
-  std::mutex mtx_;
+  mutable std::mutex mtx_;
+  // For per-layer layout: one tensor per layer
   std::unordered_map<std::string, std::unique_ptr<FTensor>> ftensors_;
+  // For contiguous layout: single tensor containing all layers
+  std::unique_ptr<FTensor> contiguous_kv_tensor_;
   std::shared_ptr<Page> zero_page_;
 };
 

--- a/csrc/inc/constants.hpp
+++ b/csrc/inc/constants.hpp
@@ -10,7 +10,8 @@ using generic_ptr_t = void *;
 using page_id_t = int64_t;
 using offset_t = page_id_t;
 
-static constexpr size_t kPageSize = 2 * 1024 * 1024;
+// Page size is now configurable via kvcached initialization
+extern size_t kPageSize;
 static constexpr size_t kStartAddr = 0x1f0'000'000'000;
 
 static constexpr page_id_t INV_PAGE_ID = -1;

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -9,9 +9,9 @@
 
 namespace kvcached {
 
-void init_kvcached(const std::string &dev_str) {
+void init_kvcached(const std::string &dev_str, size_t page_size = 0) {
   py::gil_scoped_release release;
-  FTensorAllocator::init(dev_str);
+  FTensorAllocator::init(dev_str, page_size);
 }
 
 void shutdown_kvcached() {
@@ -50,7 +50,8 @@ bool unmap_from_kv_tensors(const std::vector<offset_t> &offsets) {
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.doc() = "kvcached VMM plugin";
 
-  m.def("init_kvcached", &kvcached::init_kvcached, "Initialize kvcached");
+  m.def("init_kvcached", &kvcached::init_kvcached, "Initialize kvcached",
+        py::arg("dev_str"), py::arg("page_size") = 0);
   m.def("shutdown_kvcached", &kvcached::shutdown_kvcached, "Shutdown kvcached");
   m.def("create_kv_tensors", &kvcached::create_kv_tensors, "create_kv_tensors");
   m.def("kv_tensors_created", &kvcached::kv_tensors_created,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -9,9 +9,10 @@
 
 namespace kvcached {
 
-void init_kvcached(const std::string &dev_str, size_t page_size = 0) {
+void init_kvcached(const std::string &dev_str, size_t page_size = 0,
+                   bool contiguous_layout = false) {
   py::gil_scoped_release release;
-  FTensorAllocator::init(dev_str, page_size);
+  FTensorAllocator::init(dev_str, page_size, contiguous_layout);
 }
 
 void shutdown_kvcached() {
@@ -45,13 +46,15 @@ bool unmap_from_kv_tensors(const std::vector<offset_t> &offsets) {
   auto allocator = FTensorAllocator::global_allocator();
   return allocator->unmap_from_kv_tensors(offsets);
 }
+
 } // namespace kvcached
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.doc() = "kvcached VMM plugin";
 
   m.def("init_kvcached", &kvcached::init_kvcached, "Initialize kvcached",
-        py::arg("dev_str"), py::arg("page_size") = 0);
+        py::arg("dev_str"), py::arg("page_size") = 0,
+        py::arg("contiguous_layout") = false);
   m.def("shutdown_kvcached", &kvcached::shutdown_kvcached, "Shutdown kvcached");
   m.def("create_kv_tensors", &kvcached::create_kv_tensors, "create_kv_tensors");
   m.def("kv_tensors_created", &kvcached::kv_tensors_created,

--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -15,23 +15,26 @@ logger = get_kvcached_logger()
 _kvcached_initialized: bool = False
 _kvcached_device = None
 _async_sched = False
+_contiguous_layout = True
 
 
 def init_kvcached(tp_rank: int = 0,
                   tp_size: int = 1,
                   device: Optional[str] = None,
-                  async_sched: bool = False) -> None:
-    global _kvcached_initialized, _kvcached_device, _async_sched
+                  async_sched: bool = False,
+                  contiguous_layout: bool = True) -> None:
+    global _kvcached_initialized, _kvcached_device, _async_sched, _contiguous_layout
     if _kvcached_initialized:
         return
 
     if device is None:
         device = f"cuda:{torch.cuda.current_device()}"
 
-    _init_kvcached_impl(device, PAGE_SIZE)
+    _init_kvcached_impl(device, PAGE_SIZE, contiguous_layout)
     _kvcached_initialized = True
     _kvcached_device = device
     _async_sched = async_sched
+    _contiguous_layout = contiguous_layout
 
     if tp_size > 1:
         # start the listener thread for tensor parallel kv cache management
@@ -39,7 +42,7 @@ def init_kvcached(tp_rank: int = 0,
 
 
 def shutdown_kvcached() -> None:
-    global _kvcached_initialized, _kvcached_device, _async_sched
+    global _kvcached_initialized, _kvcached_device, _async_sched, _contiguous_layout
     if not _kvcached_initialized:
         return
 
@@ -47,6 +50,7 @@ def shutdown_kvcached() -> None:
     _kvcached_initialized = False
     _kvcached_device = None
     _async_sched = False
+    _contiguous_layout = True
 
 
 def alloc_kv_cache(
@@ -83,6 +87,10 @@ def alloc_kv_cache(
     blocks_per_page = PAGE_SIZE // block_mem_size
 
     gpu_mem_size = torch.cuda.get_device_properties(device).total_memory
+
+    # Calculate virtual memory size based on layout
+    # For contiguous layout, C++ will handle num_layers multiplication
+    # So we still calculate per-layer size and let C++ multiply
     num_pages = gpu_mem_size // num_layers // 2 // PAGE_SIZE
     virtual_mem_size = num_pages * PAGE_SIZE * 2
 
@@ -113,9 +121,12 @@ def get_kv_cache_manager(num_blocks: int,
         raise RuntimeError(
             "kvcached is not initialized. Please call init_kvcached() first.")
 
-    return KVCacheManager(num_blocks,
-                          block_size,
-                          cell_size,
-                          num_layers,
-                          async_sched=_async_sched,
-                          reserve_null_block=reserve_null_block)
+    return KVCacheManager(
+        num_blocks,
+        block_size,
+        cell_size,
+        num_layers,
+        contiguous_layout=_contiguous_layout,
+        async_sched=_async_sched,
+        reserve_null_block=reserve_null_block,
+    )

--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -28,7 +28,7 @@ def init_kvcached(tp_rank: int = 0,
     if device is None:
         device = f"cuda:{torch.cuda.current_device()}"
 
-    _init_kvcached_impl(device)
+    _init_kvcached_impl(device, PAGE_SIZE)
     _kvcached_initialized = True
     _kvcached_device = device
     _async_sched = async_sched

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -28,7 +28,7 @@ def init_kvcached(tp_rank: int = 0,
     if device is None:
         device = f"cuda:{torch.cuda.current_device()}"
 
-    _init_kvcached_impl(device)
+    _init_kvcached_impl(device, PAGE_SIZE)
     _kvcached_initialized = True
     _kvcached_device = device
     _tp_size = tp_size

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -63,7 +63,9 @@ class KVCacheManager:
             cell_size: Size of each cell in bytes.
             num_layers: Number of layers.
             async_sched: Whether asynchronous scheduling is enabled.
-            reserve_null_block: Whether to reserve the first block as null block for padding tokens. This is required by SGLang which assumes the first block is always reserved as padded tokens.
+            reserve_null_block: Whether to reserve the first block as null block
+                for padding tokens. This is required by SGLang which assumes the
+                first block is always reserved as padded tokens.
         """
         self.num_blocks = num_blocks
         self.block_mem_size = block_size * cell_size
@@ -84,13 +86,12 @@ class KVCacheManager:
         self.full_pages: Dict[int, Page] = {}
 
         self.reserved_blocks: List[int] = []
+        self.null_block: Optional[list[int]] = None
 
         self.in_shrink: bool = False
         self.target_num_blocks: Optional[int] = None
         # NOTE: we use a no-op lock for sync scheduling to avoid overhead
         self._lock = threading.RLock() if async_sched else NoOpLock()
-
-        self.null_block: Optional[list[int]] = None
 
         # Event used to signal that _post_init() has finished.
         self._post_init_done = threading.Event()
@@ -181,34 +182,30 @@ class KVCacheManager:
 
         remaining_need = need_size
 
-        if self.reserved_blocks:
-            if len(self.reserved_blocks) >= remaining_need:
-                ret_index = self.reserved_blocks[:remaining_need]
-                self.reserved_blocks = self.reserved_blocks[remaining_need:]
-                remaining_need = 0
-            else:
-                ret_index = self.reserved_blocks
-                remaining_need -= len(self.reserved_blocks)
-                self.reserved_blocks = []
+        if self.reserved_blocks:  # Try to allocate from reserved blocks first
+            num_from_reserved = min(len(self.reserved_blocks), remaining_need)
+            # ret_index is empty before so we directly assign it
+            ret_index = self.reserved_blocks[:num_from_reserved]
+            self.reserved_blocks = self.reserved_blocks[num_from_reserved:]
+            remaining_need -= num_from_reserved
 
-        while remaining_need > 0:
+        while remaining_need > 0:  # Allocate the remaining blocks from pages
             if not self.avail_pages:
                 page = self.page_allocator.alloc_page()
                 page.init(self.block_mem_size)
                 self.num_avail_blocks += page.num_free_blocks()
             else:
                 _, page = self.avail_pages.popitem()
-            num_to_alloc_from_page = min(page.num_free_blocks(),
-                                         remaining_need)
-            alloced_index = page.alloc(num_to_alloc_from_page)
+            num_from_page = min(page.num_free_blocks(), remaining_need)
+            alloced_index = page.alloc(num_from_page)
             ret_index.extend(alloced_index)
             if page.full():
                 self.full_pages[page.page_id] = page
             else:
                 self.avail_pages[page.page_id] = page
 
-            self.num_avail_blocks -= num_to_alloc_from_page
-            remaining_need -= num_to_alloc_from_page
+            self.num_avail_blocks -= num_from_page
+            remaining_need -= num_from_page
 
         with RwLockedShm(self.ipc_name, MemInfoStruct.SHM_SIZE,
                          RwLockedShm.WLOCK) as mm:
@@ -232,6 +229,7 @@ class KVCacheManager:
                     raise ValueError(f"Freed index {idx} is in "
                                      " reserved_blocks, which is not allowed.")
 
+        # Group indices by page_id
         idx_dict = defaultdict(list)
         for idx in indices:
             page_id = self.page_allocator.get_page_id(idx, self.block_mem_size)
@@ -319,8 +317,8 @@ class KVCacheManager:
         # Failed to resize due to too many in-use blocks.
         assert (len(self.reserved_blocks) == 0
                 ), "Reserved blocks must be freed before resizing."
-        # NOTE: we can support resizing with reserved blocks, but we want to enforce
-        # this check for now to ensure correctness.
+        # NOTE: we can support resizing with reserved blocks, but we want to
+        # enforce this check for now to ensure correctness.
         self.in_shrink = True
         self.target_num_blocks = new_mem_size // self.block_mem_size
         self.free_reserved()

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -335,7 +335,10 @@ class KVCacheManager:
         # Blocks from fully allocated pages
         blocks_from_full_pages = len(self.full_pages) * Page.get_num_blocks(
             self.page_size, self.block_mem_size)
-        # Blocks from partially allocated pages
+        # Blocks from partially allocated pages. num_avail_blocks is the number
+        # of free blocks in the partially allocated pages so the number of
+        # allocated blocks is the total number of blocks in the partially
+        # allocated pages minus the number of free blocks.
         blocks_from_avail_pages = len(self.avail_pages) * Page.get_num_blocks(
             self.page_size, self.block_mem_size) - self.num_avail_blocks
         # Blocks from reserved blocks

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -368,19 +368,20 @@ class KVCacheManager:
     def _get_used_size(self) -> int:
         # Memory actively used by allocations (excludes preallocated pages)
         return (self.page_allocator.get_num_inuse_pages() * self.num_layers *
-                PAGE_SIZE * 2)
+                self.page_size * 2)
 
     @synchronized
     def _get_prealloc_size(self) -> int:
         # Memory held by preallocated pages that are not yet actively used
         return (self.page_allocator.get_num_reserved_pages() *
-                self.num_layers * PAGE_SIZE * 2)
+                self.num_layers * self.page_size * 2)
 
     @synchronized
     def _physical_free_size(self) -> int:
         avail_phy_pages = self.page_allocator.get_avail_physical_pages()
         # Use the page allocator's method to get accurate block count per page
-        blocks_per_page = Page.get_num_blocks(PAGE_SIZE, self.block_mem_size)
+        blocks_per_page = Page.get_num_blocks(self.page_size,
+                                              self.block_mem_size)
         avail_phy_blocks = avail_phy_pages * blocks_per_page
         return avail_phy_blocks
 

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -226,15 +226,14 @@ class KVCacheManager:
         if len(indices) == 0:
             return  # Nothing to free
 
-        unique_indices = set(indices)
-        if self.reserved_blocks:
-            self.reserved_blocks = [
-                idx for idx in self.reserved_blocks
-                if idx not in unique_indices
-            ]
+        if SANITY_CHECK:
+            for idx in indices:
+                if idx in self.reserved_blocks:
+                    raise ValueError(f"Freed index {idx} is in "
+                                     " reserved_blocks, which is not allowed.")
 
         idx_dict = defaultdict(list)
-        for idx in unique_indices:
+        for idx in indices:
             page_id = self.page_allocator.get_page_id(idx, self.block_mem_size)
             idx_dict[page_id].append(idx)
 

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -45,6 +45,7 @@ class KVCacheManager:
         cell_size: int,
         num_layers: int,
         tp_size: int = 1,
+        contiguous_layout: bool = False,
         async_sched: bool = False,
         reserve_null_block: bool = False,
     ):
@@ -54,6 +55,8 @@ class KVCacheManager:
             block_size: Size of each block in bytes.
             cell_size: Size of each cell in bytes.
             num_layers: Number of layers.
+            tp_size: Number of tensor parallel processes.
+            contiguous_layout: Whether to use contiguous layout.
             async_sched: Whether asynchronous scheduling is enabled.
             reserve_null_block: Whether to reserve the first block as null block
                 for padding tokens. This is required by SGLang which assumes the
@@ -69,9 +72,14 @@ class KVCacheManager:
         # NOTE: this is the memory size of the K or V tensor in one layer
         self.mem_size = self.num_blocks * self.block_mem_size
         self.tp_size = tp_size
-        self.page_allocator = PageAllocator(self.num_layers, self.mem_size,
-                                            self.page_size, self.tp_size,
-                                            async_sched)
+        self.page_allocator = PageAllocator(
+            self.num_layers,
+            self.mem_size,
+            self.page_size,
+            self.tp_size,
+            contiguous_layout=contiguous_layout,
+            async_sched=async_sched,
+        )
 
         self.num_avail_blocks = 0  # Only count free blocks in avail_pages
         self.avail_pages: Dict[int, Page] = {}

--- a/kvcached/mem_info_tracker.py
+++ b/kvcached/mem_info_tracker.py
@@ -16,8 +16,7 @@ class MemInfoTracker:
     def __init__(self, total_mem_size: int):
         """
         Args:
-            ipc_name: IPC name for shared memory
-            total_mem_size: Total memory size to initialize with
+            total_mem_size: Total memory size to initialize shared memory with
         """
         self.ipc_name = get_ipc_name(DEFAULT_IPC_NAME)
         init_kv_cache_limit(self.ipc_name, total_mem_size)

--- a/kvcached/mem_info_tracker.py
+++ b/kvcached/mem_info_tracker.py
@@ -1,0 +1,83 @@
+import atexit
+import os
+import signal
+from typing import Optional
+
+import posix_ipc
+
+from kvcached.cli.utils import (MemInfoStruct, RwLockedShm, get_ipc_name,
+                                get_ipc_path, init_kv_cache_limit)
+from kvcached.utils import DEFAULT_IPC_NAME
+
+
+class MemInfoTracker:
+    """Tracks memory usage information through shared memory."""
+
+    def __init__(self, total_mem_size: int):
+        """
+        Args:
+            ipc_name: IPC name for shared memory
+            total_mem_size: Total memory size to initialize with
+        """
+        self.ipc_name = get_ipc_name(DEFAULT_IPC_NAME)
+        init_kv_cache_limit(self.ipc_name, total_mem_size)
+        self._register_cleanup()
+
+    def check_and_get_resize_target(self, current_mem_size: int,
+                                    num_layers: int) -> Optional[int]:
+        """
+        Check if memory size has changed and return new target size if needed.
+
+        Returns:
+            New memory size if resize is needed, None otherwise
+        """
+        with RwLockedShm(self.ipc_name, MemInfoStruct.SHM_SIZE,
+                         RwLockedShm.RLOCK) as mm:
+            mem_info = MemInfoStruct.from_buffer(mm)
+            new_mem_size = mem_info.total_size // num_layers // 2
+            if new_mem_size != current_mem_size:
+                return new_mem_size
+        return None
+
+    def update_memory_usage(self, used_size: int, prealloc_size: int):
+        """Update the memory usage information in shared memory."""
+        with RwLockedShm(self.ipc_name, MemInfoStruct.SHM_SIZE,
+                         RwLockedShm.WLOCK) as mm:
+            mem_info = MemInfoStruct.from_buffer(mm)
+            mem_info.used_size = used_size
+            mem_info.prealloc_size = prealloc_size
+            mem_info.write_to_buffer(mm)
+
+    def cleanup(self, *args):
+        """Remove the POSIX shared-memory segment and its backing file."""
+        try:
+            # Unlink the POSIX shared memory object (no-op if already removed)
+            posix_ipc.unlink_shared_memory(self.ipc_name)
+        except Exception:
+            pass
+
+        # Also attempt to remove the backing file in /dev/shm (created by RwLockedShm)
+        try:
+            os.unlink(get_ipc_path(self.ipc_name))
+        except FileNotFoundError:
+            pass
+
+        # If invoked as a signal handler, re-raise the default behaviour so the
+        # process exits with the expected status code.
+        if args and isinstance(args[0], int):
+            signum = args[0]
+            signal.signal(signum, signal.SIG_DFL)
+            os.kill(os.getpid(), signum)
+
+    def _register_cleanup(self):
+        """Register atexit and signal handlers for shared-memory cleanup."""
+        # Run on normal interpreter shutdown
+        atexit.register(self.cleanup)
+
+        # Handle common termination signals (e.g., Ctrl-C or docker stop)
+        for _sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP,
+                     signal.SIGQUIT):
+            try:
+                signal.signal(_sig, self.cleanup)
+            except Exception:
+                pass

--- a/kvcached/page_allocator.py
+++ b/kvcached/page_allocator.py
@@ -1,5 +1,4 @@
 import threading
-from abc import ABC, abstractmethod
 from collections import deque
 from typing import List, Optional, Tuple, cast
 
@@ -121,34 +120,7 @@ class Page:
         return page_size // block_mem_size
 
 
-class PageAllocatorBase(ABC):
-
-    @abstractmethod
-    def __init__(self, total_mem_size: int, page_size: int):
-        pass
-
-    @abstractmethod
-    def alloc_page(self) -> Page:
-        pass
-
-    @abstractmethod
-    def free_page(self, page_id: int) -> None:
-        pass
-
-    @abstractmethod
-    def free_pages(self, page_ids: List[int]) -> None:
-        pass
-
-    @abstractmethod
-    def get_num_free_pages(self) -> int:
-        pass
-
-    @abstractmethod
-    def get_num_total_pages(self) -> int:
-        pass
-
-
-class PageAllocator(PageAllocatorBase):
+class PageAllocator:
 
     def __init__(self,
                  total_mem_size: int,

--- a/kvcached/page_allocator.py
+++ b/kvcached/page_allocator.py
@@ -374,18 +374,6 @@ class PageAllocator:
     def get_page_id(self, block_id: int, block_mem_size: int) -> int:
         return block_id * block_mem_size // self.page_size
 
-    def get_num_free_blocks(self, block_mem_size: int) -> int:
-        return self.get_num_free_pages() * Page.get_num_blocks(
-            self.page_size, block_mem_size)
-
-    def get_num_inuse_blocks(self, block_mem_size: int) -> int:
-        return self.get_num_inuse_pages() * Page.get_num_blocks(
-            self.page_size, block_mem_size)
-
-    def get_num_total_blocks(self, block_mem_size: int) -> int:
-        return self.get_num_total_pages() * Page.get_num_blocks(
-            self.page_size, block_mem_size)
-
     # Private methods
     def _prealloc_worker(self):
         """Worker thread that preallocates and maps physical pages."""

--- a/kvcached/page_allocator.py
+++ b/kvcached/page_allocator.py
@@ -129,6 +129,7 @@ class PageAllocator:
                  page_size: int,
                  tp_size: int = 1,
                  async_sched: bool = False,
+                 contiguous_layout: bool = False,
                  enable_page_prealloc: bool = PAGE_PREALLOC_ENABLED):
         """
         Args:
@@ -137,6 +138,7 @@ class PageAllocator:
             page_size: Page size in bytes.
             tp_size: Tensor parallel size.
             async_sched: Whether asynchronous scheduling is enabled.
+            contiguous_layout: Whether to use contiguous layout.
             enable_page_prealloc: Whether to enable page preallocation.
         """
         logger.info(
@@ -147,6 +149,7 @@ class PageAllocator:
             f"page_size={page_size//(1024*1024)}MB, "
             f"tp_size={tp_size}, "
             f"async_sched={async_sched}, "
+            f"contiguous_layout={contiguous_layout}, "
             f"enable_prealloc={enable_page_prealloc}")
         # WARNING (YIFAN): kvcached_ops.init_kvcached must have been called
         # before this.
@@ -156,6 +159,7 @@ class PageAllocator:
         self.page_size = page_size
         self.tp_size = tp_size
         self.async_sched = async_sched
+        self.contiguous_layout = contiguous_layout
         self.gpu_utilization = GPU_UTILIZATION
         self.num_free_pages = mem_size_per_layer // page_size
         self.num_total_pages = mem_size_per_layer // page_size
@@ -454,7 +458,12 @@ class PageAllocator:
             self._cond.notify()
 
     def _map_pages(self, page_ids: list[int]) -> None:
-        offsets = [pid * self.page_size for pid in page_ids]
+        if self.contiguous_layout:
+            offsets = [
+                pid * self.page_size * self.num_layers for pid in page_ids
+            ]
+        else:
+            offsets = [pid * self.page_size for pid in page_ids]
         if self.tp_size > 1:  # map pages across all tensor parallel workers.
             broadcast_map_to_kv_tensors_to_workers(self.tp_size, offsets)
         else:
@@ -463,7 +472,12 @@ class PageAllocator:
         self._update_memory_usage()
 
     def _unmap_pages(self, page_ids: list[int]) -> None:
-        offsets = [pid * self.page_size for pid in page_ids]
+        if self.contiguous_layout:
+            offsets = [
+                pid * self.page_size * self.num_layers for pid in page_ids
+            ]
+        else:
+            offsets = [pid * self.page_size for pid in page_ids]
         if self.tp_size > 1:  # unmap pages across all tensor parallel workers.
             broadcast_unmap_from_kv_tensors_to_workers(self.tp_size, offsets)
         else:

--- a/kvcached/utils.py
+++ b/kvcached/utils.py
@@ -1,7 +1,40 @@
 import logging
 import os
 
-PAGE_SIZE = 2 * 1024 * 1024  # 2MB
+
+def _get_page_size() -> int:
+    """Get PAGE_SIZE from environment variable with validation.
+
+    Returns:
+        PAGE_SIZE in bytes, must be a multiple of 2MB (2097152 bytes)
+
+    Raises:
+        ValueError: If PAGE_SIZE is not a multiple of 2MB
+    """
+    default_page_size = 2 * 1024 * 1024  # 2MB
+    page_size_mb_str = os.getenv("KVCACHED_PAGE_SIZE_MB")
+
+    if page_size_mb_str is None:
+        return default_page_size
+
+    try:
+        page_size = int(page_size_mb_str) * 1024 * 1024
+    except ValueError:
+        raise ValueError(
+            f"Invalid KVCACHED_PAGE_SIZE_MB: {page_size_mb_str}. Must be an integer."
+        )
+
+    # Validate that PAGE_SIZE is a multiple of 2MB
+    base_size = 2 * 1024 * 1024  # 2MB
+    if page_size <= 0 or page_size % base_size != 0:
+        raise ValueError(
+            f"PAGE_SIZE must be a positive multiple of 2MB (2097152 bytes), "
+            f"got: {page_size}")
+
+    return page_size
+
+
+PAGE_SIZE = _get_page_size()
 
 # Configuration constants for KVCacheManager
 GPU_UTILIZATION = float(os.getenv("KVCACHED_GPU_UTILIZATION", "0.95"))


### PR DESCRIPTION
This PR revises the FTensorAllocator to support a contiguous layout for all KV cache tensors. For each token, the new layout will put the K/V slot of all layers into a contiguous space, and hence they share the same page and only need to be mapped/unmapped once. To support various KV cache layouts needed by the upper-level engine, the C++ extension will view and stride the contiguous tensor in a correct way and return a set of tensor views.

This PR needs to be merged after PR #54 and PR #60 