### PR TITLE
[Fix ] Fix RadixCache Patch version issue in SGLang

### DIFF
--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -790,17 +790,20 @@ class RadixCacheLimitPatch(VersionAwarePatch, BasePatch):
 
         max_cached = MAX_CACHED_TOKENS
 
+        # SGLang >= ~0.5.9 uses EvictParams; older releases pass token count as int.
         try:
-            from sglang.srt.mem_cache.radix_cache import EvictParams
+            from sglang.srt.mem_cache.radix_cache import EvictParams as _EvictParams
         except ImportError:
-            self.logger.warning("Could not import EvictParams from sglang")
-            return False
+            _EvictParams = None  # type: ignore[misc, assignment]
 
         def _wrapped(self_rc, *args: Any, **kwargs: Any):
             original_cache_finished(self_rc, *args, **kwargs)
             excess = self_rc.evictable_size_ - max_cached
             if excess > 0:
-                self_rc.evict(EvictParams(num_tokens=excess))
+                if _EvictParams is not None:
+                    self_rc.evict(_EvictParams(num_tokens=excess))
+                else:
+                    self_rc.evict(excess)
 
         self._mark_as_patched(_wrapped)
         RadixCache.cache_finished_req = _wrapped  # type: ignore


### PR DESCRIPTION
This PR solve the issue [#295](https://github.com/ovg-project/kvcached/issues/295)

**Reason of the issue:** There is no EvictParams type in SGLang 0.5.8 post 1. kvcached’s `radix_cache_limit` patch imported `EvictParams` and called `evict(EvictParams(...))`, so the import failed, the patch was skipped, and logs showed “Could not import EvictParams from sglang” / “Failed to patch … radix_cache_limit” on that version.

**Fix:** When EvictParams exists (newer SGLang (e.g. 0.5.9)), keep using it; otherwise call evict(excess) with an integer, matching 0.5.8’s API.