### PR TITLE
fix vLLM version range

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -12,9 +12,9 @@ from kvcached.integration.patch_base import BasePatch, enable_kvcached
 from kvcached.integration.version_utils import VersionAwarePatch, VersionRange, version_range
 
 # Version ranges for vLLM support
-VLLM_V8_RANGE = ">=0.8.4,<0.8.5"  # vLLM 0.8.x versions
-VLLM_V9_PLUS_RANGE = ">=0.8.5"  # vLLM 0.9.x+ versions
-VLLM_V9_RANGE = ">=0.8.5,<=0.9.2"  # vLLM 0.9.x versions
+VLLM_V8_RANGE = ">=0.8.4,<=0.8.5"  # vLLM 0.8.x versions
+VLLM_V9_PLUS_RANGE = ">0.8.5"  # vLLM 0.9.x+ versions
+VLLM_V9_RANGE = ">0.8.5,<=0.9.2"  # vLLM 0.9.x versions
 VLLM_V10_RANGE = ">0.9.2"  # vLLM 0.10.x+ versions
 VLLM_ALL_RANGE = ">=0.8.4"  # All supported versions
 


### PR DESCRIPTION
I encountered an error while testing v0.8.5 and found a patch mismatch issue.
`bash start_two_models.sh   --engine-a vllm --engine-b vllm   --model-a /data/model/Qwen/Qwen3-0.6B --port-a 12346   --model-b /data/model/Qwen/Qwen3-0.6B  --port-b 1234`
<img width="1518" height="421" alt="截屏2025-10-23 02 41 20" src="https://github.com/user-attachments/assets/1fde15b2-7bdf-4be8-bd10-8bac09cc9e88" />
After the modification, the error no longer occurred, and all tests passed.
<img width="1226" height="252" alt="截屏2025-10-23 02 47 37" src="https://github.com/user-attachments/assets/16501522-f2a5-4454-8ba6-e0f5b242c865" />

<img width="1906" height="278" alt="截屏2025-10-23 02 49 07" src="https://github.com/user-attachments/assets/34d3c6f9-c206-44de-b0f0-34f370d71c59" />
