### PR TITLE
Fix: fix ENOENT on the socket path when tp=1

### DIFF
--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -35,6 +35,12 @@ def init_kvcached(
 ) -> None:
     global _kvcached_initialized, _kvcached_device, _world_size, _async_sched, _pp_rank, _is_worker
     if _kvcached_initialized:
+        # EngineCore call init_kvcached(is_worker=False) first. When TP=1 GPUModelRunner
+        # then calls init_kvcached(is_worker=True) in the same process; without this branch
+        # the early return would leave _is_worker False, so KVCacheManager would try Unix IPC
+        # (broadcast_kv_tensors_created) and fail with ENOENT on the socket path.
+        if is_worker and not _is_worker:
+            _is_worker = True
         return
 
     if device is None:


### PR DESCRIPTION
### Error
After the changes of PR https://github.com/ovg-project/kvcached/pull/246, there was this error when initializing KVCacheManager on a single node machine (Just run `vllm serve Qwen/Qwen3-0.6B --no-enable-prefix-caching`):
```
(EngineCore_DP0 pid=115794) [kvcached][ERROR][2026-03-24 20:07:37][kv_cache_manager.py:154] Error during KVCacheManager post-initialization: Worker 0 failed to check KV tensors created: [Errno 2] No such file or directory
(EngineCore_DP0 pid=115794) Exception in thread Thread-5 (_post_init):
(EngineCore_DP0 pid=115794) Traceback (most recent call last):
(EngineCore_DP0 pid=115794)   File "/home/ztang23/anaconda3/envs/vllm_kvcached/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
(EngineCore_DP0 pid=115794) INFO 03-24 20:07:37 [vllm.py:630] Asynchronous scheduling is enabled.
(EngineCore_DP0 pid=115794)     self.run()
(EngineCore_DP0 pid=115794)   File "/home/ztang23/anaconda3/envs/vllm_kvcached/lib/python3.12/threading.py", line 1012, in run
(EngineCore_DP0 pid=115794)     self._target(*self._args, **self._kwargs)
(EngineCore_DP0 pid=115794)   File "/home/ztang23/kvcached/kvcached/kv_cache_manager.py", line 142, in _post_init
(EngineCore_DP0 pid=115794)     while not _check_kv_tensors_created():
(EngineCore_DP0 pid=115794)               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=115794)   File "/home/ztang23/kvcached/kvcached/kv_cache_manager.py", line 134, in _check_kv_tensors_created
(EngineCore_DP0 pid=115794)     return broadcast_kv_tensors_created(
(EngineCore_DP0 pid=115794)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=115794)   File "/home/ztang23/kvcached/kvcached/tp_ipc_util.py", line 266, in broadcast_kv_tensors_created
(EngineCore_DP0 pid=115794)     return asyncio.run(_broadcast_kv_tensors_created(tp_size, pp_rank,
(EngineCore_DP0 pid=115794)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=115794)   File "/home/ztang23/anaconda3/envs/vllm_kvcached/lib/python3.12/asyncio/runners.py", line 195, in run
(EngineCore_DP0 pid=115794)     return runner.run(main)
(EngineCore_DP0 pid=115794)            ^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=115794)   File "/home/ztang23/anaconda3/envs/vllm_kvcached/lib/python3.12/asyncio/runners.py", line 118, in run
(EngineCore_DP0 pid=115794)     return self._loop.run_until_complete(task)
(EngineCore_DP0 pid=115794)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=115794)   File "/home/ztang23/anaconda3/envs/vllm_kvcached/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
(EngineCore_DP0 pid=115794)     return future.result()
(EngineCore_DP0 pid=115794)            ^^^^^^^^^^^^^^^
(EngineCore_DP0 pid=115794)   File "/home/ztang23/kvcached/kvcached/tp_ipc_util.py", line 235, in _broadcast_kv_tensors_created
(EngineCore_DP0 pid=115794)     raise RuntimeError(
(EngineCore_DP0 pid=115794) RuntimeError: Worker 0 failed to check KV tensors created: [Errno 2] No such file or directory
```

### Cause
EngineCore call `init_kvcached(is_worker=False)` first and set `_kvcached_initialized` to True. When TP=1 GPUModelRunner then calls `init_kvcached(is_worker=True)` **in the same process**; however, with `_kvcached_initialized` set to True `init_kvcached(is_worker=True)`  would early return without setting `_is_worker` to True or start_worker_listener_thread. In `KVCacheManager._post_init` at https://github.com/ovg-project/kvcached/blob/40b1b164f953396f8d4deb1ae5b004e1bb3bec86/kvcached/kv_cache_manager.py#L133, `vllm_remote` is true when`vllm_inited` and `not _is_worker`, so KVCacheManager would try Unix IPC (broadcast_kv_tensors_created) instead of local `kv_tensors_created`, and fail with ENOENT on the socket path.

### Fix
Set `_is_worker` to the value of parameter `is_worker` (which is True) even if `if _kvcached_initialized` is True. This way the code path in `KVCacheManager._post_init`  would be local `kv_tensors_created`, thus avoiding the ENOENT on the socket path.