### PR TITLE
feat: support gpt-oss in sglang-0.5.9

### DIFF
--- a/csrc/allocator.cpp
+++ b/csrc/allocator.cpp
@@ -42,8 +42,7 @@ static inline size_t get_v_base_offset(const torch::Tensor &tensor) {
 
 FTensorAllocator::FTensorAllocator(const torch::Device &device,
                                    bool contiguous_layout)
-    : dev_(device), num_layers_(0), contiguous_layout_(contiguous_layout),
-      kv_tensor_size_per_layer_(0) {
+    : dev_(device), contiguous_layout_(contiguous_layout) {
   if (dev_.is_cuda()) {
     init_cuda_();
   }
@@ -53,9 +52,7 @@ FTensorAllocator::~FTensorAllocator() { destroy(); }
 
 void FTensorAllocator::destroy() {
   std::lock_guard<std::mutex> lock(mtx_);
-  ftensors_.clear();
-  contiguous_kv_tensor_.reset();
-  zero_page_.reset();
+  kv_groups_.clear();
 }
 
 void FTensorAllocator::init(const std::string &dev_str, size_t page_size,
@@ -95,13 +92,22 @@ void FTensorAllocator::shutdown() {
   }
 }
 
+FTensorAllocator::KVGroup &
+FTensorAllocator::get_or_create_group_(int64_t group_id) {
+  // mtx_ must be held by the caller.
+  return kv_groups_[group_id]; // default-constructs if absent
+}
+
 std::vector<torch::Tensor> FTensorAllocator::create_kv_tensors(
     size_t size, torch::Dtype dtype, const std::string &dev_str,
-    int64_t num_layers, int64_t num_kv_buffers) {
+    int64_t num_layers, int64_t num_kv_buffers, int64_t group_id) {
   std::lock_guard<std::mutex> lock(mtx_);
 
-  assert(num_layers_ == 0 || num_layers_ == num_layers);
-  num_layers_ = num_layers;
+  auto &group = get_or_create_group_(group_id);
+
+  assert(group.num_layers == 0 || group.num_layers == num_layers);
+  group.num_layers = num_layers;
+
   // Ensure size is aligned to page size.
   size_t aligned_size = size;
   if (size % kPageSize != 0) {
@@ -109,42 +115,51 @@ std::vector<torch::Tensor> FTensorAllocator::create_kv_tensors(
     LOGW("Size %zu is not aligned to page size %zu, aligning to %zu", size,
          kPageSize, aligned_size);
   }
-  kv_tensor_size_per_layer_ = aligned_size;
+  group.kv_tensor_size_per_layer = aligned_size;
+
+  // Build a group-specific prefix so FTensor names don't collide across groups.
+  auto prefix = std::string(kv_prefix) + "g" + std::to_string(group_id) + "_";
 
   if (contiguous_layout_) {
     // For contiguous layout, we use compound page which groups all layers
     // together for a single page. num_kv_buffers is 2 for MHA (K+V) and
     // 1 for MLA (combined KV).
     size_t compound_page_size = kPageSize * num_layers * num_kv_buffers;
-    zero_page_ = make_shared_page(dev_, ZERO_PAGE_ID, compound_page_size);
-    // We can use the aligned size directly for contiguous layout too because
-    // both compound_page_size and aligned_size are already/will be multiplied
-    // by num_layers.
-    return create_kv_tensors_contiguous_(aligned_size, dtype, dev_str,
+    group.zero_page = make_shared_page(dev_, ZERO_PAGE_ID, compound_page_size);
+    return create_kv_tensors_contiguous_(group, aligned_size, dtype, dev_str,
                                          num_layers, compound_page_size);
   } else {
-    zero_page_ = make_shared_page(dev_, ZERO_PAGE_ID);
-    return create_kv_tensors_per_layer_(kv_prefix, aligned_size, dtype, dev_str,
-                                        num_layers);
+    group.zero_page = make_shared_page(dev_, ZERO_PAGE_ID);
+    return create_kv_tensors_per_layer_(group, prefix, aligned_size, dtype,
+                                        dev_str, num_layers);
   }
 }
 
-bool FTensorAllocator::kv_tensors_created() {
+bool FTensorAllocator::kv_tensors_created(int64_t group_id) {
   std::lock_guard<std::mutex> lock(mtx_);
-  return num_layers_ > 0;
-}
-
-bool FTensorAllocator::map_to_kv_tensors(const std::vector<offset_t> &offsets) {
-  std::unique_lock<std::mutex> lock(mtx_);
-  if (num_layers_ == 0) {
-    LOGE("try to map to KV tensors when KV tensors are not created");
+  auto it = kv_groups_.find(group_id);
+  if (it == kv_groups_.end()) {
     return false;
   }
+  return it->second.num_layers > 0;
+}
+
+bool FTensorAllocator::map_to_kv_tensors(const std::vector<offset_t> &offsets,
+                                         int64_t group_id) {
+  std::unique_lock<std::mutex> lock(mtx_);
+  auto it = kv_groups_.find(group_id);
+  if (it == kv_groups_.end() || it->second.num_layers == 0) {
+    LOGE("try to map to KV tensors when KV tensors are not created "
+         "(group_id=%ld)",
+         group_id);
+    return false;
+  }
+  auto &group = it->second;
 
   if (contiguous_layout_) {
     // In contiguous layout, use the single contiguous tensor for mapping
     // Each offset maps a block that contains all layers
-    auto ftensor = contiguous_kv_tensor_.get();
+    auto ftensor = group.contiguous_kv_tensor.get();
     auto tensor = ftensor->get_tensor();
 
     for (auto offset : offsets) {
@@ -152,10 +167,11 @@ bool FTensorAllocator::map_to_kv_tensors(const std::vector<offset_t> &offsets) {
       ftensor->map(offset);
     }
   } else {
-    // Original per-layer mapping
-    for (int64_t i = 0; i < num_layers_; i++) {
-      auto kv_name = std::string(kv_prefix) + std::to_string(i);
-      auto ftensor = ftensors_[kv_name].get();
+    // Per-layer mapping within this group
+    for (int64_t i = 0; i < group.num_layers; i++) {
+      auto kv_name = std::string(kv_prefix) + "g" + std::to_string(group_id) +
+                     "_" + std::to_string(i);
+      auto ftensor = group.ftensors[kv_name].get();
       /**
        * NOTE: we assume the K tensor and the V tensor are stacked at the 1st
        * dim. This is used for calculating the offset of the V tensor.
@@ -175,16 +191,20 @@ bool FTensorAllocator::map_to_kv_tensors(const std::vector<offset_t> &offsets) {
 }
 
 bool FTensorAllocator::unmap_from_kv_tensors(
-    const std::vector<offset_t> &offsets) {
+    const std::vector<offset_t> &offsets, int64_t group_id) {
   std::unique_lock<std::mutex> lock(mtx_);
-  if (num_layers_ == 0) {
-    LOGE("try to unmap from KV tensors when KV tensors are not created");
+  auto it = kv_groups_.find(group_id);
+  if (it == kv_groups_.end() || it->second.num_layers == 0) {
+    LOGE("try to unmap from KV tensors when KV tensors are not created "
+         "(group_id=%ld)",
+         group_id);
     return false;
   }
+  auto &group = it->second;
 
   if (contiguous_layout_) {
     // In contiguous layout, unmap using the single contiguous tensor
-    auto ftensor = contiguous_kv_tensor_.get();
+    auto ftensor = group.contiguous_kv_tensor.get();
     auto tensor = ftensor->get_tensor();
 
     for (auto offset : offsets) {
@@ -192,10 +212,11 @@ bool FTensorAllocator::unmap_from_kv_tensors(
       ftensor->unmap(offset);
     }
   } else {
-    // Original per-layer unmapping
-    for (int64_t i = 0; i < num_layers_; i++) {
-      auto kv_name = std::string(kv_prefix) + std::to_string(i);
-      auto ftensor = ftensors_[kv_name].get();
+    // Per-layer unmapping within this group
+    for (int64_t i = 0; i < group.num_layers; i++) {
+      auto kv_name = std::string(kv_prefix) + "g" + std::to_string(group_id) +
+                     "_" + std::to_string(i);
+      auto ftensor = group.ftensors[kv_name].get();
       /**
        * NOTE: we assume the K tensor and the V tensor are stacked at the 1st
        * dim. This is used for calculating the offset of the V tensor.
@@ -219,19 +240,19 @@ std::string FTensorAllocator::get_anon_tensor_name_() {
 }
 
 std::vector<torch::Tensor> FTensorAllocator::create_kv_tensors_per_layer_(
-    std::string_view prefix, size_t size, torch::Dtype dtype,
+    KVGroup &group, std::string_view prefix, size_t size, torch::Dtype dtype,
     const std::string &dev_str, int64_t num_layers) {
   std::vector<torch::Tensor> ftensors;
   for (int64_t i = 0; i < num_layers; i++) {
     auto name = std::string(prefix) + std::to_string(i);
-    auto tensor = create_ftensor_(size, dtype, dev_str, name);
+    auto tensor = create_ftensor_(group, size, dtype, dev_str, name);
     ftensors.push_back(tensor);
   }
   return ftensors;
 }
 
 std::vector<torch::Tensor> FTensorAllocator::create_kv_tensors_contiguous_(
-    size_t size, torch::Dtype dtype, const std::string &dev_str,
+    KVGroup &group, size_t size, torch::Dtype dtype, const std::string &dev_str,
     int64_t num_layers, size_t compound_page_size) {
   // In contiguous layout, Python passes per-layer size, and we multiply by
   // num_layers to get total size
@@ -239,42 +260,43 @@ std::vector<torch::Tensor> FTensorAllocator::create_kv_tensors_contiguous_(
 
   // Create the single contiguous KV tensor (contains K and V for all layers)
   auto contiguous_name = std::string(kv_prefix) + "contiguous";
-  contiguous_kv_tensor_ =
+  group.contiguous_kv_tensor =
       std::make_unique<FTensor>(contiguous_name, total_kv_size, dtype, dev_,
-                                zero_page_, compound_page_size);
+                                group.zero_page, compound_page_size);
 
   // Get the contiguous tensor
-  auto contiguous_tensor = contiguous_kv_tensor_->get_tensor();
+  auto contiguous_tensor = group.contiguous_kv_tensor->get_tensor();
   return {contiguous_tensor};
 }
 
 /** this function is not thread-safe */
-torch::Tensor FTensorAllocator::create_ftensor_(size_t size, torch::Dtype dtype,
+torch::Tensor FTensorAllocator::create_ftensor_(KVGroup &group, size_t size,
+                                                torch::Dtype dtype,
                                                 const std::string &dev_str,
                                                 std::string name) {
   if (name.empty())
     name = get_anon_tensor_name_();
 
-  if (ftensors_.find(name) != ftensors_.end()) {
-    auto tensor = ftensors_[name].get()->get_tensor();
+  if (group.ftensors.find(name) != group.ftensors.end()) {
+    auto tensor = group.ftensors[name].get()->get_tensor();
     assert(tensor.numel() * tensor.element_size() == size);
     assert(tensor.device() == torch::Device(dev_str));
     return tensor;
   }
 
   // Create a new FTensor
-  ftensors_[name] =
-      std::make_unique<FTensor>(name, size, dtype, dev_, zero_page_);
-  return ftensors_[name]->get_tensor();
+  group.ftensors[name] =
+      std::make_unique<FTensor>(name, size, dtype, dev_, group.zero_page);
+  return group.ftensors[name]->get_tensor();
 }
 
 /** this function is not thread-safe */
-void FTensorAllocator::free_ftensor_(torch::Tensor &ftensor) {
+void FTensorAllocator::free_ftensor_(KVGroup &group, torch::Tensor &ftensor) {
   auto name = ftensor.name();
-  if (ftensors_.find(name) == ftensors_.end()) {
+  if (group.ftensors.find(name) == group.ftensors.end()) {
     return;
   }
-  ftensors_.erase(name);
+  group.ftensors.erase(name);
 }
 
 void FTensorAllocator::init_cuda_() {

--- a/csrc/inc/allocator.hpp
+++ b/csrc/inc/allocator.hpp
@@ -25,13 +25,19 @@ public:
   ~FTensorAllocator();
 
   // KV cache interfaces.
+  // group_id allows multiple independent KV cache pools (e.g., for hybrid
+  // attention models with separate full-attention and sliding-window groups).
+  // Default group_id=0 preserves backward compatibility.
   std::vector<torch::Tensor> create_kv_tensors(size_t size, torch::Dtype dtype,
                                                const std::string &dev_str,
                                                int64_t num_layers,
-                                               int64_t num_kv_buffers = 2);
-  bool kv_tensors_created();
-  bool map_to_kv_tensors(const std::vector<offset_t> &offsets);
-  bool unmap_from_kv_tensors(const std::vector<offset_t> &offsets);
+                                               int64_t num_kv_buffers = 2,
+                                               int64_t group_id = 0);
+  bool kv_tensors_created(int64_t group_id = 0);
+  bool map_to_kv_tensors(const std::vector<offset_t> &offsets,
+                         int64_t group_id = 0);
+  bool unmap_from_kv_tensors(const std::vector<offset_t> &offsets,
+                             int64_t group_id = 0);
 
   // Global status interfaces.
   static void init(const std::string &dev_str, size_t page_size = 0,
@@ -41,20 +47,35 @@ public:
   void destroy();
 
 private:
+  // Per-group state that holds FTensors and metadata for one KV cache pool.
+  struct KVGroup {
+    int64_t num_layers = 0;
+    size_t kv_tensor_size_per_layer = 0;
+    // For per-layer layout: one tensor per layer
+    std::unordered_map<std::string, std::unique_ptr<FTensor>> ftensors;
+    // For contiguous layout: single tensor containing all layers
+    std::unique_ptr<FTensor> contiguous_kv_tensor;
+    std::shared_ptr<Page> zero_page;
+  };
+
+  // Get or create a KVGroup for the given group_id.  Must be called with
+  // mtx_ held.
+  KVGroup &get_or_create_group_(int64_t group_id);
+
   // Raw FTensor interfaces. Must call with lock.
   static std::string get_anon_tensor_name_();
   std::vector<torch::Tensor>
-  create_kv_tensors_per_layer_(std::string_view prefix, size_t size,
-                               torch::Dtype dtype, const std::string &dev_str,
-                               int64_t num_layers);
+  create_kv_tensors_per_layer_(KVGroup &group, std::string_view prefix,
+                               size_t size, torch::Dtype dtype,
+                               const std::string &dev_str, int64_t num_layers);
   std::vector<torch::Tensor>
-  create_kv_tensors_contiguous_(size_t size, torch::Dtype dtype,
+  create_kv_tensors_contiguous_(KVGroup &group, size_t size, torch::Dtype dtype,
                                 const std::string &dev_str, int64_t num_layers,
                                 size_t compound_page_size);
-  torch::Tensor create_ftensor_(size_t size, torch::Dtype dtype,
+  torch::Tensor create_ftensor_(KVGroup &group, size_t size, torch::Dtype dtype,
                                 const std::string &dev_str,
                                 std::string name = "");
-  void free_ftensor_(torch::Tensor &ftensor);
+  void free_ftensor_(KVGroup &group, torch::Tensor &ftensor);
 
   // CUDA util functions.
   void init_cuda_();
@@ -63,17 +84,11 @@ private:
   static std::mutex g_allocator_mutex_;
 
   torch::Device dev_;
-
-  int64_t num_layers_;
   bool contiguous_layout_;
-  size_t kv_tensor_size_per_layer_;
 
   mutable std::mutex mtx_;
-  // For per-layer layout: one tensor per layer
-  std::unordered_map<std::string, std::unique_ptr<FTensor>> ftensors_;
-  // For contiguous layout: single tensor containing all layers
-  std::unique_ptr<FTensor> contiguous_kv_tensor_;
-  std::shared_ptr<Page> zero_page_;
+  // Map from group_id to per-group KV cache state.
+  std::unordered_map<int64_t, KVGroup> kv_groups_;
 };
 
 } // namespace kvcached

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -26,30 +26,33 @@ void shutdown_kvcached() {
 std::vector<torch::Tensor> create_kv_tensors(size_t size, size_t dtype_size,
                                              const std::string &dev_str,
                                              int64_t num_layers,
-                                             int64_t num_kv_buffers = 2) {
+                                             int64_t num_kv_buffers = 2,
+                                             int64_t group_id = 0) {
   py::gil_scoped_release release;
   auto allocator = FTensorAllocator::global_allocator();
   auto dtype_ = torch_dtype_from_size(dtype_size);
   return allocator->create_kv_tensors(size, dtype_, dev_str, num_layers,
-                                      num_kv_buffers);
+                                      num_kv_buffers, group_id);
 }
 
-bool kv_tensors_created() {
+bool kv_tensors_created(int64_t group_id = 0) {
   py::gil_scoped_release release;
   auto allocator = FTensorAllocator::global_allocator();
-  return allocator->kv_tensors_created();
+  return allocator->kv_tensors_created(group_id);
 }
 
-bool map_to_kv_tensors(const std::vector<offset_t> &offsets) {
+bool map_to_kv_tensors(const std::vector<offset_t> &offsets,
+                       int64_t group_id = 0) {
   py::gil_scoped_release release;
   auto allocator = FTensorAllocator::global_allocator();
-  return allocator->map_to_kv_tensors(offsets);
+  return allocator->map_to_kv_tensors(offsets, group_id);
 }
 
-bool unmap_from_kv_tensors(const std::vector<offset_t> &offsets) {
+bool unmap_from_kv_tensors(const std::vector<offset_t> &offsets,
+                           int64_t group_id = 0) {
   py::gil_scoped_release release;
   auto allocator = FTensorAllocator::global_allocator();
-  return allocator->unmap_from_kv_tensors(offsets);
+  return allocator->unmap_from_kv_tensors(offsets, group_id);
 }
 
 } // namespace kvcached
@@ -63,10 +66,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("shutdown_kvcached", &kvcached::shutdown_kvcached, "Shutdown kvcached");
   m.def("create_kv_tensors", &kvcached::create_kv_tensors, "create_kv_tensors",
         py::arg("size"), py::arg("dtype_size"), py::arg("dev_str"),
-        py::arg("num_layers"), py::arg("num_kv_buffers") = 2);
+        py::arg("num_layers"), py::arg("num_kv_buffers") = 2,
+        py::arg("group_id") = 0);
   m.def("kv_tensors_created", &kvcached::kv_tensors_created,
-        "kv_tensors_created");
-  m.def("map_to_kv_tensors", &kvcached::map_to_kv_tensors, "map_to_kv_tensors");
+        "kv_tensors_created", py::arg("group_id") = 0);
+  m.def("map_to_kv_tensors", &kvcached::map_to_kv_tensors, "map_to_kv_tensors",
+        py::arg("offsets"), py::arg("group_id") = 0);
   m.def("unmap_from_kv_tensors", &kvcached::unmap_from_kv_tensors,
-        "unmap_from_kv_tensors");
+        "unmap_from_kv_tensors", py::arg("offsets"), py::arg("group_id") = 0);
 }

--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -65,6 +65,7 @@ def alloc_kv_cache(
     page_size: int = 1,
     attention_type: str = "MHA",  # GQA is also supported. TODO: support MLA
     kv_layout: str = "NHD",  # NHD: (num_tokens, head_num, head_dim)
+    group_id: int = 0,
 ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
@@ -96,7 +97,7 @@ def alloc_kv_cache(
 
     raw_kv_tensors = create_kv_tensors(
         gpu_mem_bytes_per_layer_k_or_v * num_k_or_v, dtype.itemsize, device, num_layers,
-        num_kv_buffers=num_k_or_v,
+        num_kv_buffers=num_k_or_v, group_id=group_id,
     )
 
     num_blocks_per_layer = gpu_mem_bytes_per_layer_k_or_v // block_mem_size
@@ -134,6 +135,7 @@ def alloc_mla_kv_cache(
     device: str,
     num_layers: int,
     page_size: int = 1,
+    group_id: int = 0,
 ) -> List[torch.Tensor]:
     """Allocate MLA-style KV cache with a single combined kv_buffer per layer.
 
@@ -163,7 +165,7 @@ def alloc_mla_kv_cache(
 
     raw_kv_tensors = create_kv_tensors(
         gpu_mem_bytes_per_layer * num_k_or_v, dtype.itemsize, device, num_layers,
-        num_kv_buffers=num_k_or_v,
+        num_kv_buffers=num_k_or_v, group_id=group_id,
     )
 
     num_blocks_per_layer = gpu_mem_bytes_per_layer // block_mem_size
@@ -199,6 +201,7 @@ def get_kv_cache_manager(
     num_layers: int,
     reserve_null_block: bool = True,
     num_kv_buffers: int = 2,
+    group_id: int = 0,
 ) -> KVCacheManager:
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
@@ -211,4 +214,5 @@ def get_kv_cache_manager(
         async_sched=_async_sched,
         reserve_null_block=reserve_null_block,
         num_kv_buffers=num_kv_buffers,
+        group_id=group_id,
     )

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -80,7 +80,15 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
                     )
 
                 def available_size(self):
-                    return self.kvcached_allocator.available_size()
+                    # Cap at the pool's token capacity.  KVCacheManager
+                    # internally manages size+1 blocks (the extra slot is
+                    # the null/padding block) and considers physical GPU
+                    # memory availability, so its reported available_size
+                    # can slightly exceed the pool's declared size.
+                    # SGLang's SWATokenToKVPoolAllocator asserts
+                    # available <= size.
+                    return min(self.kvcached_allocator.available_size(),
+                               self.size)
 
                 def alloc(self, need_size: int):
                     indices: list[int] = self.kvcached_allocator.alloc(need_size)
@@ -349,6 +357,12 @@ class ElasticMemoryPoolPatch(VersionAwarePatch, BasePatch):
             MHATokenToKVPool = getattr(mem_pool_mod, "MHATokenToKVPool")
 
             class ElasticMHATokenToKVPool(MHATokenToKVPool):  # type: ignore
+                # Auto-incrementing group_id so that each pool instance
+                # (e.g., full-attention pool and SWA pool in SWAKVPool)
+                # gets independent FTensors and page spaces in the C++
+                # FTensorAllocator.
+                _next_group_id = 0
+
                 def __init__(
                     self,
                     size: int,
@@ -364,6 +378,11 @@ class ElasticMemoryPoolPatch(VersionAwarePatch, BasePatch):
                     *args,
                     **kwargs,
                 ) -> None:
+                    # Assign group_id BEFORE super().__init__() because it
+                    # calls _create_buffers() which needs self._group_id.
+                    self._group_id = ElasticMHATokenToKVPool._next_group_id
+                    ElasticMHATokenToKVPool._next_group_id += 1
+
                     super().__init__(
                         size=size,
                         page_size=page_size,
@@ -382,14 +401,16 @@ class ElasticMemoryPoolPatch(VersionAwarePatch, BasePatch):
 
                     self.cell_size = self.head_num * self.head_dim * dtype.itemsize
                     self.kvcached_allocator = kvi.get_kv_cache_manager(
-                        math.ceil(size / page_size) + 1, page_size, self.cell_size, layer_num
+                        math.ceil(size / page_size) + 1, page_size, self.cell_size, layer_num,
+                        group_id=self._group_id,
                     )
 
                     k_size, v_size = self.get_kv_size_bytes()
                     k_size_phy, v_size_phy = self.get_kv_size_bytes_phy()
 
                     logger.info(
-                        f"VirtualKV Cache is allocated. #tokens: {size}, K size: "
+                        f"VirtualKV Cache is allocated (group_id={self._group_id}). "
+                        f"#tokens: {size}, #layers: {layer_num}, K size: "
                         f"{k_size / BYTES_PER_GB:.2f} GB, V size: {v_size / BYTES_PER_GB:.2f} GB"
                     )
                     logger.info(
@@ -420,6 +441,7 @@ class ElasticMemoryPoolPatch(VersionAwarePatch, BasePatch):
                         page_size=self.page_size,
                         attention_type="MHA",
                         kv_layout="NHD",
+                        group_id=self._group_id,
                     )
 
                 def get_kv_size_bytes_phy(self):

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -68,6 +68,7 @@ def alloc_kv_cache(
     num_layers: int,
     attention_type: str = "MHA",  # GQA is also supported. TODO: support MLA
     kv_layout: str = "NHD",  # NHD: (num_tokens, head_num, head_dim)
+    group_id: int = 0,
 ) -> List[torch.Tensor]:
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
@@ -112,7 +113,7 @@ def alloc_kv_cache(
 
     raw_kv_tensors = create_kv_tensors(
         gpu_mem_bytes_per_layer_k_or_v * num_k_or_v, dtype.itemsize, device, num_layers,
-        num_kv_buffers=num_k_or_v,
+        num_kv_buffers=num_k_or_v, group_id=group_id,
     )
 
     actual_kvcache_shape: List[int] = list(kvcache_shape)
@@ -139,6 +140,7 @@ def get_kv_cache_manager(
     cell_size: int,
     num_layers: int,
     num_kv_buffers: int = 2,
+    group_id: int = 0,
 ) -> KVCacheManager:
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
@@ -151,4 +153,5 @@ def get_kv_cache_manager(
         _tp_size,
         async_sched=_async_sched,
         num_kv_buffers=num_kv_buffers,
+        group_id=group_id,
     )

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -24,6 +24,7 @@ from kvcached.vmm_ops import kv_tensors_created
 logger = get_kvcached_logger()
 
 KV_TENSOR_WAIT_TIMEOUT: float = 10.0  # seconds
+PREALLOC_THREAD_TIMEOUT: float = 2.0  # seconds
 
 
 def synchronized(method):
@@ -51,6 +52,7 @@ class KVCacheManager:
         async_sched: bool = False,
         reserve_null_block: bool = False,
         num_kv_buffers: int = 2,
+        group_id: int = 0,
     ):
         """
         Args:
@@ -65,12 +67,15 @@ class KVCacheManager:
                 first block is always reserved as padded tokens.
             num_kv_buffers: Number of KV buffers per layer (2 for MHA K+V,
                 1 for MLA combined KV).
+            group_id: KV cache group identifier for hybrid attention models.
+                Different groups have independent FTensors and page spaces.
         """
         self.num_blocks = num_blocks
         self.block_mem_size = block_size * cell_size
         self.num_layers = num_layers
         self.num_kv_buffers = num_kv_buffers
         self.reserve_null_block = reserve_null_block
+        self.group_id = group_id
 
         # The physical page size used by kvcached page allocator.
         self.page_size = PAGE_SIZE
@@ -84,6 +89,7 @@ class KVCacheManager:
             self.tp_size,
             async_sched=async_sched,
             num_kv_buffers=self.num_kv_buffers,
+            group_id=self.group_id,
         )
 
         self.num_avail_blocks = 0  # Only count free blocks in avail_pages
@@ -111,9 +117,10 @@ class KVCacheManager:
 
         def _check_kv_tensors_created():
             if self.tp_size > 1:
-                return broadcast_kv_tensors_created(self.tp_size)
+                return broadcast_kv_tensors_created(self.tp_size,
+                                                    group_id=self.group_id)
             else:
-                return kv_tensors_created()
+                return kv_tensors_created(group_id=self.group_id)
 
         try:
             total_wait = 0.0
@@ -356,6 +363,12 @@ class KVCacheManager:
 
         self._wait_post_init()
 
+        # Stop the prealloc thread first — it runs on the PageAllocator's
+        # lock and can grab pages between our trim/reset/reserve steps,
+        # causing the null-block reservation to get a non-zero block.
+        self.page_allocator._stop_prealloc_thread(
+            timeout=PREALLOC_THREAD_TIMEOUT)
+
         # Clear reserved blocks
         self.free_reserved()
 
@@ -373,12 +386,22 @@ class KVCacheManager:
         # Trim the page allocator to free up reserved pages
         self.trim()
 
+        # Reset the page allocator's free list to its original sorted order.
+        # After free_pages + trim, freed pages are appended to the END of
+        # free_page_list, so the order is scrambled.  This matters because
+        # _reserve_null_block() pops from the LEFT and expects to get page 0
+        # (which yields block 0 — the null block SGLang requires).
+        self.page_allocator.reset_free_page_order()
+
         self.target_num_blocks = None
         self.in_shrink = False
         self.num_avail_blocks = 0
 
         # Possibly reserve the first block as null block for padding tokens
         self._reserve_null_block()
+
+        # Restart the prealloc thread now that null block is safely reserved.
+        self.page_allocator.start_prealloc_thread()
 
     # Private methods
     @synchronized

--- a/kvcached/page_allocator.py
+++ b/kvcached/page_allocator.py
@@ -139,7 +139,8 @@ class PageAllocator:
                  async_sched: bool = False,
                  contiguous_layout: bool = CONTIGUOUS_LAYOUT,
                  enable_page_prealloc: bool = PAGE_PREALLOC_ENABLED,
-                 num_kv_buffers: int = 2):
+                 num_kv_buffers: int = 2,
+                 group_id: int = 0):
         """
         Args:
             num_layers: Number of layers (for physical memory calculation).
@@ -151,6 +152,8 @@ class PageAllocator:
             enable_page_prealloc: Whether to enable page preallocation.
             num_kv_buffers: Number of KV buffers per layer (2 for MHA K+V,
                 1 for MLA combined KV).
+            group_id: KV cache group identifier for hybrid attention models.
+                Different groups have independent FTensors and page spaces.
         """
         logger.info(
             f"Init kvcached KV cache allocator: "
@@ -172,6 +175,7 @@ class PageAllocator:
         self.async_sched = async_sched
         self.contiguous_layout = contiguous_layout
         self.num_kv_buffers = num_kv_buffers
+        self.group_id = group_id
         # TODO: make this compatible with engine's memory limit after getting
         # better configuration management.
         self.gpu_utilization = GPU_UTILIZATION
@@ -413,6 +417,19 @@ class PageAllocator:
             # Update memory usage after unmapping pages
             self._update_memory_usage()
 
+    def reset_free_page_order(self) -> None:
+        """Reset the free page list to sorted order.
+
+        After free_pages + trim cycles, freed pages are appended to the
+        end of the deque so the ordering becomes scrambled.  This method
+        re-sorts the free list so that low-numbered pages (starting with
+        page 0) are allocated first — important because SGLang expects
+        the very first block (on page 0) to be reserved as the null block.
+        """
+        with self._lock:
+            sorted_pages = sorted(self.free_page_list)
+            self.free_page_list = deque(sorted_pages)
+
     def get_num_free_pages(self) -> int:
         return self.num_free_pages
 
@@ -527,9 +544,10 @@ class PageAllocator:
         else:
             offsets = [pid * self.page_size for pid in page_ids]
         if self.tp_size > 1:  # map pages across all tensor parallel workers.
-            broadcast_map_to_kv_tensors(self.tp_size, offsets)
+            broadcast_map_to_kv_tensors(self.tp_size, offsets,
+                                        group_id=self.group_id)
         else:
-            map_to_kv_tensors(offsets)
+            map_to_kv_tensors(offsets, group_id=self.group_id)
 
     def _unmap_pages(self, page_ids: list[int]) -> None:
         if self.contiguous_layout:
@@ -540,11 +558,12 @@ class PageAllocator:
         else:
             offsets = [pid * self.page_size for pid in page_ids]
         if self.tp_size > 1:  # unmap pages across all tensor parallel workers.
-            broadcast_unmap_from_kv_tensors(self.tp_size, offsets)
+            broadcast_unmap_from_kv_tensors(self.tp_size, offsets,
+                                            group_id=self.group_id)
         else:
             if self.async_sched:
                 torch.cuda.synchronize()
-            unmap_from_kv_tensors(offsets)
+            unmap_from_kv_tensors(offsets, group_id=self.group_id)
 
     def _update_memory_usage(self):
         """Update memory usage information in shared memory."""

--- a/kvcached/tp_ipc_util.py
+++ b/kvcached/tp_ipc_util.py
@@ -118,14 +118,15 @@ def start_worker_listener_thread(rank: int):
             try:
                 msg: Message = recv_msg(conn)
                 # print(f"Worker {rank} received message: {msg}")
+                group_id: int = msg.get("group_id", 0)
                 if msg["cmd"] == "map_to_kv_tensors":
-                    map_to_kv_tensors(msg["offsets"])
+                    map_to_kv_tensors(msg["offsets"], group_id=group_id)
                     send_msg(conn, {"status": "success"})
                 elif msg["cmd"] == "unmap_from_kv_tensors":
-                    unmap_from_kv_tensors(msg["offsets"])
+                    unmap_from_kv_tensors(msg["offsets"], group_id=group_id)
                     send_msg(conn, {"status": "success"})
                 elif msg["cmd"] == "kv_tensors_created":
-                    created: bool = kv_tensors_created()
+                    created: bool = kv_tensors_created(group_id=group_id)
                     send_msg(conn, {"status": "success", "created": created})
                 else:
                     send_msg(conn, {
@@ -168,11 +169,13 @@ async def _send_and_receive_message(rank: int, message: Message) -> Message:
 
 
 async def _broadcast_map_to_kv_tensors(tp_size: int,
-                                       offsets: list[int]) -> None:
+                                       offsets: list[int],
+                                       group_id: int = 0) -> None:
     """
     Broadcast the "map_to_kv_tensors" operation to all workers concurrently.
     """
-    map_message = {"cmd": "map_to_kv_tensors", "offsets": offsets}
+    map_message = {"cmd": "map_to_kv_tensors", "offsets": offsets,
+                   "group_id": group_id}
     tasks = [
         _send_and_receive_message(rank, map_message) for rank in range(tp_size)
     ]
@@ -187,11 +190,13 @@ async def _broadcast_map_to_kv_tensors(tp_size: int,
 
 
 async def _broadcast_unmap_from_kv_tensors(tp_size: int,
-                                           offsets: list[int]) -> None:
+                                           offsets: list[int],
+                                           group_id: int = 0) -> None:
     """
     Broadcast the "unmap_from_kv_tensors" operation to all workers concurrently.
     """
-    unmap_message = {"cmd": "unmap_from_kv_tensors", "offsets": offsets}
+    unmap_message = {"cmd": "unmap_from_kv_tensors", "offsets": offsets,
+                     "group_id": group_id}
     tasks = [
         _send_and_receive_message(rank, unmap_message)
         for rank in range(tp_size)
@@ -206,12 +211,13 @@ async def _broadcast_unmap_from_kv_tensors(tp_size: int,
             raise RuntimeError(f"Worker {rank} failed to unmap: {response}")
 
 
-async def _broadcast_kv_tensors_created(tp_size: int) -> bool:
+async def _broadcast_kv_tensors_created(tp_size: int,
+                                        group_id: int = 0) -> bool:
     """
     Broadcast the "kv_tensors_created" operation to all workers concurrently.
     Returns True if all workers report that KV tensors are created, False otherwise.
     """
-    check_message = {"cmd": "kv_tensors_created"}
+    check_message = {"cmd": "kv_tensors_created", "group_id": group_id}
     tasks = [
         _send_and_receive_message(rank, check_message)
         for rank in range(tp_size)
@@ -236,13 +242,15 @@ async def _broadcast_kv_tensors_created(tp_size: int) -> bool:
 
 
 # Wrapper functions to call the async function from sync code
-def broadcast_map_to_kv_tensors(tp_size: int, offsets: list[int]) -> None:
-    asyncio.run(_broadcast_map_to_kv_tensors(tp_size, offsets))
+def broadcast_map_to_kv_tensors(tp_size: int, offsets: list[int],
+                                group_id: int = 0) -> None:
+    asyncio.run(_broadcast_map_to_kv_tensors(tp_size, offsets, group_id))
 
 
-def broadcast_unmap_from_kv_tensors(tp_size: int, offsets: list[int]) -> None:
-    asyncio.run(_broadcast_unmap_from_kv_tensors(tp_size, offsets))
+def broadcast_unmap_from_kv_tensors(tp_size: int, offsets: list[int],
+                                    group_id: int = 0) -> None:
+    asyncio.run(_broadcast_unmap_from_kv_tensors(tp_size, offsets, group_id))
 
 
-def broadcast_kv_tensors_created(tp_size: int) -> bool:
-    return asyncio.run(_broadcast_kv_tensors_created(tp_size))
+def broadcast_kv_tensors_created(tp_size: int, group_id: int = 0) -> bool:
+    return asyncio.run(_broadcast_kv_tensors_created(tp_size, group_id))


### PR DESCRIPTION
Support gpt-oss in sglang-0.5.9. `GptOssForCausalLM` follows `hybrid_swa_model` path https://github.com/ztang2370/sglang/blob/38ee749dd90cdab572d393bb856430ef92c981d2/python/sglang/srt/configs/model_config.py#L1320.