### PR TITLE
Feat: Support GPT-OSS in SGLang

### DIFF
--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -84,7 +84,7 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
 
                 def alloc(self, need_size: int):
                     indices: list[int] = self.kvcached_allocator.alloc(need_size)
-                    return torch.tensor(indices, dtype=torch.int32, device="cuda")
+                    return torch.tensor(indices, dtype=torch.int64, device="cuda")
 
                 def free(self, free_index):
                     if self.is_not_in_free_group:


### PR DESCRIPTION
When running `python -m sglang.launch_server --model openai/gpt-oss-20b --disable-radix-cache --port 30000` I encountered this error:
```
[2026-02-21 13:36:10] Scheduler hit an exception: Traceback (most recent call last):
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 2677, in run_scheduler_process
    scheduler.event_loop_overlap()
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 1036, in event_loop_overlap
    batch_result = self.run_batch(batch)
                   ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sglang/srt/managers/scheduler.py", line 1999, in run_batch
    batch_result = self.model_worker.forward_batch_generation(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sglang/srt/managers/tp_worker.py", line 392, in forward_batch_generation
    logits_output, can_run_cuda_graph = self.model_runner.forward(
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 2647, in forward
    output = self._forward_raw(
             ^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 2706, in _forward_raw
    ret = self.forward_extend(
          ^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sglang/srt/model_executor/model_runner.py", line 2592, in forward_extend
    return self.model.forward(
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sglang/srt/models/gpt_oss.py", line 611, in forward
    hidden_states = self.model(
                    ^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sglang/srt/models/gpt_oss.py", line 542, in forward
    hidden_states, residual = layer(
                              ^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sglang/srt/models/gpt_oss.py", line 444, in forward
    hidden_states = self.self_attn(
                    ^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sglang/srt/models/gpt_oss.py", line 338, in forward
    s = self.forward_prepare(
        ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sglang/srt/models/gpt_oss.py", line 303, in forward_prepare
    q, k = self.rotary_emb(
           ^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sglang/srt/custom_op.py", line 67, in forward
    return self._forward_method(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sglang/srt/layers/rotary_embedding.py", line 326, in forward_cuda
    apply_rope_with_cos_sin_cache_inplace(
  File "/home/ztang23/anaconda3/envs/kvcached/lib/python3.11/site-packages/sgl_kernel/elementwise.py", line 322, in apply_rope_with_cos_sin_cache_inplace
    assert a.cache_loc.dtype == torch.int64, f"{a.cache_loc.dtype=}"
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: a.cache_loc.dtype=torch.int32
```

Changing the indices dtype to int64 fixes the error.