### PR TITLE
Fix 'kvcached::generic_ptr_t' {aka 'void*'} and 'size_t' {aka 'long unsigned int'} to binary 'operator%'

### DIFF
--- a/csrc/ftensor.cpp
+++ b/csrc/ftensor.cpp
@@ -129,8 +129,8 @@ bool FTensor::set_access_(generic_ptr_t addr, size_t size) {
 
 bool FTensor::init_with_zero_() {
   assert(reinterpret_cast<uintptr_t>(vaddr_) % kPageSize ==
-         0); // Ensure alignment.
-  assert(size_ % kPageSize == 0);  // Ensure alignment.
+         0);                      // Ensure alignment.
+  assert(size_ % kPageSize == 0); // Ensure alignment.
 
   bool succ = true;
   for (size_t offset = 0; offset < size_; offset += kPageSize) {


### PR DESCRIPTION
```log
'kvcached::generic_ptr_t' {aka 'void*'} and 'size_t' {aka 'long unsigned int'} to binary 'operator%'
  131 |   assert(vaddr_ % kPageSize == 0); // Ensure alignment.
      |          ~~~~~~ ^ ~~~~~~~~~
      |          |        |
      |          |        size_t {aka long unsigned int}
      |          kvcached::generic_ptr_t {aka void*}
```
gcc version 14 
glibc version 2.42