### PR TITLE
kvcached(interfaces): derive num_tokens from raw capacity and page-al…

### DIFF
--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -83,7 +83,6 @@ def alloc_kv_cache(
     # SGLang named it "page" to be consistent with PagedAttention. But we call
     # it "block" to distinguish a KV cache block and a physical memory page.
     block_size = page_size
-    num_tokens = kvcache_shape[0]
     block_mem_size = math.prod(kvcache_shape[1:]) * dtype.itemsize
     blocks_per_page = PAGE_SIZE // block_mem_size
 
@@ -107,8 +106,8 @@ def alloc_kv_cache(
     tokens_per_page = block_size * blocks_per_page
     actual_num_tokens = (actual_num_tokens // tokens_per_page) * tokens_per_page
     
-    print(f"[kvcached] Actual allocated tensor size: {raw_tensor.numel() * raw_tensor.element_size()} bytes")
-    print(f"[kvcached] Derived actual_num_tokens: {actual_num_tokens} (original estimate: {block_size * blocks_per_page * num_pages})")
+    logger.info(f"[kvcached] Actual allocated tensor size: {raw_tensor.numel() * raw_tensor.element_size()} bytes")
+    logger.info(f"[kvcached] Derived actual_num_tokens: {actual_num_tokens} (original estimate: {block_size * blocks_per_page * num_pages})")
     
     actual_kvcache_shape: List[int] = list(kvcache_shape)
     actual_kvcache_shape[0] = actual_num_tokens


### PR DESCRIPTION
**Background / Problem**
In the contiguous layout branch of `integration/sglang/interfaces.py`, `num_tokens` is computed via a “VRAM→pages” estimate and then used to `view` the raw contiguous buffer as `(num_tokens, num_layers, 2, H, D)`. Under GPU headroom (`GPU_UTILIZATION`), reserved/reclaimed pages, and slight accounting differences between the C++ and Python sides (e.g., when/where `num_layers` and the `×2` for K/V are applied), the estimated `num_tokens` can exceed the *actual* raw buffer capacity, leading to:

```
RuntimeError: shape '...' is invalid for input of size ...
```

Separately, when per-token per-layer (K or V) bytes are large and `KVCACHED_PAGE_SIZE_MB` is high, `mem_size_per_layer // page_size == 0` yields zero available pages, which triggers `Failed to reserve null block`.

**What this PR changes**

1. In the contiguous path, stop *estimating* `num_tokens`. Instead:

   * Use the **actual** size of `raw_kv_tensors[0]` to derive
     `elem_per_token = num_layers * 2 * prod(kvcache_shape[1:])` (in elements),
     then `actual_num_tokens = raw.numel() // elem_per_token`;
   * **Page-align** `actual_num_tokens` (`tokens_per_page = block_size * blocks_per_page`) to avoid a partially filled last page causing issues for page-level map/unmap and copies;
   * `view(actual_num_tokens, num_layers, 2, H, D)` and split out per-layer K/V tensors.
2. Add guardrails and logs: if the **requested** logical blocks (typically `size + page_size`) exceed the **physical** `actual_num_tokens`, fail fast with a clear message suggesting to reduce `size` or decrease `KVCACHED_PAGE_SIZE_MB`.
3. Remove/relax the previous assertion based on the VRAM estimate to prevent conflicts with the ground-truth raw capacity.

**Rationale**

* Treat the raw contiguous buffer (allocated in C++) as the single source of truth. This eliminates reshape overruns caused by estimation drift (dup/omitted layer×2, page reservation, integer division, etc.).
* Page-alignment keeps view boundaries consistent with page boundaries, which is safer for the allocator’s page-level operations.

**Compatibility / Impact**

* Only affects how the token dimension is computed in the contiguous branch of `alloc_kv_cache`.
* Does **not** change the underlying allocation size or memory layout (the raw buffer remains the same; `view` is zero-copy).
* No behavior change for healthy configurations. In previously broken edge cases, the error becomes earlier and clearer.

**Testing Plan**

* Run typical 7B/8B configs (`num_layers=32`, `head_num=32`, `head_dim=128`, `fp16`) across:

  * `KVCACHED_PAGE_SIZE_MB=2` and `=1`;
  * `size` slightly below / equal to / above `actual_num_tokens` thresholds;
  * SWA + Full combined via `SWAKVPool` smoke tests.
* Verify no more `Failed to reserve null block` (when size ≥ per-page threshold) and no more reshape errors. Validate free/alloc cycles.

**Risk & Rollback**

* Low risk: purely Python-side fix to the reshape token axis; no changes to C++ allocation.
* Rollback: revert to the previous VRAM-estimate `num_tokens` computation.