### PR TITLE
fix: update scripts to adapt to new vllm versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ python -m sglang.launch_server --model meta-llama/Llama-3.2-1B-Instruct --disabl
 python -m sglang.bench_serving --backend sglang-oai --model meta-llama/Llama-3.2-1B-Instruct --dataset-name sharegpt --request-rate 10 --num-prompts 1000 --port 30000
 
 # for vllm
-vllm serve meta-llama/Llama-3.2-1B-Instruct --disable-log-requests --no-enable-prefix-caching --port=12346
+vllm serve meta-llama/Llama-3.2-1B-Instruct --no-enable-prefix-caching --port=12346
 vllm bench serve --model meta-llama/Llama-3.2-1B-Instruct --request-rate 10 --num-prompts 1000 --port 12346
 ```
 

--- a/benchmarks/bench_kvcached_overhead/start_server.sh
+++ b/benchmarks/bench_kvcached_overhead/start_server.sh
@@ -18,7 +18,6 @@ if [ "$op" == "vllm" ]; then
     export ENABLE_KVCACHED=true
     export KVCACHED_AUTOPATCH=1
     vllm serve "$MODEL" \
-    --disable-log-requests \
     --no-enable-prefix-caching \
     --port="$VLLM_PORT"
 elif [ "$op" == "sgl" -o "$op" == "sglang" ]; then

--- a/benchmarks/bench_latency_benefit/bench-config.yaml
+++ b/benchmarks/bench_latency_benefit/bench-config.yaml
@@ -34,7 +34,6 @@ instances: # instances configuration
       - "VLLM_ATTENTION_BACKEND=FLASH_ATTN"
       - "VLLM_SERVER_DEV_MODE=1" # To enable model sleep
     engine_args:
-      - "--disable-log-requests"
       - "--no-enable-prefix-caching"
       - "--host=localhost"
       - "--port=12346"
@@ -55,7 +54,6 @@ instances: # instances configuration
       - "VLLM_ATTENTION_BACKEND=FLASH_ATTN"
       - "VLLM_SERVER_DEV_MODE=1" # To enable model sleep
     engine_args:
-      - "--disable-log-requests"
       - "--no-enable-prefix-caching"
       - "--host=localhost"
       - "--port=30000"
@@ -76,7 +74,6 @@ instances: # instances configuration
       - "VLLM_ATTENTION_BACKEND=FLASH_ATTN"
       - "VLLM_SERVER_DEV_MODE=1" # To enable model sleep
     engine_args:
-      - "--disable-log-requests"
       - "--no-enable-prefix-caching"
       - "--host=localhost"
       - "--port=40000"

--- a/benchmarks/bench_latency_benefit/bench_kvcached_vllm.py
+++ b/benchmarks/bench_latency_benefit/bench_kvcached_vllm.py
@@ -35,28 +35,24 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Literal, Optional
 
+import aiohttp
 import numpy as np
-from backend_request_func import (
+from tqdm.asyncio import tqdm
+from transformers import PreTrainedTokenizerBase
+from typing_extensions import deprecated
+from vllm.benchmarks.lib.endpoint_request_func import (
     ASYNC_REQUEST_FUNCS,
     OPENAI_COMPATIBLE_BACKENDS,
     RequestFuncInput,
     RequestFuncOutput,
 )
-from tqdm.asyncio import tqdm
-from transformers import PreTrainedTokenizerBase
-from typing_extensions import deprecated
 
 try:
     from vllm.transformers_utils.tokenizer import get_tokenizer
 except ImportError:
-    from backend_request_func import get_tokenizer
+    from vllm.tokenizers import get_tokenizer
 
-try:
-    from vllm.utils import FlexibleArgumentParser
-except ImportError:
-    from argparse import ArgumentParser as FlexibleArgumentParser
-
-from benchmark_dataset import (
+from vllm.benchmarks.datasets import (
     AIMODataset,
     ASRDataset,
     BurstGPTDataset,
@@ -72,8 +68,9 @@ from benchmark_dataset import (
     SonnetDataset,
     VisionArenaDataset,
 )
-from benchmark_utils import convert_to_pytorch_benchmark_format, write_to_json
+from vllm.benchmarks.lib.utils import convert_to_pytorch_benchmark_format, write_to_json
 from vllm.benchmarks.serve import get_request
+from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 MILLISECONDS_TO_SECONDS_CONVERSION = 1000
 
@@ -335,6 +332,20 @@ async def benchmark(
     else:
         raise ValueError(f"Unknown backend: {backend}")
 
+    # Create a shared aiohttp session for all requests
+    connector = aiohttp.TCPConnector(
+        limit=0,
+        limit_per_host=0,
+        keepalive_timeout=60,
+        enable_cleanup_closed=True,
+        force_close=False,
+    )
+    session = aiohttp.ClientSession(
+        connector=connector,
+        trust_env=True,
+        timeout=aiohttp.ClientTimeout(total=6 * 60 * 60),
+    )
+
     print("Starting initial single prompt test run...")
     test_prompt, test_prompt_len, test_output_len, test_mm_content = (
         input_requests[0].prompt,
@@ -364,7 +375,7 @@ async def benchmark(
         extra_body=extra_body,
     )
 
-    test_output = await request_func(request_func_input=test_input)
+    test_output = await request_func(request_func_input=test_input, session=session)
     if not test_output.success:
         raise ValueError(
             "Initial test run failed - Please make sure benchmark arguments "
@@ -393,7 +404,7 @@ async def benchmark(
             ignore_eos=ignore_eos,
             extra_body=extra_body,
         )
-        profile_output = await request_func(request_func_input=profile_input)
+        profile_output = await request_func(request_func_input=profile_input, session=session)
         if profile_output.success:
             print("Profiler started")
 
@@ -426,9 +437,9 @@ async def benchmark(
 
     async def limited_request_func(request_func_input, pbar):
         if semaphore is None:
-            return await request_func(request_func_input=request_func_input, pbar=pbar)
+            return await request_func(request_func_input=request_func_input, session=session, pbar=pbar)
         async with semaphore:
-            return await request_func(request_func_input=request_func_input, pbar=pbar)
+            return await request_func(request_func_input=request_func_input, session=session, pbar=pbar)
 
     from itertools import cycle
 
@@ -666,10 +677,11 @@ async def benchmark(
             output_len=test_output_len,
             logprobs=logprobs,
         )
-        profile_output = await request_func(request_func_input=profile_input)
+        profile_output = await request_func(request_func_input=profile_input, session=session)
         if profile_output.success:
             print("Profiler stopped")
 
+    await session.close()
     return result
 
 

--- a/benchmarks/bench_latency_benefit/run_benchmark.sh
+++ b/benchmarks/bench_latency_benefit/run_benchmark.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 set -ex
 
+# Ensure Ctrl+C kills all background benchmark clients
+trap 'echo "Caught interrupt, killing all benchmark clients..."; kill $(jobs -p) 2>/dev/null; exit 1' INT TERM
+
 # Set environment variables
 export KVCACHED_IPC_NAME=VLLM
 
 # Add vLLM benchmarks and kvcached to Python path
-export PYTHONPATH="../../engine_integration/vllm-v0.9.2/benchmarks:../../:../../benchmarks:$PYTHONPATH"
+export PYTHONPATH="../../:../../benchmarks:$PYTHONPATH"
 
 # Benchmark parameters
 PROMPT_LEN=256

--- a/benchmarks/bench_latency_benefit/start_vllm_server.sh
+++ b/benchmarks/bench_latency_benefit/start_vllm_server.sh
@@ -13,7 +13,6 @@ PORT=8000
 
 # Start vLLM server
 vllm serve "$MODEL" \
-    --disable-log-requests \
     --no-enable-prefix-caching \
     --gpu-memory-utilization 0.5 \
     --port="$PORT" \

--- a/benchmarks/gsm8k/README.md
+++ b/benchmarks/gsm8k/README.md
@@ -10,7 +10,7 @@ Start the vLLM or SGLang engine server regularly. For example
 # Activate the same venv as the server if needed
 source /path/to/your/vllm-venv/bin/activate
 
-vllm serve Qwen/Qwen2.5-Math-1.5B --disable-log-requests --no-enable-prefix-caching --port=12346
+vllm serve Qwen/Qwen2.5-Math-1.5B --no-enable-prefix-caching --port=12346
 python -m sglang.launch_server --model Qwen/Qwen2.5-Math-1.5B --disable-radix-cache --port 30000
 ```
 

--- a/benchmarks/simple_bench/start_server.sh
+++ b/benchmarks/simple_bench/start_server.sh
@@ -137,7 +137,6 @@ if [ "$engine" == "vllm" ]; then
         VLLM_L4_ARGS="--enforce-eager"
     fi
     vllm serve "$MODEL" \
-    --disable-log-requests \
     --no-enable-prefix-caching \
     --port="$VLLM_PORT" \
     --tensor-parallel-size="$TP_SIZE" \

--- a/controller/example-config.yaml
+++ b/controller/example-config.yaml
@@ -32,7 +32,6 @@ instances: # instances configuration
       - "VLLM_ATTENTION_BACKEND=FLASH_ATTN"
       - "VLLM_SERVER_DEV_MODE=1" # To enable model sleep
     engine_args:
-      - "--disable-log-requests"
       - "--no-enable-prefix-caching"
       - "--host=localhost"
       - "--port=12346"

--- a/docker/README.md
+++ b/docker/README.md
@@ -62,7 +62,7 @@ export VLLM_USE_V1=1
 export VLLM_ATTENTION_BACKEND=FLASH_ATTN
 export ENABLE_KVCACHED=true
 export KVCACHED_AUTOPATCH=1
-vllm serve meta-llama/Llama-3.2-1B --disable-log-requests --no-enable-prefix-caching --port=12346 --tensor-parallel-size=1
+vllm serve meta-llama/Llama-3.2-1B --no-enable-prefix-caching --port=12346 --tensor-parallel-size=1
 vllm bench serve --model meta-llama/Llama-3.2-1B --request-rate 10 --num-prompts 1000 --port 12346
 ```
 

--- a/examples/01_simple_two_models/README.md
+++ b/examples/01_simple_two_models/README.md
@@ -18,7 +18,6 @@ export KVCACHED_AUTOPATCH=1
 export VLLM_USE_V1=1
 export VLLM_ATTENTION_BACKEND=FLASH_ATTN
 vllm serve "${MODEL}" \
-  --disable-log-requests \
   --no-enable-prefix-caching \
   --port "${PORT}"
 ```

--- a/examples/01_simple_two_models/start_two_models.sh
+++ b/examples/01_simple_two_models/start_two_models.sh
@@ -137,7 +137,6 @@ run_vllm() {
     export VLLM_USE_V1=1
     export VLLM_ATTENTION_BACKEND=FLASH_ATTN
     vllm serve "$model" \
-      --disable-log-requests \
       --no-enable-prefix-caching \
       --port "$port" \
       --tensor-parallel-size "$tp" \

--- a/examples/04_inference_and_finetune/start_llm_server.sh
+++ b/examples/04_inference_and_finetune/start_llm_server.sh
@@ -135,7 +135,6 @@ if [[ "$engine" == "vllm" ]]; then
         VLLM_L4_ARGS="--enforce-eager"
     fi
     vllm serve "$MODEL" \
-    --disable-log-requests \
     --no-enable-prefix-caching \
     --port="$VLLM_PORT" \
     --tensor-parallel-size="$TP_SIZE" \

--- a/examples/05_multi_agents/start_multi_agent_models.sh
+++ b/examples/05_multi_agents/start_multi_agent_models.sh
@@ -179,7 +179,6 @@ run_vllm() {
     export VLLM_ATTENTION_BACKEND=FLASH_ATTN
 
     vllm serve "$model" \
-      --disable-log-requests \
       --no-enable-prefix-caching \
       --port "$port" \
       --tensor-parallel-size "$tp" \

--- a/examples/07_inference_and_diffusion/start_llm_server.sh
+++ b/examples/07_inference_and_diffusion/start_llm_server.sh
@@ -133,7 +133,6 @@ if [[ "$engine" == "vllm" ]]; then
         VLLM_L4_ARGS="--enforce-eager"
     fi
     vllm serve "$MODEL" \
-    --disable-log-requests \
     --no-enable-prefix-caching \
     --port="$VLLM_PORT" \
     --tensor-parallel-size="$TP_SIZE" \

--- a/examples/08_hybrid_attention_models/start_two_models.sh
+++ b/examples/08_hybrid_attention_models/start_two_models.sh
@@ -88,7 +88,6 @@ run_vllm() {
     export VLLM_USE_V1=1
     export VLLM_ATTENTION_BACKEND=FLASH_ATTN
     vllm serve "$model" \
-      --disable-log-requests \
       --no-enable-prefix-caching \
       --port "$port" \
       --tensor-parallel-size 1 \


### PR DESCRIPTION
This PR

1. Removes `disable-log-requests` as this flag was removed from vllm since v0.12.0 (https://github.com/vllm-project/vllm/pull/29402)

2. Updates `benchmarks/bench_latency_benefit/bench_kvcached_vllm.py` to make it compatible with newer vllm versions.