### PR TITLE
docs: Add comprehensive documentation and semantic router example

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,266 @@
+# kvcached API Reference
+
+This document provides detailed API documentation for kvcached's public interfaces.
+
+## Table of Contents
+
+- [Environment Variables](#environment-variables)
+- [CLI Tools](#cli-tools)
+- [Python API](#python-api)
+- [Integration APIs](#integration-apis)
+
+---
+
+## Environment Variables
+
+### Core Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ENABLE_KVCACHED` | `false` | Enable kvcached integration |
+| `KVCACHED_AUTOPATCH` | `0` | Enable automatic patching of vLLM/SGLang |
+| `KVCACHED_IPC_NAME` | Auto-detected | Custom name for the shared memory segment |
+| `KVCACHED_GPU_UTILIZATION` | `0.95` | Maximum GPU memory fraction for KV cache |
+| `KVCACHED_PAGE_SIZE_MB` | `2` | Page size in megabytes (must be multiple of 2) |
+| `KVCACHED_LOG_LEVEL` | `INFO` | Logging level (DEBUG, INFO, WARNING, ERROR) |
+
+### Advanced Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KVCACHED_PAGE_PREALLOC_ENABLED` | `true` | Enable background page preallocation |
+| `KVCACHED_MIN_RESERVED_PAGES` | `5` | Minimum pages to keep pre-allocated |
+| `KVCACHED_MAX_RESERVED_PAGES` | `10` | Maximum pages to pre-allocate |
+| `KVCACHED_CONTIGUOUS_LAYOUT` | `true` | Use contiguous memory layout for KV tensors |
+| `KVCACHED_SANITY_CHECK` | `false` | Enable additional runtime safety checks |
+| `KVCACHED_LOG_COLOR` | `true` | Enable colored log output |
+
+---
+
+## CLI Tools
+
+### kvctl
+
+The `kvctl` command provides control over kvcached memory segments.
+
+```bash
+# Start interactive shell
+kvctl shell
+
+# List all IPC segments
+kvctl list [--json]
+
+# Set absolute memory limit
+kvctl limit <ipc_name> <size>
+# Example: kvctl limit kvcached_vLLM_12345 8G
+
+# Set memory limit as percentage of GPU
+kvctl limit-percent <ipc_name> <percent>
+# Example: kvctl limit-percent kvcached_vLLM_12345 80
+
+# Watch memory usage in real-time
+kvctl watch [-n <interval>] [ipc_name...]
+
+# Launch curses-based UI
+kvctl kvtop [--refresh <seconds>]
+
+# Delete an IPC segment
+kvctl delete <ipc_name>
+```
+
+### Size Format
+
+The CLI accepts human-readable size formats:
+- `512M` or `512MB` - 512 megabytes
+- `2G` or `2GB` - 2 gigabytes
+- `1024` - 1024 bytes (raw number)
+
+---
+
+## Python API
+
+### Initialization
+
+```python
+# For vLLM integration
+from kvcached.integration.vllm import interfaces as kvi
+
+kvi.init_kvcached(
+    tp_rank=0,           # Tensor parallel rank
+    tp_size=1,           # Tensor parallel world size
+    is_worker=False,     # Whether this is a worker process
+    device="cuda:0",     # CUDA device string
+    async_sched=False,   # Enable async scheduling
+)
+
+# For SGLang integration
+from kvcached.integration.sglang import interfaces as kvi
+
+kvi.init_kvcached(
+    tp_rank=0,
+    tp_size=1,
+    is_worker=False,
+    device="cuda:0",
+    async_sched=True,    # Recommended for SGLang
+)
+```
+
+### Memory Allocation
+
+```python
+# Allocate KV cache tensors (vLLM)
+kv_tensors = kvi.alloc_kv_cache(
+    kvcache_shape,       # Tuple: (2, num_blocks, block_size, heads, head_dim)
+    block_size,          # Tokens per block
+    dtype,               # torch.float16, torch.bfloat16, etc.
+    device,              # "cuda"
+    num_layers,          # Number of transformer layers
+    attention_type="MHA", # "MHA" or "GQA"
+    kv_layout="NHD",     # Layout format
+)
+
+# Allocate KV cache tensors (SGLang)
+k_tensors, v_tensors = kvi.alloc_kv_cache(
+    kvcache_shape,       # Tuple: (num_tokens, heads, head_dim)
+    dtype,
+    device,
+    num_layers,
+    page_size=1,         # Tokens per page (default 1 for SGLang)
+    attention_type="MHA",
+    kv_layout="NHD",
+)
+```
+
+### KV Cache Manager
+
+```python
+# Get a KV cache manager for block-level operations
+manager = kvi.get_kv_cache_manager(
+    num_blocks,          # Total number of blocks
+    block_size,          # Tokens per block
+    cell_size,           # Bytes per cell
+    num_layers,          # Number of layers
+)
+
+# Allocate blocks
+block_ids = manager.alloc(num_blocks)
+
+# Free blocks
+manager.free(block_ids)
+
+# Check available space
+available = manager.available_size()
+```
+
+### Shutdown
+
+```python
+# Clean up resources
+kvi.shutdown_kvcached()
+```
+
+---
+
+## Integration APIs
+
+### vLLM Integration
+
+kvcached automatically patches vLLM when `KVCACHED_AUTOPATCH=1`. The following vLLM components are modified:
+
+1. **BlockPool**: Replaced with `ElasticBlockPool` for dynamic allocation
+2. **GPUModelRunner**: Patched to use kvcached for KV tensor allocation
+3. **Worker**: Modified to skip GPU memory reservation checks
+
+### SGLang Integration
+
+kvcached patches SGLang's memory pool:
+
+1. **MHATokenToKVPool**: Replaced with `ElasticMHATokenToKVPool`
+2. **Memory management**: Dynamic allocation instead of static reservation
+
+### Manual Integration
+
+For custom integrations, use the low-level VMM operations:
+
+```python
+from kvcached.vmm_ops import (
+    create_kv_tensors,
+    map_to_kv_tensors,
+    unmap_from_kv_tensors,
+)
+
+# Create virtual memory tensors
+raw_tensors = create_kv_tensors(
+    mem_size_per_layer,
+    dtype_size,
+    device,
+    num_layers,
+)
+
+# Map physical pages to virtual addresses
+map_to_kv_tensors(page_ids, block_ids)
+
+# Unmap pages when done
+unmap_from_kv_tensors(page_ids, block_ids)
+```
+
+---
+
+## Controller API
+
+The multi-model controller exposes REST endpoints:
+
+### Core Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/v1/completions` | POST | OpenAI-compatible completions |
+| `/v1/chat/completions` | POST | OpenAI-compatible chat |
+| `/health` | GET | Router health check |
+| `/models` | GET | List available models |
+| `/health/{model}` | GET | Model-specific health |
+
+### Traffic Monitoring
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/traffic/stats` | GET | Traffic statistics for all models |
+| `/traffic/stats/{model}` | GET | Model-specific traffic stats |
+| `/models/idle` | GET | List idle models |
+| `/models/active` | GET | List active models |
+
+### Sleep Management
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/sleep/status` | GET | Sleep status of all models |
+| `/action/sleep/{model}` | POST | Put model to sleep |
+| `/action/wakeup/{model}` | POST | Wake up sleeping model |
+| `/sleep/candidates` | GET | Models eligible for sleep |
+
+---
+
+## Error Handling
+
+### Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `RuntimeError: kvcached is not initialized` | Called API before init | Call `init_kvcached()` first |
+| `ValueError: Cannot get N free blocks` | Insufficient memory | Reduce requests or increase GPU utilization |
+| `FileNotFoundError: /dev/shm/...` | IPC segment missing | Ensure kvcached is initialized |
+| `NotImplementedError: Hybrid models...` | Unsupported attention | Update to latest kvcached version |
+
+### Debugging
+
+Enable debug logging for detailed information:
+
+```bash
+export KVCACHED_LOG_LEVEL=DEBUG
+```
+
+Monitor memory usage:
+
+```bash
+kvctl kvtop
+```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,227 @@
+# kvcached Architecture
+
+This document explains the architecture of kvcached and how engines, models, and memory management interact.
+
+## System Overview
+
+```
++-------------------+     +-------------------+     +-------------------+
+|    vLLM/SGLang    |     |    vLLM/SGLang    |     |    vLLM/SGLang    |
+|    Engine #1      |     |    Engine #2      |     |    Engine #3      |
++--------+----------+     +--------+----------+     +--------+----------+
+         |                         |                         |
+         |     KV Cache Requests   |                         |
+         v                         v                         v
++------------------------------------------------------------------------+
+|                        kvcached Memory Manager                          |
+|                                                                         |
+|  +------------------+  +------------------+  +------------------+       |
+|  | Page Allocator   |  | KV Cache Manager |  | IPC Coordinator  |       |
+|  +------------------+  +------------------+  +------------------+       |
+|                                                                         |
++------------------------------------------------------------------------+
+                                   |
+                                   v
++------------------------------------------------------------------------+
+|                          GPU Physical Memory                            |
+|  [Page 0] [Page 1] [Page 2] [Page 3] [Page 4] [Page 5] [Page 6] ...   |
++------------------------------------------------------------------------+
+```
+
+## Component Decoupling
+
+### Engine Independence
+
+Each inference engine (vLLM or SGLang instance) operates independently:
+
+1. **Separate Process Space**: Each engine runs in its own process
+2. **Shared Memory Communication**: Engines communicate via `/dev/shm`
+3. **Virtual Memory Abstraction**: Each engine sees a virtual address space
+
+### How Decoupling Works
+
+```
+Engine A (vLLM)                    Engine B (SGLang)
+     |                                  |
+     v                                  v
+Virtual KV Cache                  Virtual KV Cache
+[Block 0-99]                      [Block 0-99]
+     |                                  |
+     |   (kvcached mapping layer)       |
+     v                                  v
+Physical Pages (shared pool)
+[Page 0] [Page 1] [Page 2] ...
+```
+
+**Key Insight**: Virtual block IDs are local to each engine, but physical pages are shared across all engines.
+
+## Connecting to Pre-Started Engines
+
+kvcached supports attaching to engines that are already running.
+
+### Method 1: Environment Variable Naming
+
+Start engines with the same IPC name:
+
+```bash
+# Terminal 1 - Engine A
+export KVCACHED_IPC_NAME=my_shared_cache
+export ENABLE_KVCACHED=true
+vllm serve model-a --port 8001
+
+# Terminal 2 - Engine B (connects to same IPC segment)
+export KVCACHED_IPC_NAME=my_shared_cache
+export ENABLE_KVCACHED=true
+vllm serve model-b --port 8002
+```
+
+### Method 2: Controller Orchestration
+
+Use the controller to manage multiple engines:
+
+```yaml
+# config.yaml
+kvcached:
+  kvcached_gpu_utilization: 0.95
+
+instances:
+  - name: model-a
+    model: meta-llama/Llama-3.2-1B
+    engine: vllm
+    engine_args:
+      - "--port=8001"
+  - name: model-b
+    model: Qwen/Qwen3-0.6B
+    engine: sglang
+    engine_args:
+      - "--port=8002"
+```
+
+### Method 3: Manual Integration
+
+For custom setups, initialize kvcached programmatically:
+
+```python
+from kvcached.integration.vllm import interfaces as kvi
+
+# Connect to existing IPC segment
+import os
+os.environ["KVCACHED_IPC_NAME"] = "existing_segment"
+
+# Initialize with existing configuration
+kvi.init_kvcached(
+    tp_rank=0,
+    tp_size=1,
+    device="cuda:0",
+)
+
+# Now engine will use the shared memory pool
+```
+
+## IPC Mechanism
+
+### Shared Memory Segments
+
+kvcached uses POSIX shared memory for coordination:
+
+```
+/dev/shm/
+├── kvcached_vLLM_12345           # Memory info for engine group
+├── kvcached_vLLM_12345_page_0    # Page allocation bitmap
+└── kvcached_vLLM_12345_lock      # Coordination lock
+```
+
+### Memory Info Structure
+
+Each IPC segment tracks:
+- `total_size`: Maximum allocatable memory
+- `used_size`: Currently allocated memory
+- `prealloc_size`: Pre-allocated but unused pages
+
+### Tensor Parallel Coordination
+
+For multi-GPU tensor parallelism:
+
+```
+Rank 0 (Scheduler)          Rank 1 (Worker)          Rank 2 (Worker)
+     |                           |                        |
+     v                           v                        v
++-----------+              +-----------+            +-----------+
+| Local VMM |              | Local VMM |            | Local VMM |
++-----------+              +-----------+            +-----------+
+     |                           |                        |
+     +------ Unix Socket IPC ----+------------------------+
+     |
+     v
++------------------+
+| Broadcast alloc/ |
+| free operations  |
++------------------+
+```
+
+## Memory Lifecycle
+
+### Allocation Flow
+
+1. **Request arrives**: Engine needs N blocks for new sequence
+2. **Virtual allocation**: KVCacheManager assigns virtual block IDs
+3. **Page mapping**: PageAllocator maps virtual blocks to physical pages
+4. **Memory mapping**: VMM maps physical pages to GPU virtual addresses
+5. **Ready for use**: KV cache tensors are ready for attention computation
+
+### Deallocation Flow
+
+1. **Sequence completes**: Engine frees block IDs
+2. **Page unmapping**: VMM unmaps physical pages from virtual addresses
+3. **Page return**: Physical pages return to free pool
+4. **Available for reuse**: Memory available for other engines/sequences
+
+## Configuration for Decoupled Operation
+
+### Shared Configuration
+
+All engines sharing memory should use consistent settings:
+
+```bash
+# Must match across all engines
+export KVCACHED_IPC_NAME=shared_cache
+export KVCACHED_GPU_UTILIZATION=0.95
+export KVCACHED_PAGE_SIZE_MB=2
+```
+
+### Independent Configuration
+
+These can vary per engine:
+
+```bash
+# Can differ per engine
+export KVCACHED_LOG_LEVEL=INFO
+export KVCACHED_PAGE_PREALLOC_ENABLED=true
+```
+
+## Monitoring Decoupled Engines
+
+### View All Segments
+
+```bash
+kvctl list
+```
+
+Output:
+```
+IPC                      Limit        Used       %
+kvcached_vLLM_12345      8.00 GB      2.50 GB    31.3%
+kvcached_SGLang_67890    8.00 GB      1.20 GB    15.0%
+```
+
+### Monitor Specific Segment
+
+```bash
+kvctl watch kvcached_vLLM_12345
+```
+
+### Real-Time Visualization
+
+```bash
+kvctl kvtop
+```

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,186 @@
+# Compatibility Guide
+
+This document describes version compatibility and known issues with kvcached.
+
+## Supported Versions
+
+### vLLM
+
+| vLLM Version | Status | Notes |
+|--------------|--------|-------|
+| 0.8.4 - 0.8.5 | Supported | Use `VLLM_USE_V1=1` |
+| 0.9.0 - 0.9.2 | Supported | Recommended |
+| 0.10.x | Supported | Requires latest kvcached |
+| 0.11.x | Experimental | Requires CUDA 12.8+ |
+
+### SGLang
+
+| SGLang Version | Status | Notes |
+|----------------|--------|-------|
+| 0.4.x | Supported | Use `--disable-radix-cache` |
+| 0.5.x | Experimental | May require updates |
+
+### PyTorch
+
+| PyTorch Version | Status | Notes |
+|-----------------|--------|-------|
+| 2.4.x | Supported | |
+| 2.5.x | Supported | |
+| 2.6.x | Supported | |
+| 2.7.x | Supported | |
+| 2.8.x | Known Issue | See below |
+
+## Known Issues
+
+### PyTorch 2.8.0 - Undefined Symbol Error
+
+**Issue**: When using PyTorch 2.8.0, you may encounter:
+```
+undefined symbol: _ZNK2at10TensorBase4nameEv
+```
+
+**Cause**: ABI incompatibility between kvcached's C++ bindings and PyTorch 2.8.0.
+
+**Solutions**:
+1. **Recommended**: Use PyTorch 2.7.x or earlier
+2. **Alternative**: Rebuild kvcached from source with PyTorch 2.8.0:
+   ```bash
+   pip install -e . --no-build-isolation
+   ```
+
+### CUDA Version Requirements
+
+| kvcached Feature | Minimum CUDA |
+|------------------|--------------|
+| Basic functionality | CUDA 11.8 |
+| Flash Attention support | CUDA 12.0 |
+| vLLM 0.11.x support | CUDA 12.8 |
+
+## GPU Support
+
+### NVIDIA GPUs
+
+| GPU Architecture | Status |
+|------------------|--------|
+| Ampere (A100, A10) | Fully Supported |
+| Hopper (H100, H200) | Fully Supported |
+| Ada Lovelace (L40S) | Fully Supported |
+| Blackwell (B100, B200) | Untested |
+
+### AMD GPUs
+
+AMD GPU support is planned but not yet available. See issue #94.
+
+### ARM64 Support
+
+ARM64 (aarch64) support is in progress. See issue #225.
+
+## Memory Requirements
+
+### Minimum GPU Memory
+
+kvcached requires sufficient GPU memory for:
+1. Model weights
+2. KV cache (managed by kvcached)
+3. Activation memory during inference
+
+**Recommended**: At least 2GB free after loading model weights.
+
+### Multi-Model Recommendations
+
+| Total GPU Memory | Recommended Models |
+|------------------|-------------------|
+| 24GB | 2-3 small models (7B) |
+| 48GB | 2 medium models (13B) or 4 small |
+| 80GB | 2 large models (70B) or 4+ medium |
+
+## Container/Kubernetes Compatibility
+
+### Docker
+
+kvcached works in Docker containers with:
+- `/dev/shm` mounted with sufficient size
+- NVIDIA runtime configured
+
+```yaml
+services:
+  model:
+    image: your-image
+    shm_size: '16gb'  # Important!
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+```
+
+### Kubernetes
+
+For Kubernetes deployments:
+
+1. **Shared Memory**: Ensure adequate `/dev/shm`:
+   ```yaml
+   volumes:
+     - name: shm
+       emptyDir:
+         medium: Memory
+         sizeLimit: 16Gi
+   ```
+
+2. **GPU Resources**: Use NVIDIA device plugin:
+   ```yaml
+   resources:
+     limits:
+       nvidia.com/gpu: 1
+   ```
+
+3. **Dynamic Scaling**: kvcached automatically detects available GPU memory. When Kubernetes scales GPU resources, kvcached will utilize the new capacity on next initialization.
+
+See issue #87 for more details on Kubernetes integration.
+
+## Troubleshooting Compatibility Issues
+
+### Check Versions
+
+```bash
+# Check PyTorch version
+python -c "import torch; print(torch.__version__)"
+
+# Check CUDA version
+nvcc --version
+
+# Check vLLM version
+python -c "import vllm; print(vllm.__version__)"
+
+# Check SGLang version
+python -c "import sglang; print(sglang.__version__)"
+```
+
+### Verify kvcached Installation
+
+```bash
+# Check if C++ extensions are built correctly
+python -c "from kvcached import _C; print('C++ extensions OK')"
+
+# Check VMM operations
+python -c "from kvcached.vmm_ops import is_available; print(f'VMM: {is_available()}')"
+```
+
+### Common Fixes
+
+1. **Rebuild with matching PyTorch**:
+   ```bash
+   pip uninstall kvcached
+   pip install kvcached --no-cache-dir
+   ```
+
+2. **Clear pip cache**:
+   ```bash
+   pip cache purge
+   ```
+
+3. **Check shared memory**:
+   ```bash
+   df -h /dev/shm
+   ls -la /dev/shm/kvcached*
+   ```

--- a/examples/09_semantic_router/README.md
+++ b/examples/09_semantic_router/README.md
@@ -1,0 +1,108 @@
+# Semantic Router Example
+
+This example demonstrates how to build a semantic router that directs requests to specialized models based on query content.
+
+## Overview
+
+Instead of routing by model name, a semantic router analyzes the user's query and routes to the most appropriate model:
+
+- **Code queries** -> Code-specialized model (e.g., CodeLlama, DeepSeek-Coder)
+- **Math queries** -> Math-specialized model (e.g., Qwen-Math, DeepSeek-Math)
+- **General queries** -> General-purpose model (e.g., Llama, Qwen)
+
+## Architecture
+
+```
+User Request
+     |
+     v
++------------------+
+| Semantic Router  |  <- Classifies query intent
++------------------+
+     |
+     +---> Code Model (port 12346)
+     |
+     +---> Math Model (port 12347)
+     |
+     +---> General Model (port 12348)
+```
+
+## Prerequisites
+
+1. Install sentence-transformers for semantic similarity:
+   ```bash
+   pip install sentence-transformers
+   ```
+
+2. Start multiple model servers with kvcached:
+   ```bash
+   export ENABLE_KVCACHED=true
+   export KVCACHED_AUTOPATCH=1
+
+   # Start code model
+   vllm serve deepseek-ai/deepseek-coder-1.3b-instruct --port 12346 &
+
+   # Start math model
+   vllm serve Qwen/Qwen2.5-Math-1.5B-Instruct --port 12347 &
+
+   # Start general model
+   vllm serve Qwen/Qwen2.5-1.5B-Instruct --port 12348 &
+   ```
+
+## Usage
+
+1. Start the semantic router:
+   ```bash
+   python semantic_router.py --port 8080
+   ```
+
+2. Send requests (model selection is automatic):
+   ```bash
+   # This will route to the code model
+   curl http://localhost:8080/v1/chat/completions \
+     -H "Content-Type: application/json" \
+     -d '{"messages": [{"role": "user", "content": "Write a Python function to sort a list"}]}'
+
+   # This will route to the math model
+   curl http://localhost:8080/v1/chat/completions \
+     -H "Content-Type: application/json" \
+     -d '{"messages": [{"role": "user", "content": "Solve the integral of x^2 dx"}]}'
+
+   # This will route to the general model
+   curl http://localhost:8080/v1/chat/completions \
+     -H "Content-Type: application/json" \
+     -d '{"messages": [{"role": "user", "content": "What is the capital of France?"}]}'
+   ```
+
+## Configuration
+
+Edit `config.yaml` to customize:
+- Model endpoints
+- Category keywords/embeddings
+- Similarity thresholds
+
+## How It Works
+
+1. **Query Embedding**: The router embeds the user query using a lightweight model
+2. **Category Matching**: Compares query embedding to category embeddings
+3. **Routing Decision**: Routes to the model with highest similarity score
+4. **Fallback**: Uses general model if no category exceeds threshold
+
+## Monitoring
+
+Check routing statistics:
+```bash
+curl http://localhost:8080/stats
+```
+
+Output:
+```json
+{
+  "total_requests": 100,
+  "routes": {
+    "code": 35,
+    "math": 25,
+    "general": 40
+  }
+}
+```

--- a/examples/09_semantic_router/semantic_router.py
+++ b/examples/09_semantic_router/semantic_router.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Semantic Router for Multi-Model LLM Serving
+
+Routes requests to specialized models based on query content analysis.
+Demonstrates intelligent routing with kvcached multi-model support.
+"""
+
+import argparse
+import json
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import httpx
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import StreamingResponse
+import uvicorn
+
+# Optional: Use sentence-transformers for better semantic matching
+try:
+    from sentence_transformers import SentenceTransformer
+    EMBEDDINGS_AVAILABLE = True
+except ImportError:
+    EMBEDDINGS_AVAILABLE = False
+    print("Warning: sentence-transformers not installed. Using keyword matching.")
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="Semantic Router", description="Routes to specialized models")
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for a specialized model."""
+    name: str
+    endpoint: str
+    categories: List[str]
+    keywords: List[str]
+    priority: int = 0
+
+
+# Default model configurations
+DEFAULT_MODELS = [
+    ModelConfig(
+        name="code",
+        endpoint="http://localhost:12346",
+        categories=["programming", "coding", "software"],
+        keywords=[
+            "code", "program", "function", "class", "algorithm", "python",
+            "javascript", "rust", "debug", "compile", "syntax", "api",
+            "implement", "script", "library", "framework", "git", "docker"
+        ],
+        priority=1,
+    ),
+    ModelConfig(
+        name="math",
+        endpoint="http://localhost:12347",
+        categories=["mathematics", "calculation", "equations"],
+        keywords=[
+            "math", "calculate", "solve", "equation", "integral", "derivative",
+            "algebra", "geometry", "statistics", "probability", "matrix",
+            "vector", "calculus", "theorem", "proof", "formula", "sum"
+        ],
+        priority=1,
+    ),
+    ModelConfig(
+        name="general",
+        endpoint="http://localhost:12348",
+        categories=["general", "conversation", "knowledge"],
+        keywords=[],  # Fallback for everything else
+        priority=0,
+    ),
+]
+
+
+class SemanticRouter:
+    """Routes queries to specialized models based on content."""
+
+    def __init__(self, models: List[ModelConfig], embedding_model: str = "all-MiniLM-L6-v2"):
+        self.models = {m.name: m for m in models}
+        self.stats: Dict[str, int] = {m.name: 0 for m in models}
+        self.total_requests = 0
+
+        # Initialize embeddings if available
+        self.embedder = None
+        self.category_embeddings: Dict[str, any] = {}
+        if EMBEDDINGS_AVAILABLE:
+            try:
+                self.embedder = SentenceTransformer(embedding_model)
+                self._precompute_embeddings()
+                logger.info("Initialized semantic embeddings")
+            except Exception as e:
+                logger.warning(f"Failed to load embeddings: {e}")
+
+    def _precompute_embeddings(self):
+        """Pre-compute embeddings for category keywords."""
+        if not self.embedder:
+            return
+        for model in self.models.values():
+            if model.keywords:
+                text = " ".join(model.keywords + model.categories)
+                self.category_embeddings[model.name] = self.embedder.encode(text)
+
+    def classify_query(self, query: str) -> str:
+        """Classify a query and return the best model name."""
+        query_lower = query.lower()
+
+        # Try semantic matching first
+        if self.embedder and self.category_embeddings:
+            query_embedding = self.embedder.encode(query)
+            best_score = -1
+            best_model = "general"
+
+            for name, cat_embedding in self.category_embeddings.items():
+                # Cosine similarity
+                score = float(query_embedding @ cat_embedding) / (
+                    (query_embedding @ query_embedding) ** 0.5 *
+                    (cat_embedding @ cat_embedding) ** 0.5
+                )
+                if score > best_score and score > 0.3:  # Threshold
+                    best_score = score
+                    best_model = name
+
+            if best_score > 0.3:
+                logger.debug(f"Semantic match: {best_model} (score={best_score:.3f})")
+                return best_model
+
+        # Fallback to keyword matching
+        best_match = "general"
+        best_count = 0
+        for model in self.models.values():
+            if model.name == "general":
+                continue
+            count = sum(1 for kw in model.keywords if kw in query_lower)
+            if count > best_count:
+                best_count = count
+                best_match = model.name
+
+        logger.debug(f"Keyword match: {best_match} (count={best_count})")
+        return best_match
+
+    def route(self, query: str) -> ModelConfig:
+        """Route a query to the appropriate model."""
+        model_name = self.classify_query(query)
+        self.stats[model_name] = self.stats.get(model_name, 0) + 1
+        self.total_requests += 1
+        return self.models[model_name]
+
+    def get_stats(self) -> dict:
+        """Return routing statistics."""
+        return {
+            "total_requests": self.total_requests,
+            "routes": self.stats.copy(),
+        }
+
+
+# Global router instance
+router: Optional[SemanticRouter] = None
+
+
+def extract_query(request_body: dict) -> str:
+    """Extract the user query from various request formats."""
+    # Chat completions format
+    if "messages" in request_body:
+        messages = request_body["messages"]
+        for msg in reversed(messages):
+            if msg.get("role") == "user":
+                return msg.get("content", "")
+
+    # Completions format
+    if "prompt" in request_body:
+        return request_body["prompt"]
+
+    return ""
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Request):
+    """Route chat completion requests to appropriate model."""
+    body = await request.json()
+    query = extract_query(body)
+
+    if not query:
+        raise HTTPException(status_code=400, detail="No query found in request")
+
+    model_config = router.route(query)
+    logger.info(f"Routing to {model_config.name}: {query[:50]}...")
+
+    # Forward request to selected model
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        response = await client.post(
+            f"{model_config.endpoint}/v1/chat/completions",
+            json=body,
+            headers={"Content-Type": "application/json"},
+        )
+
+        if body.get("stream", False):
+            return StreamingResponse(
+                response.aiter_bytes(),
+                media_type="text/event-stream",
+            )
+        return response.json()
+
+
+@app.post("/v1/completions")
+async def completions(request: Request):
+    """Route completion requests to appropriate model."""
+    body = await request.json()
+    query = extract_query(body)
+
+    if not query:
+        raise HTTPException(status_code=400, detail="No query found in request")
+
+    model_config = router.route(query)
+    logger.info(f"Routing to {model_config.name}: {query[:50]}...")
+
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        response = await client.post(
+            f"{model_config.endpoint}/v1/completions",
+            json=body,
+            headers={"Content-Type": "application/json"},
+        )
+
+        if body.get("stream", False):
+            return StreamingResponse(
+                response.aiter_bytes(),
+                media_type="text/event-stream",
+            )
+        return response.json()
+
+
+@app.get("/stats")
+async def get_stats():
+    """Return routing statistics."""
+    return router.get_stats()
+
+
+@app.get("/health")
+async def health():
+    """Health check endpoint."""
+    return {"status": "ok", "models": list(router.models.keys())}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Semantic Router for LLM serving")
+    parser.add_argument("--port", type=int, default=8080, help="Port to run on")
+    parser.add_argument("--host", default="0.0.0.0", help="Host to bind to")
+    parser.add_argument("--config", help="Path to config file")
+    args = parser.parse_args()
+
+    global router
+
+    # Load custom config or use defaults
+    if args.config:
+        with open(args.config) as f:
+            config = json.load(f)
+        models = [ModelConfig(**m) for m in config["models"]]
+    else:
+        models = DEFAULT_MODELS
+
+    router = SemanticRouter(models)
+    logger.info(f"Starting semantic router on {args.host}:{args.port}")
+    logger.info(f"Models: {list(router.models.keys())}")
+
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -106,9 +106,15 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
             def get_new_blocks(
                 self, num_blocks: int
             ) -> list["KVCacheBlock"]:
-                if num_blocks > self.get_num_free_blocks():
+                free_blocks = self.get_num_free_blocks()
+                if num_blocks > free_blocks:
+                    usage_pct = self.get_usage() * 100
                     raise ValueError(
-                        f"Cannot get {num_blocks} free blocks from the pool")
+                        f"Cannot get {num_blocks} free blocks from the pool. "
+                        f"Available: {free_blocks}, Total: {self.num_gpu_blocks}, "
+                        f"Usage: {usage_pct:.1f}%. "
+                        f"Try reducing concurrent requests or increasing kvcached_gpu_utilization."
+                    )
 
                 block_ids = self.kv_cache_manager.alloc(num_blocks)
                 assert block_ids is not None and len(block_ids) == num_blocks


### PR DESCRIPTION
## Summary

This PR addresses multiple documentation and feature requests to improve the kvcached user experience:

### Documentation (docs/)

- **API.md** - Comprehensive API reference including:
  - Environment variables documentation
  - CLI tools reference (kvctl commands)
  - Python API with code examples for vLLM and SGLang
  - Integration APIs and manual integration guide
  - Controller REST API endpoints

- **COMPATIBILITY.md** - Version compatibility guide:
  - PyTorch version support matrix (2.4.x - 2.8.x)
  - vLLM version compatibility (0.8.4 - 0.11.x)
  - SGLang version support
  - Known issues (PyTorch 2.8.0 undefined symbol error)
  - GPU architecture support table
  - Container/Kubernetes compatibility notes

- **ARCHITECTURE.md** - System architecture documentation:
  - System overview with ASCII diagrams
  - Engine decoupling explanation
  - IPC mechanism details
  - Memory lifecycle (allocation/deallocation flow)
  - Configuration guidance for multi-engine setups

### Examples (examples/)

- **09_semantic_router/** - Content-based request routing:
  - FastAPI-based semantic router
  - Sentence-transformers integration for query classification
  - Fallback keyword matching when embeddings unavailable
  - Statistics and monitoring endpoints

### Bug Fixes

- **Improved error messages** in ElasticBlockPool.get_new_blocks():
  - Shows available vs requested blocks
  - Displays current memory usage percentage
  - Provides actionable suggestions

## Issues Addressed

- Closes #48 (API documentation)
- Closes #87 (Kubernetes integration notes)
- Closes #91 (Semantic router example)
- Closes #117 (Engine decoupling documentation)
- Closes #197 (Better error messages for block allocation)
- Closes #222 (PyTorch version compatibility docs)

## Test Plan

- [ ] Verify docs render correctly on GitHub
- [ ] Run semantic router example with test models
- [ ] Verify error message improvements in block allocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)