### PR TITLE
[Chore] Example READMEs venv path fix

### DIFF
--- a/examples/01_simple_two_models/README.md
+++ b/examples/01_simple_two_models/README.md
@@ -56,7 +56,7 @@ bash start_two_models.sh \
   --engine-a vllm --engine-b vllm \
   --model-a meta-llama/Llama-3.2-1B --port-a 12346 \
   --model-b Qwen/Qwen3-0.6B        --port-b 12347 \
-  --venv-vllm-path ../../engine_integration/vllm-v0.9.2/.venv
+  --venv-vllm-path ${VENV_PATH}
 ```
 
 (2) In a separate terminal, send simple requests:

--- a/examples/03_model_router_sleep/README.md
+++ b/examples/03_model_router_sleep/README.md
@@ -7,7 +7,7 @@ Automatically traffic monitor and idled models sleep.
 ```bash
 # 1. Start controller
 cd /kvcached
-source engine_integration/vllm-v0.9.2/.venv/bin/activate
+source ${VENV_PATH}/bin/activate
 cd controller
 python launch.py --config example-config.yaml
 ```

--- a/examples/05_multi_agents/README.md
+++ b/examples/05_multi_agents/README.md
@@ -30,7 +30,7 @@ bash start_multi_agent_models.sh \
     --writing-model Qwen/Qwen3-4B \
     --research-engine vllm \
     --writing-engine vllm \
-    --venv-vllm-path ../../engine_integration/vllm-v0.9.2/.venv
+    --venv-vllm-path ${VENV_PATH}
 ```
 
 ### 3. Run Multi-Agent Examples with LangChain


### PR DESCRIPTION
Update the vllm env path in the READMEs of the examples from ``engine_integration/vllm-v0.9.2/.venv`` to ``${VENV_PATH}`` because the path could be different for different setup.