### PR TITLE
[Release] Bump version to 0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "kvcached"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
     {name = "The kvcached team"}
 ]


### PR DESCRIPTION
Bug fixes:
- Fix unique IPC socket when TP is enabled
- Support flashinfer kvcache shape for vLLM
- Fix exceptions in vLLM prefix-cache-related APIs
- Export missing autopatch env
- More precise vLLM version detection
- Fix memory tracker IPC name collision
- Fix type casting in get_avail_physical_pages
- Fix vLLM version range
- Fix SGLang clear() function support

Features:
- Add example for hybrid attention models

Documentation:
- Add deepwiki to README
- Update README with kvcached caching note
- Add action video and blog link