### PR TITLE
[Fix] Fix sleep status endpointof router

### DIFF
--- a/controller/frontend.py
+++ b/controller/frontend.py
@@ -463,7 +463,7 @@ class MultiLLMFrontend:
                 "idle_threshold_seconds":
                 self.sleep_manager.config.idle_threshold_seconds,
                 "wakeup_on_request":
-                self.sleep_manager.config.wake_on_request
+                self.sleep_manager.config.wakeup_on_request
             }),
                                 status=200,
                                 content_type='application/json')


### PR DESCRIPTION
Error:
```
$ curl http://localhost:8080/sleep/status
{"error": "'SleepConfig' object has no attribute 'wake_on_request'"}
```

After fix:
```
$ curl http://localhost:8080/sleep/status
{"sleeping_models": {}, "sleep_candidates": [], "auto_sleep_enabled": false, "idle_threshold_seconds": 300, "wakeup_on_request": true}
```
