### PR TITLE
Fix vLLM cross-version compatibility in kvcached block pool integration

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -35,7 +35,7 @@ def _validate_kv_cache_groups(kv_cache_config: Any) -> None:
     groups share the same block geometry (block_size and cell_size).
     Raises ValueError on mismatch.
     """
-    from vllm.v1 import kv_cache_interface as kv_cache_interface_mod
+    from vllm.v1 import kv_cache_interface
 
     supported_names = (
         "FullAttentionSpec",
@@ -46,7 +46,7 @@ def _validate_kv_cache_groups(kv_cache_config: Any) -> None:
     supported: tuple[type[Any], ...] = tuple(
         dict.fromkeys(
             cls for cls in
-            (getattr(kv_cache_interface_mod, name, None) for name in supported_names)
+            (getattr(kv_cache_interface, name, None) for name in supported_names)
             if isinstance(cls, type))
     )
     kv_groups = kv_cache_config.kv_cache_groups
@@ -58,11 +58,7 @@ def _validate_kv_cache_groups(kv_cache_config: Any) -> None:
     for idx, grp in enumerate(kv_groups):
         grp_spec = grp.kv_cache_spec
         is_supported_type = isinstance(grp_spec, supported)
-        has_attention_shape = all(
-            hasattr(grp_spec, attr)
-            for attr in ("block_size", "page_size_bytes", "num_kv_heads", "head_size", "dtype")
-        )
-        if not is_supported_type and not has_attention_shape:
+        if not is_supported_type:
             raise ValueError(
                 "kvcached only supports known attention KV-cache specs "
                 f"({', '.join(supported_names)}) for group validation; got "

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -31,14 +31,24 @@ if TYPE_CHECKING:
 def _validate_kv_cache_groups(kv_cache_config: Any) -> None:
     """Validate KV cache groups for kvcached compatibility.
 
-    Checks that all groups use supported spec types (FullAttentionSpec,
-    SlidingWindowSpec, or MLAAttentionSpec) and that all groups share the
-    same block geometry (block_size and cell_size).  Raises ValueError on
-    mismatch.
+    Checks that all groups use supported attention spec types and that all
+    groups share the same block geometry (block_size and cell_size).
+    Raises ValueError on mismatch.
     """
-    from vllm.v1.kv_cache_interface import FullAttentionSpec, MLAAttentionSpec, SlidingWindowSpec
+    from vllm.v1 import kv_cache_interface as kv_cache_interface_mod
 
-    supported = (FullAttentionSpec, SlidingWindowSpec, MLAAttentionSpec)
+    supported_names = (
+        "FullAttentionSpec",
+        "SlidingWindowSpec",
+        "MLAAttentionSpec",
+        "AttentionSpec",
+    )
+    supported: tuple[type[Any], ...] = tuple(
+        dict.fromkeys(
+            cls for cls in
+            (getattr(kv_cache_interface_mod, name, None) for name in supported_names)
+            if isinstance(cls, type))
+    )
     kv_groups = kv_cache_config.kv_cache_groups
 
     first_spec = kv_groups[0].kv_cache_spec
@@ -47,10 +57,16 @@ def _validate_kv_cache_groups(kv_cache_config: Any) -> None:
 
     for idx, grp in enumerate(kv_groups):
         grp_spec = grp.kv_cache_spec
-        if not isinstance(grp_spec, supported):
+        is_supported_type = isinstance(grp_spec, supported)
+        has_attention_shape = all(
+            hasattr(grp_spec, attr)
+            for attr in ("block_size", "page_size_bytes", "num_kv_heads", "head_size", "dtype")
+        )
+        if not is_supported_type and not has_attention_shape:
             raise ValueError(
-                f"kvcached only supports FullAttentionSpec, SlidingWindowSpec, "
-                f"and MLAAttentionSpec, got {type(grp_spec).__name__} in group {idx}"
+                "kvcached only supports known attention KV-cache specs "
+                f"({', '.join(supported_names)}) for group validation; got "
+                f"{type(grp_spec).__name__} in group {idx}"
             )
         grp_block_size = grp_spec.block_size
         grp_cell_size, _ = _get_kv_cache_params(grp_spec, grp_block_size)
@@ -90,9 +106,7 @@ def _get_kv_cache_params(kv_cache_spec: Any, block_size: int) -> tuple:
     Returns:
         (cell_size, num_kv_buffers)
     """
-    from vllm.v1.kv_cache_interface import MLAAttentionSpec
-
-    if isinstance(kv_cache_spec, MLAAttentionSpec):
+    if _is_mla_kv_cache_spec(kv_cache_spec):
         # MLA: single combined KV buffer per layer
         # page_size_bytes = block_size * num_kv_heads * head_size * dtype_size
         cell_size = kv_cache_spec.page_size_bytes // block_size
@@ -103,6 +117,21 @@ def _get_kv_cache_params(kv_cache_spec: Any, block_size: int) -> tuple:
         cell_size = kv_cache_spec.page_size_bytes // block_size // 2
         num_kv_buffers = 2
     return cell_size, num_kv_buffers
+
+
+def _is_mla_kv_cache_spec(kv_cache_spec: Any) -> bool:
+    """Return whether this KV cache spec should use MLA layout.
+
+    Some vLLM versions mark MLA via `use_mla` on generic attention specs,
+    while others expose `MLAAttentionSpec`.
+    """
+    if bool(getattr(kv_cache_spec, "use_mla", False)):
+        return True
+    try:
+        from vllm.v1.kv_cache_interface import MLAAttentionSpec
+    except ImportError:
+        return False
+    return isinstance(kv_cache_spec, MLAAttentionSpec)
 
 
 def _get_max_cached_blocks(block_size: int) -> int:
@@ -789,7 +818,6 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
 
         def _patched_initialize_kv_cache(self, kv_cache_config: Any) -> None:
             import torch
-            from vllm.v1.kv_cache_interface import MLAAttentionSpec
             from vllm.v1.utils import bind_kv_cache
 
             from kvcached.integration.vllm import interfaces as kvi
@@ -815,7 +843,7 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             kv_cache_spec = kv_cache_config.kv_cache_groups[0].kv_cache_spec
             tensor_config = kv_cache_config.tensors[layer_name]
 
-            is_mla = isinstance(kv_cache_spec, MLAAttentionSpec)
+            is_mla = _is_mla_kv_cache_spec(kv_cache_spec)
             dtype = kv_cache_spec.dtype
             num_blocks = tensor_config.size // kv_cache_spec.page_size_bytes
             assert num_blocks >= kv_cache_config.num_blocks
@@ -862,7 +890,7 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
 
         def _allocate_kv_cache_from_kvcached(self, kv_cache_config):
             import torch
-            from vllm.v1.kv_cache_interface import KVCacheTensor, MLAAttentionSpec
+            from vllm.v1.kv_cache_interface import KVCacheTensor
 
             from kvcached.integration.vllm import interfaces as kvi
 
@@ -873,7 +901,7 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             first_kv_cache_group = kv_cache_config.kv_cache_groups[0]
             kv_cache_spec = first_kv_cache_group.kv_cache_spec
 
-            is_mla = isinstance(kv_cache_spec, MLAAttentionSpec)
+            is_mla = _is_mla_kv_cache_spec(kv_cache_spec)
 
             layer_to_tensor_cfg: dict[str, KVCacheTensor] = {}
             for tensor_cfg in kv_cache_config.kv_cache_tensors:

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -326,7 +326,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                     f"Request has {len(block_hashes)} hashes but need {num_full_blocks}"
 
                 for i, block in enumerate(new_full_blocks):
-                    if hasattr(block, 'is_null') and block.is_null:
+                    if bool(getattr(block, "is_null", False)):
                         continue
 
                     block_idx = num_cached_blocks + i
@@ -398,7 +398,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                     block_ids = [
                         block.block_id
                         for block in ordered_blocks
-                        if block is not None and not block.is_null
+                        if block is not None and not bool(getattr(block, "is_null", False))
                     ]
                     if block_ids:
                         self.kv_cache_manager.free(block_ids)
@@ -406,7 +406,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
 
                 uncached_to_free: list[int] = []
                 for block in ordered_blocks:
-                    if block is None or block.is_null:
+                    if block is None or bool(getattr(block, "is_null", False)):
                         continue
                     block.ref_cnt -= 1
                     if block.ref_cnt == 0:

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -37,17 +37,20 @@ def _validate_kv_cache_groups(kv_cache_config: Any) -> None:
     """
     from vllm.v1 import kv_cache_interface
 
+    # NOTE: Intentionally exclude the base class `AttentionSpec` so newer
+    # subclasses (ChunkedLocalAttentionSpec, EncoderOnlyAttentionSpec,
+    # CrossAttentionSpec, ...) are not silently accepted. Pre-0.11.0 MLA is
+    # expressed as FullAttentionSpec(use_mla=True), so FullAttentionSpec alone
+    # covers it; post-0.11.0 exposes a dedicated MLAAttentionSpec class.
     supported_names = (
         "FullAttentionSpec",
         "SlidingWindowSpec",
         "MLAAttentionSpec",
-        "AttentionSpec",
     )
     supported: tuple[type[Any], ...] = tuple(
-        dict.fromkeys(
-            cls for cls in
-            (getattr(kv_cache_interface, name, None) for name in supported_names)
-            if isinstance(cls, type))
+        cls for cls in
+        (getattr(kv_cache_interface, name, None) for name in supported_names)
+        if isinstance(cls, type)
     )
     kv_groups = kv_cache_config.kv_cache_groups
 
@@ -121,7 +124,7 @@ def _is_mla_kv_cache_spec(kv_cache_spec: Any) -> bool:
     Some vLLM versions mark MLA via `use_mla` on generic attention specs,
     while others expose `MLAAttentionSpec`.
     """
-    if bool(getattr(kv_cache_spec, "use_mla", False)):
+    if getattr(kv_cache_spec, "use_mla", False):
         return True
     try:
         from vllm.v1.kv_cache_interface import MLAAttentionSpec
@@ -322,7 +325,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                     f"Request has {len(block_hashes)} hashes but need {num_full_blocks}"
 
                 for i, block in enumerate(new_full_blocks):
-                    if bool(getattr(block, "is_null", False)):
+                    if getattr(block, "is_null", False):
                         continue
 
                     block_idx = num_cached_blocks + i
@@ -394,7 +397,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                     block_ids = [
                         block.block_id
                         for block in ordered_blocks
-                        if block is not None and not bool(getattr(block, "is_null", False))
+                        if block is not None and not getattr(block, "is_null", False)
                     ]
                     if block_ids:
                         self.kv_cache_manager.free(block_ids)
@@ -402,7 +405,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
 
                 uncached_to_free: list[int] = []
                 for block in ordered_blocks:
-                    if block is None or bool(getattr(block, "is_null", False)):
+                    if block is None or getattr(block, "is_null", False):
                         continue
                     block.ref_cnt -= 1
                     if block.ref_cnt == 0:

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -273,30 +273,65 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 self,
                 request: "Request",
                 blocks: list["KVCacheBlock"],
-                num_cached_blocks: int,
-                num_full_blocks: int,
-                block_size: int,
-                kv_cache_group_id: int = 0,
+                *args: Any,
+                **kwargs: Any,
             ) -> None:
                 if not self.enable_prefix_cache:
                     return
+
+                # Compatibility with vLLM call signatures across versions:
+                # - (request, blocks, num_cached_blocks, num_full_blocks, block_size[, kv_cache_group_id])
+                # - (request, blocks, block_hashes, num_cached_blocks, num_full_blocks, block_size[, kv_cache_group_id], hash_fn)
+                # - keyword variants containing block_hashes/hash_fn.
+                block_hashes = kwargs.pop("block_hashes", None)
+                num_cached_blocks = kwargs.pop("num_cached_blocks", None)
+                num_full_blocks = kwargs.pop("num_full_blocks", None)
+                _block_size = kwargs.pop("block_size", None)
+                kv_cache_group_id = kwargs.pop("kv_cache_group_id", 0)
+                _hash_fn = kwargs.pop("hash_fn", None)
+
+                remaining_args = list(args)
+                if block_hashes is None and remaining_args and isinstance(remaining_args[0], (list, tuple)):
+                    block_hashes = remaining_args.pop(0)
+
+                if num_cached_blocks is None and remaining_args:
+                    num_cached_blocks = remaining_args.pop(0)
+                if num_full_blocks is None and remaining_args:
+                    num_full_blocks = remaining_args.pop(0)
+                if _block_size is None and remaining_args:
+                    _block_size = remaining_args.pop(0)
+                if remaining_args and isinstance(remaining_args[0], int):
+                    kv_cache_group_id = remaining_args.pop(0)
+                if remaining_args:
+                    # Final positional argument is typically hash_fn; ignored.
+                    _hash_fn = remaining_args.pop(0)
+
+                if num_cached_blocks is None or num_full_blocks is None:
+                    raise TypeError(
+                        "cache_full_blocks requires num_cached_blocks and num_full_blocks"
+                    )
+                num_cached_blocks = int(num_cached_blocks)
+                num_full_blocks = int(num_full_blocks)
+                kv_cache_group_id = int(kv_cache_group_id)
 
                 if num_cached_blocks >= num_full_blocks:
                     return
 
                 new_full_blocks = blocks[num_cached_blocks:num_full_blocks]
 
-                assert hasattr(request, 'block_hashes'), "Request missing block_hashes attribute"
-                assert len(request.block_hashes) >= num_full_blocks, \
-                    f"Request has {len(request.block_hashes)} hashes but need {num_full_blocks}"
+                if block_hashes is None:
+                    assert hasattr(request, "block_hashes"), "Request missing block_hashes attribute"
+                    block_hashes = request.block_hashes
+                assert len(block_hashes) >= num_full_blocks, \
+                    f"Request has {len(block_hashes)} hashes but need {num_full_blocks}"
 
                 for i, block in enumerate(new_full_blocks):
                     if hasattr(block, 'is_null') and block.is_null:
                         continue
 
                     block_idx = num_cached_blocks + i
-                    block_hash = request.block_hashes[block_idx]
-                    key = self._make_cache_key(block_hash, int(kv_cache_group_id))
+                    block_hash = block_hashes[block_idx]
+                    key = self._make_cache_key(block_hash, kv_cache_group_id)
 
                     # Already cached, idempotent
                     if key in self._cached_blocks:

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -241,19 +241,32 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
             def get_cached_block(
                 self,
                 block_hash: Any,
-                kv_cache_group_ids: list[int]
-            ) -> Optional[list["KVCacheBlock"]]:
+                kv_cache_group_ids: Optional[Iterable[int]] = None,
+            ) -> Optional[Any]:
                 if not self.enable_prefix_cache:
                     return None
 
+                # Backward compatibility:
+                # - Older vLLM versions call get_cached_block(block_hash)
+                #   and expect a single KVCacheBlock.
+                # - Newer hybrid-attention paths pass multiple group ids and
+                #   expect one block per group.
+                if kv_cache_group_ids is None:
+                    key = self._make_cache_key(block_hash, 0)
+                    return self._cached_blocks.get(key)
+                if isinstance(kv_cache_group_ids, int):
+                    kv_cache_group_ids = [int(kv_cache_group_ids)]
+
                 cached_blocks: list["KVCacheBlock"] = []
                 for group_id in kv_cache_group_ids:
-                    key = self._make_cache_key(block_hash, group_id)
+                    key = self._make_cache_key(block_hash, int(group_id))
                     block = self._cached_blocks.get(key)
                     if block is None:
                         # Atomic: all groups must hit or return None
                         return None
                     cached_blocks.append(block)
+                if not cached_blocks:
+                    return None
                 return cached_blocks
 
             def cache_full_blocks(
@@ -263,7 +276,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 num_cached_blocks: int,
                 num_full_blocks: int,
                 block_size: int,
-                kv_cache_group_id: int,
+                kv_cache_group_id: int = 0,
             ) -> None:
                 if not self.enable_prefix_cache:
                     return
@@ -283,7 +296,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
 
                     block_idx = num_cached_blocks + i
                     block_hash = request.block_hashes[block_idx]
-                    key = self._make_cache_key(block_hash, kv_cache_group_id)
+                    key = self._make_cache_key(block_hash, int(kv_cache_group_id))
 
                     # Already cached, idempotent
                     if key in self._cached_blocks:


### PR DESCRIPTION
### Summary

- Remove hard dependency on MLAAttentionSpec for MLA detection by using use_mla first, with optional class-based fallback.
- Make ElasticBlockPool method signatures compatible across vLLM versions.

### Test

- [x] vllm v0.8.4
- [x] vllm v0.19.0