### PR TITLE
[Release] Bump version to 0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ kvcached achieves this by decoupling GPU virtual addressing from physical memory
 
 ## 📢 Updates
 
-- **[2026-02]** kvcached now supports **vLLM v0.14.0** and **SGLang v0.5.9**.
+- **[2026-02]** kvcached now supports **vLLM v0.16.0** and **SGLang v0.5.9**.
 MLA models (DeepSeek-V3, DeepSeek-V2 etc.) are supported in SGLang with both `page_size=1` and `page_size>1`.
 GPT-OSS hybrid attention models (`openai/gpt-oss-20b`) are supported in SGLang.
 
@@ -50,7 +50,7 @@ GPT-OSS hybrid attention models (`openai/gpt-oss-20b`) are supported in SGLang.
 | Engine | Versions | Attention types | Example models |
 |--------|----------|-----------------|----------------|
 | SGLang | ≥ v0.4.9 (tested up to v0.5.9) | MHA / GQA / MLA | Llama 3.1/3.3, Qwen 2.5, DeepSeek-V3, openai/gpt-oss-20b, etc. |
-| vLLM | ≥ v0.8.4 (tested up to v0.14.0) | MHA / GQA | Llama 3.1/3.3, Qwen 2.5 |
+| vLLM | ≥ v0.8.4 (tested up to v0.16.0) | MHA / GQA | Llama 3.1/3.3, Qwen 2.5 |
 
 ## Example use cases
 
@@ -119,7 +119,7 @@ Details can be found in [benchmarks/bench_latency_benefit](https://github.com/ov
 ### Prerequisites
 
 - Python (tested with 3.9 - 3.12)
-- SGLang (tested with v0.5.9) or vLLM (tested with v0.14.0)
+- SGLang (tested with v0.5.9) or vLLM (tested with v0.16.0)
 
 kvcached can be installed as a plugin with existing SGLang or vLLM environment.
 

--- a/engine_integration/scripts/setup.sh
+++ b/engine_integration/scripts/setup.sh
@@ -161,7 +161,7 @@ setup_sglang_from_source() {
 
 # Dispatch helper wrappers that pick defaults when VERSION is not provided
 setup_vllm() {
-    local _default_ver="0.14.0"
+    local _default_ver="0.16.0"
     local _version=${version:-"$_default_ver"}
 
     if [[ "$method" == "source" ]]; then
@@ -192,12 +192,12 @@ ${BOLD}${CYAN}Arguments:${RESET}
   ${BOLD}--engine${RESET}            Target engine to set up (vllm, sglang) [required]
   ${BOLD}--method${RESET}            Engine installation method: pip (default) or source
   ${BOLD}--version${RESET}           Specific engine version to install. Default versions:
-        - vllm   : 0.14.0
+        - vllm   : 0.16.0
         - sglang : 0.5.9
 
 ${BOLD}${CYAN}Examples:${RESET}
-  $0 --engine vllm                                     # vLLM 0.14.0 (pip) + kvcached (source)
-  $0 --engine vllm --method source --version 0.14.0    # vLLM 0.14.0 (source) + kvcached (source)
+  $0 --engine vllm                                     # vLLM 0.16.0 (pip) + kvcached (source)
+  $0 --engine vllm --method source --version 0.16.0    # vLLM 0.16.0 (source) + kvcached (source)
   $0 --engine sglang --method source --version 0.5.9  # sglang 0.5.9 (source) + kvcached (source)
 EOF
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 readme = "README.md"
 description = "A KV cache management system that supports on-demand KV cache allocation for LLMs with GPU virtual memory"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9,<3.14"
 license = "Apache-2.0"
 keywords = [
     "llm",


### PR DESCRIPTION
  Bug Fixes:      
  - Fix chat template warmup issue

  Features:
  - Support ElasticPagedTokenToKVPoolAllocator for page-size > 1
  - Support ElasticMLAMemoryPool 
  - Support MLA models with multi-page-size 
  - Support GPT-OSS in SGLang
  - Support vLLM 0.16.0 
  - Support SGLang 0.5.9

  Documentation / Chores:
  - Update README with "Updates section"
  - Update launch script