### PR TITLE
Fix #207 Examples_05: cannot import name 'AgentExecutor' from 'langchain.agents'

### DIFF
--- a/examples/05_multi_agents/multi_agent_example.py
+++ b/examples/05_multi_agents/multi_agent_example.py
@@ -19,7 +19,6 @@ from typing import Dict
 
 import requests
 from langchain.agents import create_agent
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.runnables import RunnableLambda
 from langchain_openai import ChatOpenAI
 


### PR DESCRIPTION
Fix #207 , the incompatibility between the API used in examples/05_multi_agents and the latest version of LangChain; tested and confirmed working.

<img width="2202" height="1286" alt="image" src="https://github.com/user-attachments/assets/735dc1e7-8596-493c-a010-c928f1d9b098" />


From the above example, we can see that it runs without any issues.  