### PR TITLE
fix: initialize FlashInfer KV layout in kvcached allocator

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -905,7 +905,7 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             backend_name = (
                 attn_backend_cls.get_name() if hasattr(attn_backend_cls, "get_name")
                 else str(attn_backend_cls)
-            )
+            ).upper()
             if backend_name == "FLASHINFER":
                 required_layout = None
                 if hasattr(attn_backend_cls, "get_required_kv_cache_layout"):

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -901,6 +901,27 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
 
             # Use version-aware attention backend access
             attn_backend_cls = patch_instance._get_version_specific_attention_backend(self)
+
+            backend_name = (
+                attn_backend_cls.get_name() if hasattr(attn_backend_cls, "get_name")
+                else str(attn_backend_cls)
+            )
+            if backend_name == "FLASHINFER":
+                required_layout = None
+                if hasattr(attn_backend_cls, "get_required_kv_cache_layout"):
+                    required_layout = attn_backend_cls.get_required_kv_cache_layout()
+
+                selected_layout = required_layout or "NHD"
+                if selected_layout != "NHD":
+                    raise RuntimeError(
+                        "kvcached currently supports NHD KV layout only, but "
+                        f"{backend_name} requires {selected_layout}."
+                    )
+
+                from vllm.v1.attention.backends.utils import set_kv_cache_layout
+
+                set_kv_cache_layout(selected_layout)
+
             kv_cache_shape = attn_backend_cls.get_kv_cache_shape(
                 num_blocks,
                 kv_cache_spec.block_size,


### PR DESCRIPTION
Fix issue https://github.com/ovg-project/kvcached/issues/304.

## Summary

Fix vLLM startup failure when using kvcached with `--attention-backend FLASHINFER`.

When kvcached overrides vLLM KV cache allocation/reshape paths, it skips the upstream path that initializes/caches KV layout state. Later, during cudagraph profiling, FlashInfer resolves KV layout outside an active `set_current_vllm_config(...)` context and hits:

`AssertionError: Current vLLM config is not set`

This change initializes the FlashInfer KV layout explicitly in kvcached's allocator path.

## What changed

In `kvcached/integration/vllm/patches.py` (`_allocate_kv_cache_from_kvcached`):

- Detect FlashInfer backend for the current model runner.
- Read backend-required KV layout (`get_required_kv_cache_layout()` when available).
- Eagerly set KV layout during KV-cache allocation (before cudagraph warmup), so later FlashInfer paths don’t depend on active vLLM config contex.

## Why this fix

Making layout initialization explicit in the kvcached path prevents late layout resolution from depending on global config context availability and avoids the FLASHINFER startup crash.