### PR TITLE
[Fix] Fix SGLang tensor parallel rank bug and improve code quality

### DIFF
--- a/kvcached/autopatch.py
+++ b/kvcached/autopatch.py
@@ -1,19 +1,41 @@
 # SPDX-FileCopyrightText: Copyright contributors to the kvcached project
 # SPDX-License-Identifier: Apache-2.0
 
+"""Automatic patching for kvcached integration with LLM serving engines.
+
+This module registers import hooks for vLLM and SGLang to enable kvcached's
+elastic KV cache management when these libraries are loaded.
+"""
+
+import logging
 from importlib import import_module
+
+logger = logging.getLogger(__name__)
 
 
 def autopatch_all() -> None:
+    """Register import hooks for all supported serving engines.
+
+    This function attempts to import the autopatch modules for vLLM and SGLang,
+    which register their respective import hooks. Failures are logged at debug
+    level since not all engines may be installed.
+    """
     # Importing these modules registers their when_imported hooks
     try:
         import_module("kvcached.integration.vllm.autopatch")
-    except Exception:
-        pass
+        logger.debug("Registered vLLM autopatch hooks")
+    except ImportError:
+        logger.debug("vLLM autopatch not available (vLLM may not be installed)")
+    except Exception as e:
+        logger.warning("Failed to register vLLM autopatch hooks: %s", e)
+
     try:
         import_module("kvcached.integration.sglang.autopatch")
-    except Exception:
-        pass
+        logger.debug("Registered SGLang autopatch hooks")
+    except ImportError:
+        logger.debug("SGLang autopatch not available (SGLang may not be installed)")
+    except Exception as e:
+        logger.warning("Failed to register SGLang autopatch hooks: %s", e)
 
 
 autopatch_all()

--- a/kvcached/cli/kvctl.py
+++ b/kvcached/cli/kvctl.py
@@ -277,12 +277,17 @@ def cmd_limit_percent(ipc: str, percent: float):
               file=sys.stderr)
         return
 
+    if not 0.0 <= percent <= 100.0:
+        print(_clr(f"Error: Percentage must be between 0 and 100, got {percent}.",
+                   'red', bold=True), file=sys.stderr)
+        return
+
     from kvcached.cli.utils import get_total_gpu_memory
 
     total_mem = get_total_gpu_memory()
     if total_mem <= 0:
-        print("CUDA unavailable; cannot compute size from percentage",
-              file=sys.stderr)
+        print(_clr("Error: CUDA unavailable; cannot compute size from percentage.",
+                   'red', bold=True), file=sys.stderr)
         sys.exit(1)
     size_bytes = int(total_mem * percent / 100.0)
     update_kv_cache_limit(ipc, size_bytes)

--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -18,18 +18,30 @@ from kvcached.vmm_ops import (
 logger = get_kvcached_logger()
 
 _kvcached_initialized: bool = False
-_kvcached_device = None
-_async_sched = False
-_contiguous_layout = CONTIGUOUS_LAYOUT
+_kvcached_device: Optional[str] = None
+_async_sched: bool = False
+_tp_size: int = 1
+_contiguous_layout: bool = CONTIGUOUS_LAYOUT
 
 
 def init_kvcached(
     tp_rank: int = 0,
     tp_size: int = 1,
+    is_worker: bool = False,
     device: Optional[str] = None,
     async_sched: bool = False,
 ) -> None:
-    global _kvcached_initialized, _kvcached_device, _async_sched
+    """Initialize kvcached for SGLang integration.
+
+    Args:
+        tp_rank: Tensor parallel rank of this process.
+        tp_size: Total number of tensor parallel processes.
+        is_worker: Whether this process is a worker (not the main scheduler).
+            Only workers should start the IPC listener thread.
+        device: CUDA device string (e.g., "cuda:0"). If None, uses current device.
+        async_sched: Whether to enable asynchronous scheduling.
+    """
+    global _kvcached_initialized, _kvcached_device, _tp_size, _async_sched
     if _kvcached_initialized:
         return
 
@@ -39,21 +51,25 @@ def init_kvcached(
     _init_kvcached_impl(device, PAGE_SIZE, _contiguous_layout)
     _kvcached_initialized = True
     _kvcached_device = device
+    _tp_size = tp_size
     _async_sched = async_sched
 
-    if tp_size > 1:
-        # start the listener thread for tensor parallel kv cache management
-        start_worker_listener_thread(torch.cuda.current_device())
+    if tp_size > 1 and is_worker:
+        # Start the listener thread for tensor parallel KV cache management.
+        # Use tp_rank (not device ID) to ensure correct socket path matching.
+        start_worker_listener_thread(tp_rank)
 
 
 def shutdown_kvcached() -> None:
-    global _kvcached_initialized, _kvcached_device, _async_sched
+    """Shutdown kvcached and release resources."""
+    global _kvcached_initialized, _kvcached_device, _tp_size, _async_sched
     if not _kvcached_initialized:
         return
 
     _shutdown_kvcached_impl()
     _kvcached_initialized = False
     _kvcached_device = None
+    _tp_size = 1
     _async_sched = False
 
 
@@ -66,6 +82,29 @@ def alloc_kv_cache(
     attention_type: str = "MHA",  # GQA is also supported. TODO: support MLA
     kv_layout: str = "NHD",  # NHD: (num_tokens, head_num, head_dim)
 ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+    """Allocate KV cache tensors with elastic memory management.
+
+    This function creates K and V tensors for each layer using kvcached's
+    virtual memory abstraction. Memory is allocated on-demand rather than
+    pre-allocated.
+
+    Args:
+        kvcache_shape: Shape of the KV cache as (num_tokens, head_num, head_dim).
+        dtype: Data type of the tensors (e.g., torch.float16, torch.bfloat16).
+        device: CUDA device string (e.g., "cuda", "cuda:0").
+        num_layers: Number of transformer layers.
+        page_size: Number of tokens per page (default 1 for SGLang).
+        attention_type: Attention mechanism type ("MHA" or "GQA").
+        kv_layout: Layout of KV cache tensors (only "NHD" supported).
+
+    Returns:
+        Tuple of (k_tensors, v_tensors) where each is a list of tensors,
+        one per layer.
+
+    Raises:
+        RuntimeError: If kvcached is not initialized.
+        ValueError: If attention_type or kv_layout is not supported.
+    """
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
 
@@ -134,6 +173,22 @@ def get_kv_cache_manager(
     num_layers: int,
     reserve_null_block: bool = True,
 ) -> KVCacheManager:
+    """Create a KVCacheManager for SGLang.
+
+    Args:
+        num_blocks: Number of KV cache blocks to manage.
+        block_size: Size of each block in tokens.
+        cell_size: Size of each cell in bytes (head_num * head_dim * dtype_size).
+        num_layers: Number of transformer layers.
+        reserve_null_block: Whether to reserve the first block as null block
+            for padding tokens. Required by SGLang.
+
+    Returns:
+        KVCacheManager instance configured for the specified parameters.
+
+    Raises:
+        RuntimeError: If kvcached is not initialized.
+    """
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
 
@@ -142,6 +197,7 @@ def get_kv_cache_manager(
         block_size,
         cell_size,
         num_layers,
+        _tp_size,
         async_sched=_async_sched,
         reserve_null_block=reserve_null_block,
     )

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -197,8 +197,28 @@ class ElasticMemoryPoolPatch(VersionAwarePatch, BasePatch):
                 def _create_buffers(self):
                     import kvcached.integration.sglang.interfaces as kvi
 
-                    # Initialize kvcached with overlap scheduling to be conservative
-                    kvi.init_kvcached(async_sched=True)
+                    # Detect tensor parallel configuration from SGLang's distributed state
+                    tp_rank, tp_size = 0, 1
+                    try:
+                        from sglang.srt.distributed.parallel_state import (
+                            get_tp_group,
+                        )
+                        tp_group = get_tp_group()
+                        if tp_group is not None:
+                            tp_rank = tp_group.rank_in_group
+                            tp_size = tp_group.world_size
+                    except (ImportError, AttributeError):
+                        pass  # Fall back to single-GPU mode
+
+                    # Initialize kvcached with overlap scheduling to be conservative.
+                    # Workers need to start the IPC listener for tensor parallel sync.
+                    is_worker = tp_rank > 0  # rank 0 is typically the scheduler
+                    kvi.init_kvcached(
+                        tp_rank=tp_rank,
+                        tp_size=tp_size,
+                        is_worker=is_worker,
+                        async_sched=True,
+                    )
 
                     if "cuda" not in self.device:
                         raise ValueError("ElasticMHATokenToKVPool only supports cuda device")

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -31,6 +31,16 @@ def init_kvcached(
     device: Optional[str] = None,
     async_sched: bool = False,
 ) -> None:
+    """Initialize kvcached for vLLM integration.
+
+    Args:
+        tp_rank: Tensor parallel rank of this process.
+        tp_size: Total number of tensor parallel processes.
+        is_worker: Whether this process is a worker (not the main engine).
+            Only workers should start the IPC listener thread.
+        device: CUDA device string (e.g., "cuda:0"). If None, uses current device.
+        async_sched: Whether to enable asynchronous scheduling.
+    """
     global _kvcached_initialized, _kvcached_device, _tp_size, _async_sched
     if _kvcached_initialized:
         return
@@ -45,11 +55,13 @@ def init_kvcached(
     _async_sched = async_sched
 
     if tp_size > 1 and is_worker:
-        # start the listener thread for tensor parallel kv cache management
+        # Start the listener thread for tensor parallel KV cache management.
+        # Use tp_rank to ensure correct socket path matching.
         start_worker_listener_thread(tp_rank)
 
 
 def shutdown_kvcached() -> None:
+    """Shutdown kvcached and release resources."""
     global _kvcached_initialized, _kvcached_device, _async_sched
     if not _kvcached_initialized:
         return
@@ -69,6 +81,29 @@ def alloc_kv_cache(
     attention_type: str = "MHA",  # GQA is also supported. TODO: support MLA
     kv_layout: str = "NHD",  # NHD: (num_tokens, head_num, head_dim)
 ) -> List[torch.Tensor]:
+    """Allocate KV cache tensors with elastic memory management for vLLM.
+
+    This function creates combined K/V tensors for each layer using kvcached's
+    virtual memory abstraction. Supports both FlashAttn and FlashInfer layouts.
+
+    Args:
+        kvcache_shape: Shape of the KV cache. Supports two layouts:
+            - FlashAttn: (2, num_blocks, block_size, head_num, head_dim)
+            - FlashInfer: (num_blocks, 2, block_size, head_num, head_dim)
+        block_size: Number of tokens per block.
+        dtype: Data type of the tensors (e.g., torch.float16, torch.bfloat16).
+        device: CUDA device type string (e.g., "cuda").
+        num_layers: Number of transformer layers.
+        attention_type: Attention mechanism type ("MHA" or "GQA").
+        kv_layout: Layout of KV cache tensors (only "NHD" supported).
+
+    Returns:
+        List of KV tensors, one per layer.
+
+    Raises:
+        RuntimeError: If kvcached is not initialized.
+        ValueError: If attention_type, kv_layout, or kvcache_shape is not supported.
+    """
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
 
@@ -135,6 +170,20 @@ def alloc_kv_cache(
 def get_kv_cache_manager(
     num_blocks: int, block_size: int, cell_size: int, num_layers: int
 ) -> KVCacheManager:
+    """Create a KVCacheManager for vLLM.
+
+    Args:
+        num_blocks: Number of KV cache blocks to manage.
+        block_size: Size of each block in tokens.
+        cell_size: Size of each cell in bytes (page_size_bytes / block_size / 2).
+        num_layers: Number of transformer layers.
+
+    Returns:
+        KVCacheManager instance configured for the specified parameters.
+
+    Raises:
+        RuntimeError: If kvcached is not initialized.
+    """
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
 


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in SGLang's tensor parallel support and improves overall code quality.

### Bug Fix
- **Critical**: Fix `start_worker_listener_thread()` call to use `tp_rank` instead of `torch.cuda.current_device()` in SGLang integration. The socket path is based on rank, not device ID, so using the wrong value causes IPC communication failures in multi-GPU tensor parallel setups.
- Add `is_worker` parameter to SGLang's `init_kvcached()` to match vLLM's behavior - only workers should start the listener thread.
- Add `_tp_size` global state to SGLang interfaces and pass it to `KVCacheManager` for proper tensor parallel coordination.
- Update SGLang patches to detect `tp_rank` and `tp_size` from SGLang's distributed state via `get_tp_group()`.

### Code Quality Improvements
- Replace bare `except` clauses in `autopatch.py` with specific exception handling (`ImportError` vs other exceptions) and add debug/warning logging.
- Add comprehensive docstrings to all public API functions in both vLLM and SGLang integration modules.
- Add type hints to global module state variables.
- Add input validation for `limit-percent` CLI command (0-100 range).

## Test plan
- [ ] Verify Python syntax is valid (checked locally with `py_compile`)
- [ ] Test with SGLang single-GPU inference
- [ ] Test with SGLang tensor parallel (multi-GPU) inference
- [ ] Test with vLLM to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)