### PR TITLE
feature: support hybrid linear-attention (attention + mamba) in vLLM integration (non-contiguous layout)

### DIFF
--- a/csrc/allocator.cpp
+++ b/csrc/allocator.cpp
@@ -46,7 +46,7 @@ static inline size_t get_v_base_offset(const torch::Tensor &tensor) {
 FTensorAllocator::FTensorAllocator(const torch::Device &device,
                                    bool contiguous_layout)
     : dev_(device), num_layers_(0), contiguous_layout_(contiguous_layout),
-      kv_tensor_size_per_layer_(0) {
+      unified_pool_(false), kv_tensor_size_per_layer_(0) {
   if (dev_.is_cuda()) {
     init_cuda_();
   }
@@ -110,11 +110,12 @@ void FTensorAllocator::shutdown() {
 
 std::vector<torch::Tensor> FTensorAllocator::create_kv_tensors(
     size_t size, torch::Dtype dtype, const std::string &dev_str,
-    int64_t num_layers, int64_t num_kv_buffers) {
+    int64_t num_layers, int64_t num_kv_buffers, bool unified_pool) {
   std::lock_guard<std::mutex> lock(mtx_);
 
   assert(num_layers_ == 0 || num_layers_ == num_layers);
   num_layers_ = num_layers;
+  unified_pool_ = unified_pool;
   // Ensure size is aligned to page size.
   size_t aligned_size = size;
   if (size % kPageSize != 0) {
@@ -164,6 +165,16 @@ bool FTensorAllocator::map_to_kv_tensors(const std::vector<offset_t> &offsets) {
       // Map K and V regions for this block (covers all layers)
       ftensor->map(offset);
     }
+  } else if (unified_pool_) {
+    // Unified pool: K and V share a single block-interleaved FTensor per
+    // layer. Each page id maps exactly one VMM page at pid * page_size.
+    for (int64_t i = 0; i < num_layers_; i++) {
+      auto kv_name = std::string(kv_prefix) + std::to_string(i);
+      auto ftensor = ftensors_[kv_name].get();
+      for (auto offset : offsets) {
+        ftensor->map(offset);
+      }
+    }
   } else {
     // Original per-layer mapping
     for (int64_t i = 0; i < num_layers_; i++) {
@@ -203,6 +214,15 @@ bool FTensorAllocator::unmap_from_kv_tensors(
     for (auto offset : offsets) {
       // Unmap K and V regions for this block (covers all layers)
       ftensor->unmap(offset);
+    }
+  } else if (unified_pool_) {
+    // Unified pool: single unmap per pid.
+    for (int64_t i = 0; i < num_layers_; i++) {
+      auto kv_name = std::string(kv_prefix) + std::to_string(i);
+      auto ftensor = ftensors_[kv_name].get();
+      for (auto offset : offsets) {
+        ftensor->unmap(offset);
+      }
     }
   } else {
     // Original per-layer unmapping

--- a/csrc/inc/allocator.hpp
+++ b/csrc/inc/allocator.hpp
@@ -28,7 +28,8 @@ public:
   std::vector<torch::Tensor> create_kv_tensors(size_t size, torch::Dtype dtype,
                                                const std::string &dev_str,
                                                int64_t num_layers,
-                                               int64_t num_kv_buffers = 2);
+                                               int64_t num_kv_buffers = 2,
+                                               bool unified_pool = false);
   bool kv_tensors_created();
   bool map_to_kv_tensors(const std::vector<offset_t> &offsets);
   bool unmap_from_kv_tensors(const std::vector<offset_t> &offsets);
@@ -74,6 +75,7 @@ private:
 
   int64_t num_layers_;
   bool contiguous_layout_;
+  bool unified_pool_;
   size_t kv_tensor_size_per_layer_;
 
   mutable std::mutex mtx_;

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -23,16 +23,15 @@ void shutdown_kvcached() {
   FTensorAllocator::shutdown();
 }
 
-std::vector<torch::Tensor> create_kv_tensors(size_t size, size_t dtype_size,
-                                             const std::string &dev_str,
-                                             int64_t num_layers,
-                                             int64_t num_kv_buffers = 2,
-                                             int64_t group_id = 0) {
+std::vector<torch::Tensor>
+create_kv_tensors(size_t size, size_t dtype_size, const std::string &dev_str,
+                  int64_t num_layers, int64_t num_kv_buffers = 2,
+                  int64_t group_id = 0, bool unified_pool = false) {
   py::gil_scoped_release release;
   auto allocator = FTensorAllocator::global_allocator(group_id);
   auto dtype_ = torch_dtype_from_size(dtype_size);
   return allocator->create_kv_tensors(size, dtype_, dev_str, num_layers,
-                                      num_kv_buffers);
+                                      num_kv_buffers, unified_pool);
 }
 
 bool kv_tensors_created(int64_t group_id = 0) {
@@ -67,7 +66,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("create_kv_tensors", &kvcached::create_kv_tensors, "create_kv_tensors",
         py::arg("size"), py::arg("dtype_size"), py::arg("dev_str"),
         py::arg("num_layers"), py::arg("num_kv_buffers") = 2,
-        py::arg("group_id") = 0);
+        py::arg("group_id") = 0, py::arg("unified_pool") = false);
   m.def("kv_tensors_created", &kvcached::kv_tensors_created,
         "kv_tensors_created", py::arg("group_id") = 0);
   m.def("map_to_kv_tensors", &kvcached::map_to_kv_tensors, "map_to_kv_tensors",

--- a/examples/08_hybrid_attention_models/README.md
+++ b/examples/08_hybrid_attention_models/README.md
@@ -2,7 +2,16 @@
 
 This example shows the minimal, end-to-end setup to colocate two models on the same GPU using kvcached. Both models are served by vLLM engines and share GPU memory elastically through kvcached.
 
-The key configuration to enable this is passing `--disable-hybrid-kv-cache-manager` to vLLM.
+## Two flavors of hybrid models
+
+vLLM uses the term "hybrid" for two very different things, and kvcached needs different settings for each:
+
+| Flavor | Examples | vLLM flag | kvcached env |
+|---|---|---|---|
+| **Attention-only hybrid** (full attention + sliding window, all groups unify to `FullAttentionSpec`) | GPT-OSS | `--disable-hybrid-kv-cache-manager` | (default; `KVCACHED_CONTIGUOUS_LAYOUT=true`) |
+| **Linear-attention hybrid** (full attention + Mamba/SSM, groups have different specs and cannot be unified) | Jamba, Bamba, NemotronH, Zamba2, Plamo2 | **do NOT pass** `--disable-hybrid-kv-cache-manager` | `KVCACHED_CONTIGUOUS_LAYOUT=false` |
+
+The `start_two_models.sh` script defaults to GPT-OSS (attention-only). For Jamba/Bamba and other Mamba-hybrid models, drop `--disable-hybrid-kv-cache-manager` from the `vllm serve` command and export `KVCACHED_CONTIGUOUS_LAYOUT=false` before launching.
 
 ## Prerequisites
 - A working vLLM installation with kvcached.

--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -137,11 +137,24 @@ def alloc_kv_cache(
     k_tensors, v_tensors = [], []
 
     if not _contiguous_layout:
-        num_eles = num_k_or_v * math.prod(actual_kvcache_shape)
+        # In the per-layer FTensors, K occupies [0, v_offset) and V
+        # occupies [v_offset, 2*v_offset) where v_offset equals
+        # gpu_mem_bytes_per_layer_k_or_v.  A plain contiguous view would
+        # place V at num_blocks_per_layer * block_mem_size, which differs
+        # from v_offset when block_mem_size does not evenly divide
+        # gpu_mem_bytes_per_layer_k_or_v.  Use as_strided so the K/V
+        # dimension stride matches the real V offset.
+        v_offset_eles = gpu_mem_bytes_per_layer_k_or_v // dtype.itemsize
+        kv_shape = [num_k_or_v] + list(actual_kvcache_shape)
+        strides = [0] * len(kv_shape)
+        strides[-1] = 1
+        for i in range(len(kv_shape) - 2, 0, -1):
+            strides[i] = strides[i + 1] * kv_shape[i + 1]
+        strides[0] = v_offset_eles
         for t in raw_kv_tensors:
-            t = t.view(dtype=dtype)[:num_eles].view(num_k_or_v, *actual_kvcache_shape)
-            k_tensors.append(t.narrow(0, 0, 1).view(actual_kvcache_shape))
-            v_tensors.append(t.narrow(0, 1, 1).view(actual_kvcache_shape))
+            kv = torch.as_strided(t.view(dtype=dtype), kv_shape, strides)
+            k_tensors.append(kv[0])
+            v_tensors.append(kv[1])
     else:
         contiguous_shape = (num_tokens, num_layers, num_k_or_v, *actual_kvcache_shape[1:])
         num_eles = math.prod(contiguous_shape)

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -93,6 +93,7 @@ def alloc_kv_cache(
     attention_type: str = "MHA",  # MHA, GQA, or MLA.
     kv_layout: str = "NHD",  # NHD: (num_tokens, head_num, head_dim)
     group_id: int = 0,
+    return_raw_buffers: bool = False,
 ) -> List[torch.Tensor]:
     """Allocate KV cache tensors for all supported attention types.
 
@@ -101,6 +102,22 @@ def alloc_kv_cache(
       - FlashInfer: (num_blocks, 2, block_size, head_num, head_dim)
     For MLA, kvcache_shape is expected to be:
       - (num_blocks, block_size, head_size)
+
+    For hybrid models (attention + mamba), the caller should set
+    ``num_layers`` to the group_size (max layers across KV cache groups)
+    and pass ``return_raw_buffers=True``.  The same VM-backed tensor pool
+    is shared by one attention layer and one mamba layer, mirroring the
+    native vLLM ``KVCacheTensor`` sharing pattern.
+
+    Returns:
+        List[torch.Tensor] when return_raw_buffers is False.
+        Otherwise (kv_tensors, raw_info) where raw_info is a dict with:
+          buffers          - raw int8 tensors (per-pool list or single base)
+          num_blocks       - number of blocks per pool
+          page_size_bytes  - bytes per block per pool
+          block_stride_bytes - byte stride between consecutive blocks
+          num_pools        - number of pools (== num_layers)
+          is_contiguous    - whether contiguous layout is used
     """
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
@@ -170,6 +187,10 @@ def alloc_kv_cache(
     actual_kvcache_shape: List[int] = list(kvcache_shape)
     actual_kvcache_shape[blocks_dim_idx] = num_blocks_per_layer
 
+    page_size_bytes = math.prod(
+        actual_kvcache_shape[:blocks_dim_idx] + actual_kvcache_shape[blocks_dim_idx + 1:]
+    ) * dtype.itemsize
+
     # --- Reshape raw tensors into per-layer KV cache views ---
     if not _contiguous_layout:
         kv_tensors: List[torch.Tensor] = []
@@ -212,7 +233,26 @@ def alloc_kv_cache(
             contiguous_tensor[:, i].permute(*permute_order) for i in range(num_layers)
         ]
 
-    return kv_tensors
+    if not return_raw_buffers:
+        return kv_tensors
+
+    # --- Build raw info for mamba / non-attention layers ---
+    if not _contiguous_layout:
+        raw_buffers = list(raw_kv_tensors)
+        block_stride_bytes = page_size_bytes
+    else:
+        raw_buffers = [raw_kv_tensors[0]]
+        block_stride_bytes = num_layers * page_size_bytes
+
+    raw_info = {
+        "buffers": raw_buffers,
+        "num_blocks": num_blocks_per_layer,
+        "page_size_bytes": page_size_bytes,
+        "block_stride_bytes": block_stride_bytes,
+        "num_pools": num_layers,
+        "is_contiguous": _contiguous_layout,
+    }
+    return kv_tensors, raw_info  # type: ignore[return-value]
 
 
 def get_kv_cache_manager(

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -172,10 +172,37 @@ def alloc_kv_cache(
 
     # --- Reshape raw tensors into per-layer KV cache views ---
     if not _contiguous_layout:
-        num_eles = math.prod(actual_kvcache_shape)
-        kv_tensors: List[torch.Tensor] = [
-            t.view(dtype=dtype)[:num_eles].view(actual_kvcache_shape) for t in raw_kv_tensors
-        ]
+        kv_tensors: List[torch.Tensor] = []
+        if is_mla:
+            num_eles = math.prod(actual_kvcache_shape)
+            kv_tensors = [
+                t.view(dtype=dtype)[:num_eles].view(actual_kvcache_shape)
+                for t in raw_kv_tensors
+            ]
+        else:
+            # In the per-layer FTensors, K occupies [0, v_offset) and V
+            # occupies [v_offset, 2*v_offset) where v_offset equals
+            # gpu_mem_bytes_per_layer_k_or_v.  A plain contiguous view
+            # would place V at num_blocks_per_layer * block_mem_bytes,
+            # which differs from v_offset when block_mem_bytes does not
+            # evenly divide gpu_mem_bytes_per_layer_k_or_v.  Use
+            # as_strided so the K/V dimension stride matches the real
+            # V offset in the underlying virtual memory.
+            v_offset_eles = gpu_mem_bytes_per_layer_k_or_v // dtype.itemsize
+            shape = list(actual_kvcache_shape)
+            strides = [0] * len(shape)
+            strides[-1] = 1
+            for i in range(len(shape) - 2, 1, -1):
+                strides[i] = strides[i + 1] * shape[i + 1]
+            if blocks_dim_idx == 1:              # FlashAttn (2, N, ...)
+                strides[1] = strides[2] * shape[2]
+                strides[0] = v_offset_eles
+            else:                                 # FlashInfer (N, 2, ...)
+                strides[0] = strides[2] * shape[2]
+                strides[1] = v_offset_eles
+            for t in raw_kv_tensors:
+                kv_tensors.append(
+                    torch.as_strided(t.view(dtype=dtype), shape, strides))
     else:
         layer_elem_shape = actual_kvcache_shape[:blocks_dim_idx] + actual_kvcache_shape[blocks_dim_idx + 1:]
         contiguous_shape = [num_blocks_per_layer, num_layers] + layer_elem_shape

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -94,6 +94,7 @@ def alloc_kv_cache(
     kv_layout: str = "NHD",  # NHD: (num_tokens, head_num, head_dim)
     group_id: int = 0,
     return_raw_buffers: bool = False,
+    num_kv_buffers_override: Optional[int] = None,
 ) -> List[torch.Tensor]:
     """Allocate KV cache tensors for all supported attention types.
 
@@ -104,20 +105,23 @@ def alloc_kv_cache(
       - (num_blocks, block_size, head_size)
 
     For hybrid models (attention + mamba), the caller should set
-    ``num_layers`` to the group_size (max layers across KV cache groups)
-    and pass ``return_raw_buffers=True``.  The same VM-backed tensor pool
-    is shared by one attention layer and one mamba layer, mirroring the
-    native vLLM ``KVCacheTensor`` sharing pattern.
+    ``num_layers`` to the group_size, ``return_raw_buffers=True``,
+    and ``num_kv_buffers_override=1``.  Using a single FTensor per
+    pool ensures VM page mappings use page_size_bytes granularity
+    (K+V combined), matching the ``as_strided_`` access pattern that
+    vLLM's ``_update_hybrid_attention_mamba_layout`` applies.
 
     Returns:
         List[torch.Tensor] when return_raw_buffers is False.
         Otherwise (kv_tensors, raw_info) where raw_info is a dict with:
-          buffers          - raw int8 tensors (per-pool list or single base)
-          num_blocks       - number of blocks per pool
-          page_size_bytes  - bytes per block per pool
-          block_stride_bytes - byte stride between consecutive blocks
-          num_pools        - number of pools (== num_layers)
-          is_contiguous    - whether contiguous layout is used
+          buffers            - flat int8 tensors (one per pool when
+                               non-contiguous, single base when contiguous)
+          num_blocks         - number of blocks per pool
+          page_size_bytes    - uniform page size (bytes) shared by all groups
+          block_stride_bytes - byte stride between consecutive blocks of the
+                               same pool
+          num_pools          - number of pools (== num_layers)
+          is_contiguous      - whether contiguous layout is used
     """
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
@@ -179,9 +183,10 @@ def alloc_kv_cache(
             f"Requested {requested_num_blocks} blocks, but only {num_blocks_per_layer} blocks are available."
         )
 
+    actual_num_kv_buffers = num_kv_buffers_override if num_kv_buffers_override is not None else num_k_or_v
     raw_kv_tensors = create_kv_tensors(
         gpu_mem_bytes_per_layer_k_or_v * num_k_or_v, dtype.itemsize, device, num_layers,
-        num_kv_buffers=num_k_or_v, group_id=group_id,
+        num_kv_buffers=actual_num_kv_buffers, group_id=group_id,
     )
 
     actual_kvcache_shape: List[int] = list(kvcache_shape)
@@ -236,16 +241,17 @@ def alloc_kv_cache(
     if not return_raw_buffers:
         return kv_tensors
 
-    # --- Build raw info for mamba / non-attention layers ---
+    # --- Build raw int8 buffers for hybrid model (mamba) support ---
     if not _contiguous_layout:
-        raw_buffers = list(raw_kv_tensors)
+        pool_bytes = num_blocks_per_layer * page_size_bytes
+        raw_int8 = [t.view(torch.int8)[:pool_bytes] for t in raw_kv_tensors]
         block_stride_bytes = page_size_bytes
     else:
-        raw_buffers = [raw_kv_tensors[0]]
+        raw_int8 = [raw_kv_tensors[0].view(torch.int8)]
         block_stride_bytes = num_layers * page_size_bytes
 
     raw_info = {
-        "buffers": raw_buffers,
+        "buffers": raw_int8,
         "num_blocks": num_blocks_per_layer,
         "page_size_bytes": page_size_bytes,
         "block_stride_bytes": block_stride_bytes,

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -139,7 +139,13 @@ def alloc_kv_cache(
 
     if is_hybrid_linear and _contiguous_layout:
         raise ValueError(
-            "attention_type='HYBRID_LINEAR' is only supported with non-contiguous layout.")
+            "kvcached detected a hybrid linear-attention model "
+            "(e.g. Jamba/Bamba/NemotronH/Zamba2/Plamo2), which requires the "
+            "non-contiguous KV layout. Re-launch with "
+            "KVCACHED_CONTIGUOUS_LAYOUT=false. Also do NOT pass "
+            "--disable-hybrid-kv-cache-manager to vLLM for these models — "
+            "it only applies to attention-only hybrids like sliding-window "
+            "models (e.g. GPT-OSS).")
 
     num_k_or_v = 1 if is_mla else 2
 

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -90,11 +90,10 @@ def alloc_kv_cache(
     dtype: torch.dtype,
     device: str,
     num_layers: int,
-    attention_type: str = "MHA",  # MHA, GQA, or MLA.
+    attention_type: str = "MHA",  # MHA, GQA, MLA, or HYBRID_LINEAR.
     kv_layout: str = "NHD",  # NHD: (num_tokens, head_num, head_dim)
     group_id: int = 0,
-    return_raw_buffers: bool = False,
-    num_kv_buffers_override: Optional[int] = None,
+    kernel_block_size: Optional[int] = None,
 ) -> List[torch.Tensor]:
     """Allocate KV cache tensors for all supported attention types.
 
@@ -104,16 +103,18 @@ def alloc_kv_cache(
     For MLA, kvcache_shape is expected to be:
       - (num_blocks, block_size, head_size)
 
-    For hybrid models (attention + mamba), the caller should set
-    ``num_layers`` to the group_size, ``return_raw_buffers=True``,
-    and ``num_kv_buffers_override=1``.  Using a single FTensor per
-    pool ensures VM page mappings use page_size_bytes granularity
-    (K+V combined), matching the ``as_strided_`` access pattern that
-    vLLM's ``_update_hybrid_attention_mamba_layout`` applies.
+    ``attention_type="HYBRID_LINEAR"`` selects the layout for hybrid
+    models that mix full attention with linear attention (mamba/SSM).
+    It collapses K and V into a single FTensor per pool so VM page
+    mappings use page_size_bytes granularity (K+V combined), matching
+    the ``as_strided_`` access pattern that vLLM's
+    ``_update_hybrid_attention_mamba_layout`` applies. Callers should
+    set ``num_layers`` to the group_size in this mode.
 
     Returns:
-        List[torch.Tensor] when return_raw_buffers is False.
-        Otherwise (kv_tensors, raw_info) where raw_info is a dict with:
+        List[torch.Tensor] for MHA/GQA/MLA.
+        For HYBRID_LINEAR, returns (kv_tensors, raw_info) where
+        raw_info is a dict with:
           buffers            - flat int8 tensors (one per pool when
                                non-contiguous, single base when contiguous)
           num_blocks         - number of blocks per pool
@@ -126,14 +127,33 @@ def alloc_kv_cache(
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
 
-    if attention_type not in ["MHA", "GQA", "MLA"]:
+    if attention_type not in ["MHA", "GQA", "MLA", "HYBRID_LINEAR"]:
         raise ValueError(f"Attention type {attention_type} is not supported.")
 
     if kv_layout != "NHD":
         raise ValueError(f"KV layout {kv_layout} is not supported.")
 
     is_mla = attention_type == "MLA"
+    is_hybrid_linear = attention_type == "HYBRID_LINEAR"
+    unified_pool = is_hybrid_linear
+
+    if is_hybrid_linear and _contiguous_layout:
+        raise ValueError(
+            "attention_type='HYBRID_LINEAR' is only supported with non-contiguous layout.")
+
     num_k_or_v = 1 if is_mla else 2
+
+    # Kernel-block granularity. vLLM may split a virtual block (``block_size``
+    # tokens) into ``ratio`` kernel-sized blocks. The attention zero kernel
+    # assumes the per-layer tensor is strided at kernel-block granularity, so
+    # the as_strided view we hand back must match.
+    if kernel_block_size is None:
+        kernel_block_size = block_size
+    if block_size % kernel_block_size != 0:
+        raise ValueError(
+            f"block_size ({block_size}) must be a multiple of "
+            f"kernel_block_size ({kernel_block_size})")
+    ratio = block_size // kernel_block_size
 
     # --- Validate shape and determine layout indices ---
     if is_mla:
@@ -183,10 +203,12 @@ def alloc_kv_cache(
             f"Requested {requested_num_blocks} blocks, but only {num_blocks_per_layer} blocks are available."
         )
 
-    actual_num_kv_buffers = num_kv_buffers_override if num_kv_buffers_override is not None else num_k_or_v
+    ftensor_bytes_per_layer = gpu_mem_bytes_per_layer_k_or_v * num_k_or_v
+
     raw_kv_tensors = create_kv_tensors(
-        gpu_mem_bytes_per_layer_k_or_v * num_k_or_v, dtype.itemsize, device, num_layers,
-        num_kv_buffers=actual_num_kv_buffers, group_id=group_id,
+        ftensor_bytes_per_layer, dtype.itemsize, device, num_layers,
+        num_kv_buffers=num_k_or_v, group_id=group_id,
+        unified_pool=unified_pool,
     )
 
     actual_kvcache_shape: List[int] = list(kvcache_shape)
@@ -196,40 +218,68 @@ def alloc_kv_cache(
         actual_kvcache_shape[:blocks_dim_idx] + actual_kvcache_shape[blocks_dim_idx + 1:]
     ) * dtype.itemsize
 
+    # Build a second shape expressed at kernel-block granularity. vLLM's zero
+    # kernel and attention kernels index the KV tensor using ``kernel_bs``-
+    # token blocks; each virtual block is ``ratio`` contiguous kernel blocks.
+    # When ratio == 1, kernel_kvcache_shape == actual_kvcache_shape.
+    kernel_kvcache_shape: List[int] = list(actual_kvcache_shape)
+    if ratio > 1:
+        kernel_kvcache_shape[blocks_dim_idx] = num_blocks_per_layer * ratio
+        # Token dim index: for MHA it's 2, for MLA it's 1 (right after block dim).
+        token_dim_idx = 2 if not is_mla else 1
+        kernel_kvcache_shape[token_dim_idx] = kernel_block_size
+
     # --- Reshape raw tensors into per-layer KV cache views ---
     if not _contiguous_layout:
         kv_tensors: List[torch.Tensor] = []
         if is_mla:
-            num_eles = math.prod(actual_kvcache_shape)
+            num_eles = math.prod(kernel_kvcache_shape)
             kv_tensors = [
-                t.view(dtype=dtype)[:num_eles].view(actual_kvcache_shape)
+                t.view(dtype=dtype)[:num_eles].view(kernel_kvcache_shape)
                 for t in raw_kv_tensors
             ]
         else:
-            # In the per-layer FTensors, K occupies [0, v_offset) and V
-            # occupies [v_offset, 2*v_offset) where v_offset equals
-            # gpu_mem_bytes_per_layer_k_or_v.  A plain contiguous view
-            # would place V at num_blocks_per_layer * block_mem_bytes,
-            # which differs from v_offset when block_mem_bytes does not
-            # evenly divide gpu_mem_bytes_per_layer_k_or_v.  Use
-            # as_strided so the K/V dimension stride matches the real
-            # V offset in the underlying virtual memory.
-            v_offset_eles = gpu_mem_bytes_per_layer_k_or_v // dtype.itemsize
-            shape = list(actual_kvcache_shape)
+            # Build attention view with as_strided. Two modes:
+            #   split-half (default): K occupies [0, v_offset), V occupies
+            #     [v_offset, 2*v_offset). K/V dim stride = v_offset_eles.
+            #   unified_pool (HYBRID_LINEAR): K and V interleaved per kernel
+            #     block. This mirrors native vLLM's
+            #     _update_hybrid_attention_mamba_layout and lets an attached
+            #     linear-attention / mamba layer read the same flat buffer
+            #     (mamba still indexes by virtual block; each virtual block
+            #     spans ``ratio`` kernel blocks).
+            shape = list(kernel_kvcache_shape)
             strides = [0] * len(shape)
             strides[-1] = 1
             for i in range(len(shape) - 2, 1, -1):
                 strides[i] = strides[i + 1] * shape[i + 1]
-            if blocks_dim_idx == 1:              # FlashAttn (2, N, ...)
-                strides[1] = strides[2] * shape[2]
-                strides[0] = v_offset_eles
-            else:                                 # FlashInfer (N, 2, ...)
-                strides[0] = strides[2] * shape[2]
-                strides[1] = v_offset_eles
+            # hidden_size_eles uses kernel_block_size (shape[2]), not block_size.
+            hidden_size_eles = strides[2] * shape[2]  # = kernel_bs * h * d
+            if unified_pool:
+                # Block-interleaved at kernel granularity: inter-(kernel-)block
+                # stride = 2*hidden_size; K/V dim stride = hidden_size.
+                if blocks_dim_idx == 1:          # FlashAttn (2, N*ratio, ...)
+                    strides[1] = 2 * hidden_size_eles
+                    strides[0] = hidden_size_eles
+                else:                             # FlashInfer (N*ratio, 2, ...)
+                    strides[0] = 2 * hidden_size_eles
+                    strides[1] = hidden_size_eles
+            else:
+                v_offset_eles = gpu_mem_bytes_per_layer_k_or_v // dtype.itemsize
+                if blocks_dim_idx == 1:          # FlashAttn (2, N*ratio, ...)
+                    strides[1] = hidden_size_eles
+                    strides[0] = v_offset_eles
+                else:                             # FlashInfer (N*ratio, 2, ...)
+                    strides[0] = hidden_size_eles
+                    strides[1] = v_offset_eles
             for t in raw_kv_tensors:
                 kv_tensors.append(
                     torch.as_strided(t.view(dtype=dtype), shape, strides))
     else:
+        if ratio > 1:
+            raise NotImplementedError(
+                "Contiguous layout with kernel_block_size != block_size "
+                "is not supported yet.")
         layer_elem_shape = actual_kvcache_shape[:blocks_dim_idx] + actual_kvcache_shape[blocks_dim_idx + 1:]
         contiguous_shape = [num_blocks_per_layer, num_layers] + layer_elem_shape
         num_eles = math.prod(contiguous_shape)
@@ -238,7 +288,7 @@ def alloc_kv_cache(
             contiguous_tensor[:, i].permute(*permute_order) for i in range(num_layers)
         ]
 
-    if not return_raw_buffers:
+    if not unified_pool:
         return kv_tensors
 
     # --- Build raw int8 buffers for hybrid model (mamba) support ---

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -117,11 +117,17 @@ def _should_enable_async_sched(vllm_config: Any) -> bool:
 
 
 def _reshape_mamba_non_contiguous(
-    raw_tensor: Any, kv_cache_spec: Any, get_dtype_size: Any,
+    raw_int8: Any, kv_cache_spec: Any, get_dtype_size: Any,
 ) -> list:
-    """Create strided mamba state views from a per-layer int8 buffer."""
+    """Create strided mamba state views from a per-pool flat int8 buffer.
+
+    Mirrors vLLM's native ``_reshape_kv_cache_tensors`` for MambaSpec:
+    the raw int8 buffer is reinterpreted via ``torch.as_strided`` into
+    the shapes/dtypes declared by the spec.
+    """
     import torch
 
+    raw_tensor = raw_int8
     num_blocks = raw_tensor.numel() // kv_cache_spec.page_size_bytes
     state_tensors: list = []
     storage_offset_bytes = 0
@@ -155,7 +161,7 @@ def _reshape_mamba_contiguous(
     """
     import torch
 
-    base_buffer = mamba_info["buffers"][0]
+    base_buffer = mamba_info["buffers"][0]  # flat int8 buffer
     num_blocks = mamba_info["num_blocks"]
     page_size_bytes = mamba_info["page_size_bytes"]
     block_stride_bytes = mamba_info["block_stride_bytes"]
@@ -617,7 +623,16 @@ class KVCacheCoordinatorPatch(VersionAwarePatch, BasePatch):
             kv_cache_spec = first_attn_group.kv_cache_spec
             block_size = kv_cache_spec.block_size
 
-            cell_size, num_kv_buffers = _get_kv_cache_params(kv_cache_spec, block_size)
+            has_mamba = any(
+                _is_mamba_spec(g.kv_cache_spec)
+                for g in kv_cache_config.kv_cache_groups
+            )
+
+            if has_mamba:
+                cell_size = kv_cache_spec.page_size_bytes // block_size
+                num_kv_buffers = 1
+            else:
+                cell_size, num_kv_buffers = _get_kv_cache_params(kv_cache_spec, block_size)
 
             try:
                 from vllm.distributed.parallel_state import get_tensor_model_parallel_world_size
@@ -1071,6 +1086,7 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 attention_type="MLA" if is_mla else "MHA",
                 kv_layout="NHD",
                 return_raw_buffers=has_mamba,
+                num_kv_buffers_override=1 if has_mamba else None,
             )
 
             if has_mamba:
@@ -1125,22 +1141,25 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
 
             mamba_info = getattr(self, "_kvcached_mamba_raw_info", None)
 
-            # kv_cache_raw_tensors is a list of pool tensors indexed by
-            # pool_idx.  Map each layer to its pool following vLLM's sharing
-            # pattern: pool i is shared by layer i from each group.
             for kv_cache_group in kv_cache_config.kv_cache_groups:
                 kv_cache_spec = kv_cache_group.kv_cache_spec
 
                 if _is_mamba_spec(kv_cache_spec):
                     has_mamba = True
+                    if mamba_info is None:
+                        raise RuntimeError(
+                            "Mamba layers found but no raw buffer info "
+                            "available from kvcached"
+                        )
                     for pool_idx, layer_name in enumerate(kv_cache_group.layer_names):
-                        if mamba_info is not None and mamba_info["is_contiguous"]:
+                        if mamba_info["is_contiguous"]:
                             state_tensors = _reshape_mamba_contiguous(
                                 mamba_info, kv_cache_spec, pool_idx, get_dtype_size,
                             )
                         else:
                             state_tensors = _reshape_mamba_non_contiguous(
-                                kv_cache_raw_tensors[pool_idx], kv_cache_spec, get_dtype_size,
+                                mamba_info["buffers"][pool_idx],
+                                kv_cache_spec, get_dtype_size,
                             )
                         kv_caches[layer_name] = state_tensors  # type: ignore[assignment]
                 else:

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -652,8 +652,10 @@ class KVCacheCoordinatorPatch(VersionAwarePatch, BasePatch):
 
             first_attn_group = _get_first_attention_group(kv_cache_config)
             if first_attn_group is None:
-                logger.warning("No attention groups found; kvcached has nothing to manage")
-                return
+                raise RuntimeError(
+                    "kvcached is enabled but the KV cache config contains no "
+                    "attention groups; nothing to manage."
+                )
 
             kv_cache_spec = first_attn_group.kv_cache_spec
             block_size = kv_cache_spec.block_size
@@ -1040,8 +1042,6 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                         "kv_cache_config.num_blocks"
                     )
 
-            result: dict[str, torch.Tensor] = {}
-
             first_attn_group_id = None
             first_attn_group = None
             for idx, grp in enumerate(kv_cache_config.kv_cache_groups):
@@ -1050,8 +1050,11 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                     first_attn_group = grp
                     break
 
-            if first_attn_group is None:
-                return result
+            if first_attn_group is None or first_attn_group_id is None:
+                raise RuntimeError(
+                    "kvcached is enabled but the KV cache config contains no "
+                    "attention groups; nothing to allocate."
+                )
 
             kv_cache_spec = first_attn_group.kv_cache_spec
             attention_type = _infer_attention_type(kv_cache_config)

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -28,36 +28,76 @@ if TYPE_CHECKING:
         Request = Any  # type: ignore[misc,assignment]
 
 
+def _is_attention_spec(spec: Any) -> bool:
+    """Check if a KV cache spec is an attention-type spec managed by kvcached."""
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, MLAAttentionSpec, SlidingWindowSpec
+
+    return isinstance(spec, (FullAttentionSpec, SlidingWindowSpec, MLAAttentionSpec))
+
+
+def _is_mamba_spec(spec: Any) -> bool:
+    """Check if a KV cache spec is a MambaSpec (SSM state, not managed by kvcached)."""
+    try:
+        from vllm.v1.kv_cache_interface import MambaSpec
+
+        return isinstance(spec, MambaSpec)
+    except ImportError:
+        return False
+
+
+def _get_first_attention_group(kv_cache_config: Any) -> Any:
+    """Return the first attention-type KV cache group, or None."""
+    for grp in kv_cache_config.kv_cache_groups:
+        if _is_attention_spec(grp.kv_cache_spec):
+            return grp
+    return None
+
+
+def _get_group_size(kv_cache_config: Any) -> int:
+    """Return the maximum number of layers across all KV cache groups.
+
+    This matches vLLM's shared memory pool count: ``group_size`` pools
+    are created, each shared by one layer from every group.
+    """
+    return max(len(g.layer_names) for g in kv_cache_config.kv_cache_groups)
+
+
 def _validate_kv_cache_groups(kv_cache_config: Any) -> None:
     """Validate KV cache groups for kvcached compatibility.
 
-    Checks that all groups use supported spec types (FullAttentionSpec,
-    SlidingWindowSpec, or MLAAttentionSpec) and that all groups share the
-    same block geometry (block_size and cell_size).  Raises ValueError on
-    mismatch.
+    Checks that all groups use supported spec types and that all attention
+    groups share the same block geometry (block_size and cell_size).
+    MambaSpec groups are accepted but not managed by kvcached.
+    Raises ValueError on mismatch.
     """
-    from vllm.v1.kv_cache_interface import FullAttentionSpec, MLAAttentionSpec, SlidingWindowSpec
-
-    supported = (FullAttentionSpec, SlidingWindowSpec, MLAAttentionSpec)
     kv_groups = kv_cache_config.kv_cache_groups
 
-    first_spec = kv_groups[0].kv_cache_spec
+    for idx, grp in enumerate(kv_groups):
+        grp_spec = grp.kv_cache_spec
+        if not _is_attention_spec(grp_spec) and not _is_mamba_spec(grp_spec):
+            raise ValueError(
+                f"kvcached only supports FullAttentionSpec, SlidingWindowSpec, "
+                f"MLAAttentionSpec, and MambaSpec, got {type(grp_spec).__name__} in group {idx}"
+            )
+
+    first_attn_group = _get_first_attention_group(kv_cache_config)
+    if first_attn_group is None:
+        return
+
+    first_spec = first_attn_group.kv_cache_spec
     block_size = first_spec.block_size
     cell_size, _ = _get_kv_cache_params(first_spec, block_size)
 
     for idx, grp in enumerate(kv_groups):
         grp_spec = grp.kv_cache_spec
-        if not isinstance(grp_spec, supported):
-            raise ValueError(
-                f"kvcached only supports FullAttentionSpec, SlidingWindowSpec, "
-                f"and MLAAttentionSpec, got {type(grp_spec).__name__} in group {idx}"
-            )
+        if not _is_attention_spec(grp_spec):
+            continue
         grp_block_size = grp_spec.block_size
         grp_cell_size, _ = _get_kv_cache_params(grp_spec, grp_block_size)
         if grp_block_size != block_size or grp_cell_size != cell_size:
             raise ValueError(
-                "kvcached requires all KV cache groups to have the "
-                f"same block geometry. Group 0: block_size={block_size},"
+                "kvcached requires all attention KV cache groups to have the "
+                f"same block geometry. First attention group: block_size={block_size},"
                 f" cell_size={cell_size}; group {idx}: "
                 f"block_size={grp_block_size}, cell_size={grp_cell_size}"
             )
@@ -74,6 +114,72 @@ def _should_enable_async_sched(vllm_config: Any) -> bool:
         return False
     scheduler_config = getattr(vllm_config, "scheduler_config", None)
     return bool(getattr(scheduler_config, "async_scheduling", False))
+
+
+def _reshape_mamba_non_contiguous(
+    raw_tensor: Any, kv_cache_spec: Any, get_dtype_size: Any,
+) -> list:
+    """Create strided mamba state views from a per-layer int8 buffer."""
+    import torch
+
+    num_blocks = raw_tensor.numel() // kv_cache_spec.page_size_bytes
+    state_tensors: list = []
+    storage_offset_bytes = 0
+    for shape, dtype in zip(kv_cache_spec.shapes, kv_cache_spec.dtypes):
+        dtype_size = get_dtype_size(dtype)
+        num_element_per_page = kv_cache_spec.page_size_bytes // dtype_size
+        target_shape = (num_blocks, *shape)
+        stride = torch.empty(target_shape).stride()
+        target_stride = (num_element_per_page, *stride[1:])
+        assert storage_offset_bytes % dtype_size == 0
+        tensor = torch.as_strided(
+            raw_tensor.view(dtype),
+            size=target_shape,
+            stride=target_stride,
+            storage_offset=storage_offset_bytes // dtype_size,
+        )
+        state_tensors.append(tensor)
+        storage_offset_bytes += stride[0] * dtype_size
+    return state_tensors
+
+
+def _reshape_mamba_contiguous(
+    mamba_info: dict, kv_cache_spec: Any, pool_idx: int, get_dtype_size: Any,
+) -> list:
+    """Create strided mamba state views from a contiguous interleaved buffer.
+
+    In contiguous layout, block N for pool L sits at byte offset
+    ``(N * num_pools + L) * page_size_bytes`` inside the single base
+    buffer.  The inter-block stride is therefore
+    ``num_pools * page_size_bytes`` bytes, not ``page_size_bytes``.
+    """
+    import torch
+
+    base_buffer = mamba_info["buffers"][0]
+    num_blocks = mamba_info["num_blocks"]
+    page_size_bytes = mamba_info["page_size_bytes"]
+    block_stride_bytes = mamba_info["block_stride_bytes"]
+
+    layer_offset_bytes = pool_idx * page_size_bytes
+
+    state_tensors: list = []
+    inner_offset_bytes = 0
+    for shape, dtype in zip(kv_cache_spec.shapes, kv_cache_spec.dtypes):
+        dtype_size = get_dtype_size(dtype)
+        block_stride_elems = block_stride_bytes // dtype_size
+        target_shape = (num_blocks, *shape)
+        inner_stride = torch.empty(target_shape).stride()
+        target_stride = (block_stride_elems, *inner_stride[1:])
+        storage_offset = (layer_offset_bytes + inner_offset_bytes) // dtype_size
+        tensor = torch.as_strided(
+            base_buffer.view(dtype),
+            size=target_shape,
+            stride=target_stride,
+            storage_offset=storage_offset,
+        )
+        state_tensors.append(tensor)
+        inner_offset_bytes += inner_stride[0] * dtype_size
+    return state_tensors
 
 
 # Version ranges for vLLM support
@@ -503,9 +609,12 @@ class KVCacheCoordinatorPatch(VersionAwarePatch, BasePatch):
 
             _validate_kv_cache_groups(kv_cache_config)
 
-            # All groups validated to share the same block geometry,
-            # so group 0's spec is representative.
-            kv_cache_spec = kv_cache_config.kv_cache_groups[0].kv_cache_spec
+            first_attn_group = _get_first_attention_group(kv_cache_config)
+            if first_attn_group is None:
+                logger.warning("No attention groups found; kvcached has nothing to manage")
+                return
+
+            kv_cache_spec = first_attn_group.kv_cache_spec
             block_size = kv_cache_spec.block_size
 
             cell_size, num_kv_buffers = _get_kv_cache_params(kv_cache_spec, block_size)
@@ -535,7 +644,7 @@ class KVCacheCoordinatorPatch(VersionAwarePatch, BasePatch):
             block_pool_mod = importlib.import_module("vllm.v1.core.block_pool")
             ElasticBlockPool = getattr(block_pool_mod, "ElasticBlockPool")
 
-            num_layers = _count_kv_cache_layers(kv_cache_config)
+            num_layers = _get_group_size(kv_cache_config)
             self.block_pool = ElasticBlockPool(
                 kv_cache_config.num_blocks,
                 block_size,
@@ -868,13 +977,6 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
 
             _validate_kv_cache_groups(kv_cache_config)
 
-            # All groups validated to share the same block geometry by
-            # _validate_kv_cache_groups, so group 0's spec is representative.
-            first_kv_cache_group = kv_cache_config.kv_cache_groups[0]
-            kv_cache_spec = first_kv_cache_group.kv_cache_spec
-
-            is_mla = isinstance(kv_cache_spec, MLAAttentionSpec)
-
             layer_to_tensor_cfg: dict[str, KVCacheTensor] = {}
             for tensor_cfg in kv_cache_config.kv_cache_tensors:
                 for ln in tensor_cfg.shared_by:
@@ -895,12 +997,30 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                         "kv_cache_config.num_blocks"
                     )
 
-            first_layer_name = first_kv_cache_group.layer_names[0]
+            result: dict[str, torch.Tensor] = {}
+
+            first_attn_group_id = None
+            first_attn_group = None
+            for idx, grp in enumerate(kv_cache_config.kv_cache_groups):
+                if _is_attention_spec(grp.kv_cache_spec):
+                    first_attn_group_id = idx
+                    first_attn_group = grp
+                    break
+
+            if first_attn_group is None:
+                return result
+
+            kv_cache_spec = first_attn_group.kv_cache_spec
+            is_mla = isinstance(kv_cache_spec, MLAAttentionSpec)
+
+            first_layer_name = first_attn_group.layer_names[0]
             rep_tensor_cfg = layer_to_tensor_cfg[first_layer_name]
             num_blocks = rep_tensor_cfg.size // kv_cache_spec.page_size_bytes
 
             # Use version-aware attention backend access
-            attn_backend_cls = patch_instance._get_version_specific_attention_backend(self)
+            attn_backend_cls = patch_instance._get_version_specific_attention_backend(
+                self, kv_cache_group_id=first_attn_group_id
+            )
 
             backend_name = (
                 attn_backend_cls.get_name() if hasattr(attn_backend_cls, "get_name")
@@ -929,19 +1049,38 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 kv_cache_spec.head_size,
             )
 
-            num_layers = _count_kv_cache_layers(kv_cache_config)
+            has_mamba = any(
+                _is_mamba_spec(g.kv_cache_spec)
+                for g in kv_cache_config.kv_cache_groups
+            )
+
+            # Allocate group_size shared VM-backed pools, mirroring vLLM's
+            # KVCacheTensor sharing: pool i is shared by layer i from each
+            # group, and different groups use different block IDs within the
+            # same pool.
+            group_size = _get_group_size(kv_cache_config)
             dtype = kv_cache_spec.dtype
             device_type = getattr(self, "device", torch.device("cuda")).type
 
-            kv_cache_raw_tensors = kvi.alloc_kv_cache(
+            alloc_result = kvi.alloc_kv_cache(
                 kv_cache_shape,
                 kv_cache_spec.block_size,
                 dtype,
                 device_type,
-                num_layers,
+                group_size,
                 attention_type="MLA" if is_mla else "MHA",
                 kv_layout="NHD",
+                return_raw_buffers=has_mamba,
             )
+
+            if has_mamba:
+                kv_cache_raw_tensors, raw_info = alloc_result
+                self._kvcached_mamba_raw_info = raw_info
+            else:
+                kv_cache_raw_tensors = alloc_result
+
+            # Return the list of pool tensors directly; the layer-name
+            # mapping is done in _reshape_kv_cache_tensors_from_kvcached.
             return kv_cache_raw_tensors
 
         setattr(
@@ -978,13 +1117,41 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             self, kv_cache_config, kv_cache_raw_tensors, *args: Any, **kwargs: Any
         ):
             import torch
+            from vllm.utils.torch_utils import get_dtype_size
 
             kv_caches: dict[str, torch.Tensor] = {}
-            layer_id = 0
+            has_attn = False
+            has_mamba = False
+
+            mamba_info = getattr(self, "_kvcached_mamba_raw_info", None)
+
+            # kv_cache_raw_tensors is a list of pool tensors indexed by
+            # pool_idx.  Map each layer to its pool following vLLM's sharing
+            # pattern: pool i is shared by layer i from each group.
             for kv_cache_group in kv_cache_config.kv_cache_groups:
-                for layer_name in kv_cache_group.layer_names:
-                    kv_caches[layer_name] = kv_cache_raw_tensors[layer_id]
-                    layer_id += 1
+                kv_cache_spec = kv_cache_group.kv_cache_spec
+
+                if _is_mamba_spec(kv_cache_spec):
+                    has_mamba = True
+                    for pool_idx, layer_name in enumerate(kv_cache_group.layer_names):
+                        if mamba_info is not None and mamba_info["is_contiguous"]:
+                            state_tensors = _reshape_mamba_contiguous(
+                                mamba_info, kv_cache_spec, pool_idx, get_dtype_size,
+                            )
+                        else:
+                            state_tensors = _reshape_mamba_non_contiguous(
+                                kv_cache_raw_tensors[pool_idx], kv_cache_spec, get_dtype_size,
+                            )
+                        kv_caches[layer_name] = state_tensors  # type: ignore[assignment]
+                else:
+                    has_attn = True
+                    for pool_idx, layer_name in enumerate(kv_cache_group.layer_names):
+                        kv_caches[layer_name] = kv_cache_raw_tensors[pool_idx]
+
+            if has_attn and has_mamba:
+                if hasattr(self, "_update_hybrid_attention_mamba_layout"):
+                    self._update_hybrid_attention_mamba_layout(kv_caches)
+
             return kv_caches
 
         setattr(
@@ -1016,19 +1183,21 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
         return True
 
     # Version-specific helper methods for attention backend access
-    def get_attention_backend_v8(self, model_runner_instance):
+    def get_attention_backend_v8(self, model_runner_instance, kv_cache_group_id=0):
         """Get attention backend for vLLM 0.8.x versions"""
         return model_runner_instance.attn_backend
 
-    def get_attention_backend_v9(self, model_runner_instance):
+    def get_attention_backend_v9(self, model_runner_instance, kv_cache_group_id=0):
         """Get attention backend for vLLM 0.9.x versions"""
-        return model_runner_instance.attn_backends[0]
+        return model_runner_instance.attn_backends[kv_cache_group_id]
 
-    def get_attention_backend_v10(self, model_runner_instance):
+    def get_attention_backend_v10(self, model_runner_instance, kv_cache_group_id=0):
         """Get attention backend for vLLM 0.10.x+ versions"""
-        return model_runner_instance.attn_groups[0][0].backend
+        return model_runner_instance.attn_groups[kv_cache_group_id][0].backend
 
-    def _get_version_specific_attention_backend(self, model_runner_instance):
+    def _get_version_specific_attention_backend(
+        self, model_runner_instance, kv_cache_group_id=0
+    ):
         """Get the appropriate attention backend based on detected version"""
         if not self.detected_version:
             raise ValueError("vLLM version not detected")
@@ -1039,11 +1208,11 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
         v10_range = VersionRange(VLLM_V10_RANGE)
 
         if v10_range.contains(self.detected_version):
-            return self.get_attention_backend_v10(model_runner_instance)
+            return self.get_attention_backend_v10(model_runner_instance, kv_cache_group_id)
         elif v9_range.contains(self.detected_version):
-            return self.get_attention_backend_v9(model_runner_instance)
+            return self.get_attention_backend_v9(model_runner_instance, kv_cache_group_id)
         elif v8_range.contains(self.detected_version):
-            return self.get_attention_backend_v8(model_runner_instance)
+            return self.get_attention_backend_v8(model_runner_instance, kv_cache_group_id)
         else:
             raise ValueError(f"Unsupported vLLM version: {self.detected_version}")
 

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -29,14 +29,14 @@ if TYPE_CHECKING:
 
 
 def _is_attention_spec(spec: Any) -> bool:
-    """Check if a KV cache spec is an attention-type spec managed by kvcached."""
+    """Check if a KV cache spec is an attention-type spec."""
     from vllm.v1.kv_cache_interface import FullAttentionSpec, MLAAttentionSpec, SlidingWindowSpec
 
     return isinstance(spec, (FullAttentionSpec, SlidingWindowSpec, MLAAttentionSpec))
 
 
 def _is_mamba_spec(spec: Any) -> bool:
-    """Check if a KV cache spec is a MambaSpec (SSM state, not managed by kvcached)."""
+    """Check if a KV cache spec is a MambaSpec."""
     try:
         from vllm.v1.kv_cache_interface import MambaSpec
 
@@ -106,6 +106,34 @@ def _validate_kv_cache_groups(kv_cache_config: Any) -> None:
 def _count_kv_cache_layers(kv_cache_config: Any) -> int:
     """Return the total number of KV cache layers across all groups."""
     return sum(len(g.layer_names) for g in kv_cache_config.kv_cache_groups)
+
+
+def _infer_attention_type(kv_cache_config: Any) -> str:
+    """Pick the kvcached attention_type for this KV cache config.
+
+    Returns one of: "MLA", "HYBRID_LINEAR", "MHA". HYBRID_LINEAR
+    requires both a FullAttentionSpec group and a linear-attention
+    (mamba/SSM) group to be present.
+    """
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, MLAAttentionSpec
+
+    has_full_attn = False
+    has_mla = False
+    has_mamba = False
+    for grp in kv_cache_config.kv_cache_groups:
+        spec = grp.kv_cache_spec
+        if isinstance(spec, MLAAttentionSpec):
+            has_mla = True
+        elif isinstance(spec, FullAttentionSpec):
+            has_full_attn = True
+        elif _is_mamba_spec(spec):
+            has_mamba = True
+
+    if has_mla:
+        return "MLA"
+    if has_full_attn and has_mamba:
+        return "HYBRID_LINEAR"
+    return "MHA"
 
 
 def _should_enable_async_sched(vllm_config: Any) -> bool:
@@ -196,7 +224,11 @@ VLLM_V10_RANGE = ">0.9.2"  # vLLM 0.10.x+ versions, need to cover 0.10.0rc1
 VLLM_ALL_RANGE = ">=0.8.4"  # All supported versions
 
 
-def _get_kv_cache_params(kv_cache_spec: Any, block_size: int) -> tuple:
+def _get_kv_cache_params(
+    kv_cache_spec: Any,
+    block_size: int,
+    attention_type: str = "MHA",
+) -> tuple:
     """Determine cell_size and num_kv_buffers from a KV cache spec.
 
     Returns:
@@ -204,8 +236,11 @@ def _get_kv_cache_params(kv_cache_spec: Any, block_size: int) -> tuple:
     """
     from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
-    if isinstance(kv_cache_spec, MLAAttentionSpec):
+    if attention_type in ("MLA", "HYBRID_LINEAR") or isinstance(kv_cache_spec, MLAAttentionSpec):
         # MLA: single combined KV buffer per layer
+        # HYBRID_LINEAR (full attention + linear attention): K and V are
+        # interleaved into one buffer per layer, so it shares MLA's
+        # single-buffer math.
         # page_size_bytes = block_size * num_kv_heads * head_size * dtype_size
         cell_size = kv_cache_spec.page_size_bytes // block_size
         num_kv_buffers = 1
@@ -284,6 +319,15 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 self.kv_event_queue = []  # type: ignore[var-annotated]
 
                 from kvcached.integration.vllm.interfaces import get_kv_cache_manager
+
+                logger.info(
+                    "[kvcached-debug] ElasticBlockPool init: "
+                    f"num_gpu_blocks={num_gpu_blocks} "
+                    f"block_size={block_size} cell_size={cell_size} "
+                    f"block_mem_size={block_size * cell_size} "
+                    f"num_layers={num_layers} "
+                    f"num_kv_buffers={num_kv_buffers} "
+                    f"pool_bytes_per_layer={num_gpu_blocks * block_size * cell_size}")
 
                 self.kv_cache_manager = get_kv_cache_manager(
                     num_gpu_blocks, block_size, cell_size, num_layers,
@@ -623,16 +667,10 @@ class KVCacheCoordinatorPatch(VersionAwarePatch, BasePatch):
             kv_cache_spec = first_attn_group.kv_cache_spec
             block_size = kv_cache_spec.block_size
 
-            has_mamba = any(
-                _is_mamba_spec(g.kv_cache_spec)
-                for g in kv_cache_config.kv_cache_groups
-            )
+            attention_type = _infer_attention_type(kv_cache_config)
 
-            if has_mamba:
-                cell_size = kv_cache_spec.page_size_bytes // block_size
-                num_kv_buffers = 1
-            else:
-                cell_size, num_kv_buffers = _get_kv_cache_params(kv_cache_spec, block_size)
+            cell_size, num_kv_buffers = _get_kv_cache_params(
+                kv_cache_spec, block_size, attention_type=attention_type)
 
             try:
                 from vllm.distributed.parallel_state import get_tensor_model_parallel_world_size
@@ -659,12 +697,12 @@ class KVCacheCoordinatorPatch(VersionAwarePatch, BasePatch):
             block_pool_mod = importlib.import_module("vllm.v1.core.block_pool")
             ElasticBlockPool = getattr(block_pool_mod, "ElasticBlockPool")
 
-            num_layers = _get_group_size(kv_cache_config)
+            group_size = _get_group_size(kv_cache_config)
             self.block_pool = ElasticBlockPool(
                 kv_cache_config.num_blocks,
                 block_size,
                 cell_size=cell_size,
-                num_layers=num_layers,
+                num_layers=group_size,
                 enable_caching=getattr(self, "enable_caching", False),
                 num_kv_buffers=num_kv_buffers,
                 max_cached_blocks=_get_max_cached_blocks(block_size)
@@ -913,7 +951,6 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
 
         def _patched_initialize_kv_cache(self, kv_cache_config: Any) -> None:
             import torch
-            from vllm.v1.kv_cache_interface import MLAAttentionSpec
             from vllm.v1.utils import bind_kv_cache
 
             from kvcached.integration.vllm import interfaces as kvi
@@ -939,7 +976,7 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             kv_cache_spec = kv_cache_config.kv_cache_groups[0].kv_cache_spec
             tensor_config = kv_cache_config.tensors[layer_name]
 
-            is_mla = isinstance(kv_cache_spec, MLAAttentionSpec)
+            attention_type = _infer_attention_type(kv_cache_config)
             dtype = kv_cache_spec.dtype
             num_blocks = tensor_config.size // kv_cache_spec.page_size_bytes
             assert num_blocks >= kv_cache_config.num_blocks
@@ -956,7 +993,7 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 dtype,
                 self.device.type,
                 num_layers,
-                attention_type="MLA" if is_mla else "MHA",
+                attention_type=attention_type,
                 kv_layout="NHD",
             )
             layer_id = 0
@@ -986,7 +1023,7 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
 
         def _allocate_kv_cache_from_kvcached(self, kv_cache_config):
             import torch
-            from vllm.v1.kv_cache_interface import KVCacheTensor, MLAAttentionSpec
+            from vllm.v1.kv_cache_interface import KVCacheTensor
 
             from kvcached.integration.vllm import interfaces as kvi
 
@@ -1026,7 +1063,7 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 return result
 
             kv_cache_spec = first_attn_group.kv_cache_spec
-            is_mla = isinstance(kv_cache_spec, MLAAttentionSpec)
+            attention_type = _infer_attention_type(kv_cache_config)
 
             first_layer_name = first_attn_group.layer_names[0]
             rep_tensor_cfg = layer_to_tensor_cfg[first_layer_name]
@@ -1064,11 +1101,6 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 kv_cache_spec.head_size,
             )
 
-            has_mamba = any(
-                _is_mamba_spec(g.kv_cache_spec)
-                for g in kv_cache_config.kv_cache_groups
-            )
-
             # Allocate group_size shared VM-backed pools, mirroring vLLM's
             # KVCacheTensor sharing: pool i is shared by layer i from each
             # group, and different groups use different block IDs within the
@@ -1077,19 +1109,29 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             dtype = kv_cache_spec.dtype
             device_type = getattr(self, "device", torch.device("cuda")).type
 
+            # vLLM may split a virtual block (spec.block_size tokens) into
+            # ``ratio`` kernel-sized blocks; the attention zero kernel indexes
+            # by kernel-block stride. Forward kernel_block_size so we build the
+            # per-layer tensor at kernel granularity.
+            kernel_block_sizes = getattr(self, "_kernel_block_sizes", None)
+            kernel_block_size = (
+                kernel_block_sizes[first_attn_group_id]
+                if kernel_block_sizes is not None
+                and first_attn_group_id < len(kernel_block_sizes)
+                else None)
+
             alloc_result = kvi.alloc_kv_cache(
                 kv_cache_shape,
                 kv_cache_spec.block_size,
                 dtype,
                 device_type,
                 group_size,
-                attention_type="MLA" if is_mla else "MHA",
+                attention_type=attention_type,
                 kv_layout="NHD",
-                return_raw_buffers=has_mamba,
-                num_kv_buffers_override=1 if has_mamba else None,
+                kernel_block_size=kernel_block_size,
             )
 
-            if has_mamba:
+            if attention_type == "HYBRID_LINEAR":
                 kv_cache_raw_tensors, raw_info = alloc_result
                 self._kvcached_mamba_raw_info = raw_info
             else:
@@ -1136,8 +1178,6 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             from vllm.utils.torch_utils import get_dtype_size
 
             kv_caches: dict[str, torch.Tensor] = {}
-            has_attn = False
-            has_mamba = False
 
             mamba_info = getattr(self, "_kvcached_mamba_raw_info", None)
 
@@ -1145,7 +1185,6 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 kv_cache_spec = kv_cache_group.kv_cache_spec
 
                 if _is_mamba_spec(kv_cache_spec):
-                    has_mamba = True
                     if mamba_info is None:
                         raise RuntimeError(
                             "Mamba layers found but no raw buffer info "
@@ -1163,13 +1202,8 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                             )
                         kv_caches[layer_name] = state_tensors  # type: ignore[assignment]
                 else:
-                    has_attn = True
                     for pool_idx, layer_name in enumerate(kv_cache_group.layer_names):
                         kv_caches[layer_name] = kv_cache_raw_tensors[pool_idx]
-
-            if has_attn and has_mamba:
-                if hasattr(self, "_update_hybrid_attention_mamba_layout"):
-                    self._update_hybrid_attention_mamba_layout(kv_caches)
 
             return kv_caches
 

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -320,15 +320,6 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
 
                 from kvcached.integration.vllm.interfaces import get_kv_cache_manager
 
-                logger.info(
-                    "[kvcached-debug] ElasticBlockPool init: "
-                    f"num_gpu_blocks={num_gpu_blocks} "
-                    f"block_size={block_size} cell_size={cell_size} "
-                    f"block_mem_size={block_size * cell_size} "
-                    f"num_layers={num_layers} "
-                    f"num_kv_buffers={num_kv_buffers} "
-                    f"pool_bytes_per_layer={num_gpu_blocks * block_size * cell_size}")
-
                 self.kv_cache_manager = get_kv_cache_manager(
                     num_gpu_blocks, block_size, cell_size, num_layers,
                     num_kv_buffers=num_kv_buffers)

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -208,6 +208,9 @@ class KVCacheManager:
             if not self.avail_pages:
                 page = self.page_allocator.alloc_page()
                 page.init(self.block_mem_size)
+                if page.num_free_blocks() == 0:
+                    self.full_pages[page.page_id] = page
+                    continue
                 self.num_avail_blocks += page.num_free_blocks()
             else:
                 _, page = self.avail_pages.popitem()

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -208,6 +208,10 @@ class KVCacheManager:
             if not self.avail_pages:
                 page = self.page_allocator.alloc_page()
                 page.init(self.block_mem_size)
+                # A page may have zero usable blocks when block_mem_size is
+                # large (e.g. HYBRID_LINEAR) and every aligned block would
+                # straddle the page boundary. Park it in full_pages so it's
+                # not re-handed-out but stays lookupable by free().
                 if page.num_free_blocks() == 0:
                     self.full_pages[page.page_id] = page
                     continue


### PR DESCRIPTION
## Summary

Adds kvcached support for vLLM hybrid models that mix full attention with linear attention / SSM (mamba) layers. Introduces a new `HYBRID_LINEAR` attention type that collapses K and V into a single block-interleaved FTensor per pool, matching the layout that vLLM's `_update_hybrid_attention_mamba_layout` expects.

## Scope

Only the non-contiguous layout path is supported. `HYBRID_LINEAR` + contiguous layout raises `ValueError` at alloc_kv_cache entry; contiguous support can be added in a follow-up.

## Changes

- `csrc/`: new `unified_pool` mode in FTensorAllocator — single-FTensor-per-layer mapping at `page_size_bytes` granularity (K+V combined).
- `interfaces.alloc_kv_cache`: adds `attention_type=HYBRID_LINEAR` and `kernel_block_size`; returns `(kv_tensors, raw_info)` so mamba layers can reshape the same VM-backed buffer.
- `integration/vllm/patches.py`: `_infer_attention_type` selects MLA / HYBRID_LINEAR / MHA from the KV cache config; `group_size` (max layers across groups) replaces total-layer count so attention and mamba layers share pools the same way native vLLM does;  forwards `kernel_block_size` from the model runner's `_kernel_block_sizes`; new `_reshape_mamba_non_contiguous` helper builds strided views over the raw buffers.
- `kv_cache_manager`: skip pages that come back with zero free blocks instead of accounting them as available.

## Test plan

- [x] Run a linear attention hybrid vLLM model (e.g. Qwen3-next) with `ENABLE_KVCACHED=true` in non-contiguous layout with `KVCACHED_CONTIGUOUS_LAYOUT=false`.
- [x] Run a non-hybrid model (MHA, MLA) to confirm no regression in the default path.
- [x] Confirm contiguous-layout path still works for non-hybrid models, and that HYBRID_LINEAR + contiguous raises cleanly.