### PR TITLE
[Do Not Merge] Fix kvcached + NixlConnector PD disaggregation

### DIFF
--- a/experiments/06_test_fix1.sh
+++ b/experiments/06_test_fix1.sh
@@ -1,0 +1,597 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Test Script: Fix 1 — Patch NixlConnector assertion for kvcached PD disagg
+#
+# Issue:  https://github.com/ovg-project/kvcached/issues/302
+# What:   Tests whether patching the NixlConnector assertion (== to >=)
+#         allows kvcached to work with PD disaggregation.
+#
+# Environment: RunPod 2xA100 80GB SXM (or any 2-GPU node with NVLink)
+#
+# Usage (fresh RunPod — just clone and run):
+#   git clone https://github.com/AAbouzeid/kvcached.git
+#   cd kvcached && git checkout fix/pd-disagg-nixl-connector
+#   chmod +x experiments/06_test_fix1.sh
+#   ./experiments/06_test_fix1.sh
+#
+# The script handles all setup automatically (deps, model download, install).
+# Logs are saved to experiments/logs/
+# =============================================================================
+
+set -euo pipefail
+
+MODEL="Qwen/Qwen2.5-1.5B-Instruct"
+MAX_MODEL_LEN=1024
+GPU_MEM_UTIL=0.8
+PREFILL_PORT=8100
+DECODE_PORT=8200
+PROXY_PORT=9100
+PREFILL_SIDE_CHANNEL=5600
+DECODE_SIDE_CHANNEL=5601
+LOG_DIR="experiments/logs"
+TIMEOUT_STARTUP=180   # seconds to wait for server to be ready
+TIMEOUT_REQUEST=60    # seconds to wait for a request to complete
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+mkdir -p "$LOG_DIR"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; }
+log_info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+cleanup() {
+    log_info "Cleaning up background processes..."
+    # Kill vLLM and its subprocesses (EngineCore, APIServer, etc.)
+    pkill -f "vllm serve" 2>/dev/null || true
+    pkill -f "VLLM::EngineCore" 2>/dev/null || true
+    jobs -p 2>/dev/null | xargs -r kill 2>/dev/null || true
+    sleep 2
+    pkill -9 -f "vllm serve" 2>/dev/null || true
+    pkill -9 -f "VLLM::EngineCore" 2>/dev/null || true
+    jobs -p 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+    wait 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_for_server() {
+    local port=$1
+    local name=$2
+    local logfile=$3
+    local elapsed=0
+
+    log_info "Waiting for $name on port $port (timeout ${TIMEOUT_STARTUP}s)..."
+    while [ $elapsed -lt $TIMEOUT_STARTUP ]; do
+        if curl -s "http://localhost:$port/health" > /dev/null 2>&1; then
+            log_pass "$name is ready (${elapsed}s)"
+            return 0
+        fi
+        # Check if process died
+        if [ -f "$logfile" ] && grep -q "Traceback (most recent call last)" "$logfile" 2>/dev/null; then
+            log_fail "$name crashed during startup. Check $logfile"
+            echo "--- Last 30 lines of $logfile ---"
+            tail -30 "$logfile"
+            return 1
+        fi
+        # Show progress every 30s so user knows it's not stuck
+        if [ $((elapsed % 30)) -eq 0 ] && [ $elapsed -gt 0 ]; then
+            local last_line
+            last_line=$(tail -1 "$logfile" 2>/dev/null | sed 's/^.*] //' | cut -c1-80)
+            log_info "  ...${elapsed}s elapsed. Last log: ${last_line:-<empty>}"
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+    log_fail "$name did not start within ${TIMEOUT_STARTUP}s. Check $logfile"
+    tail -30 "$logfile"
+    return 1
+}
+
+send_request() {
+    local port=$1
+    local prompt=$2
+    local max_tokens=${3:-30}
+
+    curl -s --max-time $TIMEOUT_REQUEST "http://localhost:$port/v1/completions" \
+        -H "Content-Type: application/json" \
+        -d "{
+            \"model\": \"$MODEL\",
+            \"prompt\": \"$prompt\",
+            \"max_tokens\": $max_tokens,
+            \"temperature\": 0
+        }"
+}
+
+check_response() {
+    local response=$1
+    local test_name=$2
+
+    if echo "$response" | python3 -c "
+import sys, json
+try:
+    r = json.load(sys.stdin)
+    text = r['choices'][0]['text'].strip()
+    if len(text) > 0:
+        print(f'Response: {text[:100]}')
+        sys.exit(0)
+    else:
+        print('Empty response')
+        sys.exit(1)
+except Exception as e:
+    print(f'Parse error: {e}')
+    print(f'Raw: {sys.stdin.read()[:200] if hasattr(sys.stdin, \"read\") else \"N/A\"}')
+    sys.exit(1)
+" 2>&1; then
+        log_pass "$test_name"
+        return 0
+    else
+        log_fail "$test_name"
+        echo "Raw response: $response"
+        return 1
+    fi
+}
+
+# =============================================================================
+# PHASE 1: Baseline without kvcached (sanity check)
+# =============================================================================
+phase1_baseline() {
+    log_info "========== PHASE 1: Baseline without kvcached =========="
+
+    # Start prefill instance
+    UCX_TLS=cuda_ipc,cuda_copy,tcp \
+    VLLM_NIXL_SIDE_CHANNEL_PORT=$PREFILL_SIDE_CHANNEL \
+    CUDA_VISIBLE_DEVICES=0 \
+    vllm serve $MODEL \
+        --host 0.0.0.0 --port $PREFILL_PORT \
+        --max-model-len $MAX_MODEL_LEN \
+        --gpu-memory-utilization $GPU_MEM_UTIL \
+        --kv-transfer-config \
+        '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_buffer_device":"cuda"}' \
+        > "$LOG_DIR/phase1_prefill.log" 2>&1 &
+
+    # Start decode instance
+    UCX_TLS=cuda_ipc,cuda_copy,tcp \
+    VLLM_NIXL_SIDE_CHANNEL_PORT=$DECODE_SIDE_CHANNEL \
+    CUDA_VISIBLE_DEVICES=1 \
+    vllm serve $MODEL \
+        --host 0.0.0.0 --port $DECODE_PORT \
+        --max-model-len $MAX_MODEL_LEN \
+        --gpu-memory-utilization $GPU_MEM_UTIL \
+        --kv-transfer-config \
+        '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_buffer_device":"cuda"}' \
+        > "$LOG_DIR/phase1_decode.log" 2>&1 &
+
+    wait_for_server $PREFILL_PORT "Prefill" "$LOG_DIR/phase1_prefill.log" || return 1
+    wait_for_server $DECODE_PORT "Decode" "$LOG_DIR/phase1_decode.log" || return 1
+
+    # Start proxy
+    python3 -c "
+import asyncio, aiohttp, json, sys
+from aiohttp import web
+
+PREFILL='http://localhost:$PREFILL_PORT'
+DECODE='http://localhost:$DECODE_PORT'
+
+async def proxy_handler(request):
+    body = await request.json()
+    # Send to prefill with max_tokens=1
+    prefill_body = {**body, 'max_tokens': 1}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f'{PREFILL}/v1/completions', json=prefill_body) as resp:
+            await resp.json()
+        # Send to decode with original max_tokens
+        async with session.post(f'{DECODE}/v1/completions', json=body) as resp:
+            result = await resp.json()
+    return web.json_response(result)
+
+app = web.Application()
+app.router.add_post('/v1/completions', proxy_handler)
+web.run_app(app, port=$PROXY_PORT, print=lambda *a: None)
+" > "$LOG_DIR/phase1_proxy.log" 2>&1 &
+
+    sleep 3  # Give proxy a moment
+
+    # Test requests
+    log_info "Sending test requests via proxy..."
+    local resp
+    resp=$(send_request $PROXY_PORT "The capital of France is")
+    check_response "$resp" "Phase 1: Basic PD disagg baseline" || return 1
+
+    resp=$(send_request $PROXY_PORT "What is 2+2? The answer is")
+    check_response "$resp" "Phase 1: Second request baseline" || return 1
+
+    log_pass "Phase 1 complete — baseline PD disagg works"
+    cleanup
+    sleep 5  # Let GPU memory free up
+}
+
+# =============================================================================
+# PHASE 2: kvcached + NixlConnector (THE MAIN TEST)
+# =============================================================================
+phase2_kvcached_nixl() {
+    log_info "========== PHASE 2: kvcached + NixlConnector (Fix 1) =========="
+
+    # Start prefill with kvcached
+    ENABLE_KVCACHED=true \
+    KVCACHED_AUTOPATCH=1 \
+    UCX_TLS=cuda_ipc,cuda_copy,tcp \
+    VLLM_NIXL_SIDE_CHANNEL_PORT=$PREFILL_SIDE_CHANNEL \
+    CUDA_VISIBLE_DEVICES=0 \
+    vllm serve $MODEL \
+        --host 0.0.0.0 --port $PREFILL_PORT \
+        --max-model-len $MAX_MODEL_LEN \
+        --gpu-memory-utilization $GPU_MEM_UTIL \
+        --kv-transfer-config \
+        '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_buffer_device":"cuda"}' \
+        > "$LOG_DIR/phase2_prefill.log" 2>&1 &
+
+    # Start decode with kvcached
+    ENABLE_KVCACHED=true \
+    KVCACHED_AUTOPATCH=1 \
+    UCX_TLS=cuda_ipc,cuda_copy,tcp \
+    VLLM_NIXL_SIDE_CHANNEL_PORT=$DECODE_SIDE_CHANNEL \
+    CUDA_VISIBLE_DEVICES=1 \
+    vllm serve $MODEL \
+        --host 0.0.0.0 --port $DECODE_PORT \
+        --max-model-len $MAX_MODEL_LEN \
+        --gpu-memory-utilization $GPU_MEM_UTIL \
+        --kv-transfer-config \
+        '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_buffer_device":"cuda"}' \
+        > "$LOG_DIR/phase2_decode.log" 2>&1 &
+
+    # Check if kvcached patches were applied (including nixl_connector)
+    sleep 10
+    log_info "Checking kvcached patch status..."
+    if grep -q "nixl_connector" "$LOG_DIR/phase2_prefill.log" 2>/dev/null; then
+        log_pass "NixlConnector patch applied on prefill"
+    else
+        log_info "NixlConnector patch not yet visible in logs (may appear later)"
+    fi
+
+    # Check for the old assertion crash
+    if grep -q "All kv cache tensors must have the same number of blocks" "$LOG_DIR/phase2_prefill.log" 2>/dev/null; then
+        log_fail "ASSERTION STILL FAILING — Fix 1 patch not working"
+        tail -30 "$LOG_DIR/phase2_prefill.log"
+        cleanup
+        return 1
+    fi
+
+    # Check for UCX/VMM errors (the big unknown)
+    if grep -qi "cuIpcGetMemHandle\|cuPointerSetAttribute.*error\|operation not supported" "$LOG_DIR/phase2_prefill.log" 2>/dev/null; then
+        log_fail "UCX/VMM compatibility error detected — VMM memory not supported by transport"
+        grep -i "cuIpc\|cuPointer\|operation not supported" "$LOG_DIR/phase2_prefill.log" | head -5
+        log_info "Try: UCX_TLS=cuda_copy,tcp (skip cuda_ipc)"
+        cleanup
+        return 1
+    fi
+
+    wait_for_server $PREFILL_PORT "Prefill+kvcached" "$LOG_DIR/phase2_prefill.log" || return 1
+    wait_for_server $DECODE_PORT "Decode+kvcached" "$LOG_DIR/phase2_decode.log" || return 1
+
+    # Verify kvcached's num_blocks adjustment message
+    if grep -q "num_blocks adjusted" "$LOG_DIR/phase2_prefill.log" 2>/dev/null; then
+        log_pass "Fix 1 patch activated — num_blocks adjusted for virtual capacity"
+        grep "num_blocks adjusted" "$LOG_DIR/phase2_prefill.log" | head -1
+    fi
+
+    # Start proxy
+    python3 -c "
+import asyncio, aiohttp, json, sys
+from aiohttp import web
+
+PREFILL='http://localhost:$PREFILL_PORT'
+DECODE='http://localhost:$DECODE_PORT'
+
+async def proxy_handler(request):
+    body = await request.json()
+    prefill_body = {**body, 'max_tokens': 1}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f'{PREFILL}/v1/completions', json=prefill_body) as resp:
+            await resp.json()
+        async with session.post(f'{DECODE}/v1/completions', json=body) as resp:
+            result = await resp.json()
+    return web.json_response(result)
+
+app = web.Application()
+app.router.add_post('/v1/completions', proxy_handler)
+web.run_app(app, port=$PROXY_PORT, print=lambda *a: None)
+" > "$LOG_DIR/phase2_proxy.log" 2>&1 &
+
+    sleep 3
+
+    # Test requests
+    log_info "Sending test requests via proxy (kvcached + NIXL)..."
+
+    local resp
+    resp=$(send_request $PROXY_PORT "The capital of France is")
+    check_response "$resp" "Phase 2: Basic PD disagg with kvcached" || {
+        log_info "--- Prefill log tail ---"
+        tail -20 "$LOG_DIR/phase2_prefill.log"
+        log_info "--- Decode log tail ---"
+        tail -20 "$LOG_DIR/phase2_decode.log"
+        cleanup
+        return 1
+    }
+
+    resp=$(send_request $PROXY_PORT "What is 2+2? The answer is")
+    check_response "$resp" "Phase 2: Second request with kvcached" || return 1
+
+    resp=$(send_request $PROXY_PORT "List the first 5 prime numbers:")
+    check_response "$resp" "Phase 2: Third request with kvcached" || return 1
+
+    # Multiple rapid requests
+    log_info "Sending 5 rapid requests..."
+    local pass_count=0
+    for i in $(seq 1 5); do
+        resp=$(send_request $PROXY_PORT "Count to $i:")
+        if echo "$resp" | python3 -c "import sys,json; r=json.load(sys.stdin); sys.exit(0 if r.get('choices') else 1)" 2>/dev/null; then
+            pass_count=$((pass_count + 1))
+        fi
+    done
+    if [ $pass_count -eq 5 ]; then
+        log_pass "Phase 2: All 5 rapid requests succeeded"
+    else
+        log_fail "Phase 2: Only $pass_count/5 rapid requests succeeded"
+    fi
+
+    log_pass "Phase 2 complete — kvcached + NixlConnector PD disagg WORKS"
+
+    # Dump init timing from logs
+    log_info "Init timing info:"
+    grep -i "register_kv_caches\|prep_xfer\|register_memory\|num_blocks\|descriptor" \
+        "$LOG_DIR/phase2_prefill.log" 2>/dev/null | head -10 || true
+
+    cleanup
+    sleep 5
+}
+
+# =============================================================================
+# PHASE 3: kvcached + NixlConnector with cuda_copy fallback
+# (Only runs if Phase 2 fails with UCX/VMM error)
+# =============================================================================
+phase3_cuda_copy_fallback() {
+    log_info "========== PHASE 3: kvcached + cuda_copy transport fallback =========="
+
+    ENABLE_KVCACHED=true \
+    KVCACHED_AUTOPATCH=1 \
+    UCX_TLS=cuda_copy,tcp \
+    VLLM_NIXL_SIDE_CHANNEL_PORT=$PREFILL_SIDE_CHANNEL \
+    CUDA_VISIBLE_DEVICES=0 \
+    vllm serve $MODEL \
+        --host 0.0.0.0 --port $PREFILL_PORT \
+        --max-model-len $MAX_MODEL_LEN \
+        --gpu-memory-utilization $GPU_MEM_UTIL \
+        --kv-transfer-config \
+        '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_buffer_device":"cuda"}' \
+        > "$LOG_DIR/phase3_prefill.log" 2>&1 &
+
+    ENABLE_KVCACHED=true \
+    KVCACHED_AUTOPATCH=1 \
+    UCX_TLS=cuda_copy,tcp \
+    VLLM_NIXL_SIDE_CHANNEL_PORT=$DECODE_SIDE_CHANNEL \
+    CUDA_VISIBLE_DEVICES=1 \
+    vllm serve $MODEL \
+        --host 0.0.0.0 --port $DECODE_PORT \
+        --max-model-len $MAX_MODEL_LEN \
+        --gpu-memory-utilization $GPU_MEM_UTIL \
+        --kv-transfer-config \
+        '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_buffer_device":"cuda"}' \
+        > "$LOG_DIR/phase3_decode.log" 2>&1 &
+
+    wait_for_server $PREFILL_PORT "Prefill+kvcached (cuda_copy)" "$LOG_DIR/phase3_prefill.log" || return 1
+    wait_for_server $DECODE_PORT "Decode+kvcached (cuda_copy)" "$LOG_DIR/phase3_decode.log" || return 1
+
+    # Quick proxy
+    python3 -c "
+import asyncio, aiohttp, json
+from aiohttp import web
+async def h(req):
+    b = await req.json()
+    async with aiohttp.ClientSession() as s:
+        async with s.post('http://localhost:$PREFILL_PORT/v1/completions', json={**b,'max_tokens':1}) as r: await r.json()
+        async with s.post('http://localhost:$DECODE_PORT/v1/completions', json=b) as r: result = await r.json()
+    return web.json_response(result)
+app = web.Application()
+app.router.add_post('/v1/completions', h)
+web.run_app(app, port=$PROXY_PORT, print=lambda *a: None)
+" > "$LOG_DIR/phase3_proxy.log" 2>&1 &
+
+    sleep 3
+
+    local resp
+    resp=$(send_request $PROXY_PORT "The capital of France is")
+    check_response "$resp" "Phase 3: PD disagg with cuda_copy fallback" || return 1
+
+    log_pass "Phase 3 complete — cuda_copy transport works as fallback"
+    cleanup
+    sleep 5
+}
+
+# =============================================================================
+# PHASE 4: Collect diagnostics
+# =============================================================================
+phase4_diagnostics() {
+    log_info "========== PHASE 4: Diagnostics =========="
+
+    echo "GPU info:"
+    nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader 2>/dev/null || true
+
+    echo ""
+    echo "CUDA version:"
+    nvcc --version 2>/dev/null | grep "release" || true
+
+    echo ""
+    echo "vLLM version:"
+    python3 -c "import vllm; print(vllm.__version__)" 2>/dev/null || true
+
+    echo ""
+    echo "kvcached version:"
+    python3 -c "import kvcached; print(kvcached.__version__)" 2>/dev/null || true
+
+    echo ""
+    echo "UCX info:"
+    ucx_info -v 2>/dev/null | head -3 || echo "ucx_info not found"
+
+    echo ""
+    echo "NIXL available:"
+    python3 -c "from nixl._api import nixl_agent; print('yes')" 2>/dev/null || echo "no"
+
+    echo ""
+    echo "NVLink topology:"
+    nvidia-smi topo -m 2>/dev/null || true
+
+    log_pass "Diagnostics collected"
+}
+
+# =============================================================================
+# PHASE 0: Auto-setup (install deps, model, kvcached)
+# =============================================================================
+phase0_setup() {
+    log_info "========== PHASE 0: Environment Setup =========="
+
+    # Kill any leftover GPU processes
+    log_info "Killing leftover GPU processes..."
+    pkill -9 -f "vllm" 2>/dev/null || true
+    sleep 2
+
+    # Check GPUs are available
+    if ! nvidia-smi > /dev/null 2>&1; then
+        log_fail "nvidia-smi not found. Need a GPU node."
+        return 1
+    fi
+
+    local gpu_count
+    gpu_count=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+    if [ "$gpu_count" -lt 2 ]; then
+        log_fail "Need at least 2 GPUs, found $gpu_count"
+        return 1
+    fi
+    log_pass "Found $gpu_count GPUs"
+
+    # Install vLLM if not present
+    if ! python3 -c "import vllm" 2>/dev/null; then
+        log_info "Installing vLLM (takes ~5 min)..."
+        pip install -q vllm==0.19.0
+    fi
+    log_pass "vLLM $(python3 -c 'import vllm; print(vllm.__version__)')"
+
+    # Install NIXL if not present
+    if ! python3 -c "from nixl._api import nixl_agent" 2>/dev/null; then
+        log_info "Installing NIXL..."
+        pip install -q nixl
+    fi
+    log_pass "NIXL available"
+
+    # Install aiohttp for proxy
+    if ! python3 -c "import aiohttp" 2>/dev/null; then
+        log_info "Installing aiohttp..."
+        pip install -q aiohttp
+    fi
+
+    # Download model if not cached
+    if ! python3 -c "
+from transformers import AutoConfig
+AutoConfig.from_pretrained('$MODEL')
+" 2>/dev/null; then
+        log_info "Downloading model $MODEL..."
+        HF_HUB_ENABLE_HF_TRANSFER=0 huggingface-cli download "$MODEL" --quiet
+    fi
+    log_pass "Model $MODEL available"
+
+    # Install kvcached from source (normal install, not editable)
+    log_info "Installing kvcached from source..."
+    CUDA_HOME=/usr/local/cuda pip install -q "$REPO_DIR" --no-build-isolation
+    log_pass "kvcached $(python3 -c 'import kvcached; print(getattr(kvcached, "__version__", "installed"))')"
+
+    # Verify patches activate
+    local patch_output
+    patch_output=$(ENABLE_KVCACHED=true KVCACHED_AUTOPATCH=1 python3 -c "import vllm" 2>&1 | head -1)
+    if echo "$patch_output" | grep -q "Applying.*patches"; then
+        log_pass "kvcached patches activate on vllm import"
+    else
+        log_fail "kvcached patches NOT activating. Got: $patch_output"
+        return 1
+    fi
+
+    log_pass "Phase 0 complete — environment ready"
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+main() {
+    echo "============================================================"
+    echo " kvcached + PD Disaggregation: Fix 1 Test Suite"
+    echo " $(date)"
+    echo "============================================================"
+    echo ""
+
+    # Phase 0 — auto-setup
+    if ! phase0_setup; then
+        log_fail "Setup failed. Check errors above."
+        exit 1
+    fi
+    echo ""
+
+    # Phase 4 — get environment info
+    phase4_diagnostics 2>&1 | tee "$LOG_DIR/diagnostics.log"
+    echo ""
+
+    # Phase 1 — baseline
+    if phase1_baseline; then
+        echo ""
+    else
+        log_fail "Baseline failed — environment issue, not kvcached. Fix before continuing."
+        exit 1
+    fi
+
+    # Phase 2 — the main test
+    if phase2_kvcached_nixl; then
+        echo ""
+        echo "============================================================"
+        log_pass "FIX 1 WORKS. kvcached + NixlConnector PD disagg is functional."
+        echo "============================================================"
+    else
+        echo ""
+        log_fail "Phase 2 failed. Checking failure mode..."
+
+        # Check if it was a UCX/VMM issue
+        if grep -qi "cuIpcGetMemHandle\|cuPointerSetAttribute.*error\|operation not supported" \
+            "$LOG_DIR/phase2_prefill.log" "$LOG_DIR/phase2_decode.log" 2>/dev/null; then
+            log_info "UCX/VMM incompatibility detected. Trying cuda_copy fallback (Phase 3)..."
+            echo ""
+            if phase3_cuda_copy_fallback; then
+                echo ""
+                echo "============================================================"
+                log_pass "FIX 1 WORKS with cuda_copy transport (not cuda_ipc)."
+                echo "  Set UCX_TLS=cuda_copy,tcp to use kvcached + NIXL PD disagg."
+                echo "============================================================"
+            else
+                log_fail "cuda_copy fallback also failed. Deeper investigation needed."
+                log_info "Check logs in $LOG_DIR/"
+            fi
+        else
+            log_info "Not a UCX/VMM issue. Check logs for the actual error:"
+            log_info "  $LOG_DIR/phase2_prefill.log"
+            log_info "  $LOG_DIR/phase2_decode.log"
+            # Show relevant errors
+            echo "--- Errors from prefill log ---"
+            grep -i "error\|exception\|assert\|fail\|crash" "$LOG_DIR/phase2_prefill.log" 2>/dev/null | tail -10 || true
+            echo "--- Errors from decode log ---"
+            grep -i "error\|exception\|assert\|fail\|crash" "$LOG_DIR/phase2_decode.log" 2>/dev/null | tail -10 || true
+        fi
+    fi
+
+    echo ""
+    log_info "All logs saved to $LOG_DIR/"
+    echo "  ls -la $LOG_DIR/"
+}
+
+main "$@"

--- a/experiments/09_equivalence.sh
+++ b/experiments/09_equivalence.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Test Script: Equivalence harness for kvcached + NixlConnector PD disagg
+#
+# Purpose:
+#   1. Black-box: run the same prompts through NIXL disagg WITHOUT kvcached
+#      (Phase A) and WITH kvcached (Phase B), diff the greedy outputs.
+#   2. White-box: grep KVCACHED_LAYOUT_DUMP / KVCACHED_BLOCK_SHA lines from
+#      Phase B prefill and decode logs and verify tensor metadata +
+#      per-block SHAs match across the two GPUs.
+#
+# Environment: RunPod 2xA100 80GB SXM (or any 2-GPU node with NVLink).
+#
+# Usage (fresh node):
+#   git clone https://github.com/AAbouzeid/kvcached.git
+#   cd kvcached && git checkout fix/pd-disagg-nixl-connector
+#   chmod +x experiments/09_equivalence.sh
+#   ./experiments/09_equivalence.sh
+#
+# Logs + per-prompt outputs are saved to experiments/logs_eq/.
+# =============================================================================
+
+set -euo pipefail
+
+MODEL="Qwen/Qwen2.5-1.5B-Instruct"
+MAX_MODEL_LEN=1024
+GPU_MEM_UTIL=0.8
+MAX_TOKENS=20
+PREFILL_PORT=8100
+DECODE_PORT=8200
+PROXY_PORT=9100
+PREFILL_SIDE_CHANNEL=5600
+DECODE_SIDE_CHANNEL=5601
+LOG_DIR="experiments/logs_eq"
+TIMEOUT_STARTUP=180
+TIMEOUT_REQUEST=60
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+mkdir -p "$LOG_DIR"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+log_fail() { echo -e "${RED}[FAIL]${NC} $1"; }
+log_info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+# Fixed deterministic prompt set. Qwen2.5-1.5B-Instruct under temperature=0
+# greedy should produce identical continuations for these across runs with
+# the same model/GPU.
+PROMPTS=(
+    "The capital of France is"
+    "List three primary colors:"
+    "Two plus two equals"
+    "The first president of the United States was"
+)
+
+cleanup() {
+    log_info "Cleaning up background processes..."
+    pkill -f "vllm serve" 2>/dev/null || true
+    pkill -f "VLLM::EngineCore" 2>/dev/null || true
+    jobs -p 2>/dev/null | xargs -r kill 2>/dev/null || true
+    sleep 2
+    pkill -9 -f "vllm serve" 2>/dev/null || true
+    pkill -9 -f "VLLM::EngineCore" 2>/dev/null || true
+    jobs -p 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+    wait 2>/dev/null || true
+}
+trap cleanup EXIT
+
+wait_for_server() {
+    local port=$1
+    local name=$2
+    local logfile=$3
+    local elapsed=0
+    log_info "Waiting for $name on port $port (timeout ${TIMEOUT_STARTUP}s)..."
+    while [ $elapsed -lt $TIMEOUT_STARTUP ]; do
+        if curl -s "http://localhost:$port/health" > /dev/null 2>&1; then
+            log_pass "$name is ready (${elapsed}s)"
+            return 0
+        fi
+        if [ -f "$logfile" ] && grep -q "Traceback (most recent call last)" "$logfile" 2>/dev/null; then
+            log_fail "$name crashed during startup. See $logfile"
+            tail -30 "$logfile"
+            return 1
+        fi
+        if [ $((elapsed % 30)) -eq 0 ] && [ $elapsed -gt 0 ]; then
+            local last_line
+            last_line=$(tail -1 "$logfile" 2>/dev/null | sed 's/^.*] //' | cut -c1-80)
+            log_info "  ...${elapsed}s elapsed. Last log: ${last_line:-<empty>}"
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+    log_fail "$name did not start within ${TIMEOUT_STARTUP}s. See $logfile"
+    tail -30 "$logfile"
+    return 1
+}
+
+start_proxy() {
+    local logfile=$1
+    python3 -c "
+import aiohttp, json, sys
+from aiohttp import web
+
+PREFILL='http://localhost:$PREFILL_PORT'
+DECODE='http://localhost:$DECODE_PORT'
+
+async def proxy_handler(request):
+    body = await request.json()
+    prefill_body = {**body, 'max_tokens': 1}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f'{PREFILL}/v1/completions', json=prefill_body) as resp:
+            await resp.json()
+        async with session.post(f'{DECODE}/v1/completions', json=body) as resp:
+            result = await resp.json()
+    return web.json_response(result)
+
+app = web.Application()
+app.router.add_post('/v1/completions', proxy_handler)
+web.run_app(app, port=$PROXY_PORT, print=lambda *a: None)
+" > "$logfile" 2>&1 &
+    sleep 3
+}
+
+# Send one prompt through the proxy; write the completion text to a file.
+# Fails (non-zero) on empty response, JSON parse error, or HTTP failure.
+send_and_capture() {
+    local prompt=$1
+    local outfile=$2
+
+    local resp
+    resp=$(curl -s --max-time $TIMEOUT_REQUEST "http://localhost:$PROXY_PORT/v1/completions" \
+        -H "Content-Type: application/json" \
+        -d "{
+            \"model\": \"$MODEL\",
+            \"prompt\": $(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$prompt"),
+            \"max_tokens\": $MAX_TOKENS,
+            \"temperature\": 0
+        }")
+
+    echo "$resp" | python3 -c "
+import sys, json
+try:
+    r = json.load(sys.stdin)
+    t = r['choices'][0]['text']
+except Exception as e:
+    print('PARSE_ERROR:' + str(e), file=sys.stderr)
+    sys.exit(1)
+if not t:
+    print('EMPTY_RESPONSE', file=sys.stderr)
+    sys.exit(1)
+with open(sys.argv[1], 'w') as f:
+    f.write(t)
+" "$outfile" || {
+        echo "Raw response: $resp" >&2
+        return 1
+    }
+    return 0
+}
+
+# -----------------------------------------------------------------------------
+# Phase 0: Environment setup (copied from 06_test_fix1.sh intent; kept minimal)
+# -----------------------------------------------------------------------------
+phase0_setup() {
+    log_info "========== PHASE 0: Environment setup =========="
+    pkill -9 -f "vllm" 2>/dev/null || true
+    sleep 2
+
+    if ! nvidia-smi > /dev/null 2>&1; then
+        log_fail "nvidia-smi not found. Need a GPU node."
+        return 1
+    fi
+    local gpu_count
+    gpu_count=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+    if [ "$gpu_count" -lt 2 ]; then
+        log_fail "Need at least 2 GPUs, found $gpu_count"
+        return 1
+    fi
+    log_pass "Found $gpu_count GPUs"
+
+    if ! python3 -c "import vllm" 2>/dev/null; then
+        log_info "Installing vLLM..."
+        pip install -q vllm==0.19.0
+    fi
+    log_pass "vLLM $(python3 -c 'import vllm; print(vllm.__version__)')"
+
+    if ! python3 -c "from nixl._api import nixl_agent" 2>/dev/null; then
+        log_info "Installing NIXL..."
+        pip install -q nixl
+    fi
+    log_pass "NIXL available"
+
+    if ! python3 -c "import aiohttp" 2>/dev/null; then
+        pip install -q aiohttp
+    fi
+
+    if ! python3 -c "from transformers import AutoConfig; AutoConfig.from_pretrained('$MODEL')" 2>/dev/null; then
+        log_info "Downloading model $MODEL..."
+        HF_HUB_ENABLE_HF_TRANSFER=0 huggingface-cli download "$MODEL" --quiet
+    fi
+    log_pass "Model available"
+
+    log_info "Installing kvcached from source..."
+    CUDA_HOME=/usr/local/cuda pip install -q "$REPO_DIR" --no-build-isolation
+    log_pass "kvcached installed"
+}
+
+# -----------------------------------------------------------------------------
+# Phase A: baseline without kvcached
+#
+# Explicitly unset kvcached env so Phase A is a clean baseline even if the
+# operator exported any of these in their shell before running the script.
+# -----------------------------------------------------------------------------
+phaseA_baseline() {
+    log_info "========== PHASE A: NIXL disagg WITHOUT kvcached =========="
+
+    ENABLE_KVCACHED=false \
+    KVCACHED_AUTOPATCH=false \
+    KVCACHED_DUMP_LAYOUT=0 \
+    UCX_TLS=cuda_ipc,cuda_copy,tcp \
+    VLLM_NIXL_SIDE_CHANNEL_PORT=$PREFILL_SIDE_CHANNEL \
+    CUDA_VISIBLE_DEVICES=0 \
+    vllm serve $MODEL \
+        --host 0.0.0.0 --port $PREFILL_PORT \
+        --max-model-len $MAX_MODEL_LEN \
+        --gpu-memory-utilization $GPU_MEM_UTIL \
+        --kv-transfer-config \
+        '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_buffer_device":"cuda"}' \
+        > "$LOG_DIR/phaseA_prefill.log" 2>&1 &
+
+    ENABLE_KVCACHED=false \
+    KVCACHED_AUTOPATCH=false \
+    KVCACHED_DUMP_LAYOUT=0 \
+    UCX_TLS=cuda_ipc,cuda_copy,tcp \
+    VLLM_NIXL_SIDE_CHANNEL_PORT=$DECODE_SIDE_CHANNEL \
+    CUDA_VISIBLE_DEVICES=1 \
+    vllm serve $MODEL \
+        --host 0.0.0.0 --port $DECODE_PORT \
+        --max-model-len $MAX_MODEL_LEN \
+        --gpu-memory-utilization $GPU_MEM_UTIL \
+        --kv-transfer-config \
+        '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_buffer_device":"cuda"}' \
+        > "$LOG_DIR/phaseA_decode.log" 2>&1 &
+
+    wait_for_server $PREFILL_PORT "Phase A prefill" "$LOG_DIR/phaseA_prefill.log" || return 1
+    wait_for_server $DECODE_PORT  "Phase A decode"  "$LOG_DIR/phaseA_decode.log"  || return 1
+
+    start_proxy "$LOG_DIR/phaseA_proxy.log"
+
+    local i=0
+    for p in "${PROMPTS[@]}"; do
+        if send_and_capture "$p" "$LOG_DIR/phaseA_${i}.txt"; then
+            log_pass "Phase A prompt $i captured"
+        else
+            log_fail "Phase A prompt $i failed"
+            return 1
+        fi
+        i=$((i + 1))
+    done
+
+    cleanup
+    sleep 5
+}
+
+# -----------------------------------------------------------------------------
+# Phase B: with kvcached + layout dump enabled
+# -----------------------------------------------------------------------------
+phaseB_kvcached() {
+    log_info "========== PHASE B: NIXL disagg WITH kvcached + layout dump =========="
+
+    ENABLE_KVCACHED=true \
+    KVCACHED_AUTOPATCH=1 \
+    KVCACHED_DUMP_LAYOUT=1 \
+    UCX_TLS=cuda_ipc,cuda_copy,tcp \
+    VLLM_NIXL_SIDE_CHANNEL_PORT=$PREFILL_SIDE_CHANNEL \
+    CUDA_VISIBLE_DEVICES=0 \
+    vllm serve $MODEL \
+        --host 0.0.0.0 --port $PREFILL_PORT \
+        --max-model-len $MAX_MODEL_LEN \
+        --gpu-memory-utilization $GPU_MEM_UTIL \
+        --kv-transfer-config \
+        '{"kv_connector":"NixlConnector","kv_role":"kv_producer","kv_buffer_device":"cuda"}' \
+        > "$LOG_DIR/phaseB_prefill.log" 2>&1 &
+
+    ENABLE_KVCACHED=true \
+    KVCACHED_AUTOPATCH=1 \
+    KVCACHED_DUMP_LAYOUT=1 \
+    UCX_TLS=cuda_ipc,cuda_copy,tcp \
+    VLLM_NIXL_SIDE_CHANNEL_PORT=$DECODE_SIDE_CHANNEL \
+    CUDA_VISIBLE_DEVICES=1 \
+    vllm serve $MODEL \
+        --host 0.0.0.0 --port $DECODE_PORT \
+        --max-model-len $MAX_MODEL_LEN \
+        --gpu-memory-utilization $GPU_MEM_UTIL \
+        --kv-transfer-config \
+        '{"kv_connector":"NixlConnector","kv_role":"kv_consumer","kv_buffer_device":"cuda"}' \
+        > "$LOG_DIR/phaseB_decode.log" 2>&1 &
+
+    wait_for_server $PREFILL_PORT "Phase B prefill" "$LOG_DIR/phaseB_prefill.log" || return 1
+    wait_for_server $DECODE_PORT  "Phase B decode"  "$LOG_DIR/phaseB_decode.log"  || return 1
+
+    start_proxy "$LOG_DIR/phaseB_proxy.log"
+
+    local i=0
+    for p in "${PROMPTS[@]}"; do
+        if send_and_capture "$p" "$LOG_DIR/phaseB_${i}.txt"; then
+            log_pass "Phase B prompt $i captured"
+        else
+            log_fail "Phase B prompt $i failed"
+            return 1
+        fi
+        i=$((i + 1))
+    done
+
+    cleanup
+    sleep 5
+}
+
+# -----------------------------------------------------------------------------
+# Phase C: comparisons
+# -----------------------------------------------------------------------------
+phaseC_compare() {
+    log_info "========== PHASE C: equivalence + layout checks =========="
+
+    local mismatches=0
+    local i=0
+    for p in "${PROMPTS[@]}"; do
+        if diff -q "$LOG_DIR/phaseA_${i}.txt" "$LOG_DIR/phaseB_${i}.txt" > /dev/null; then
+            log_pass "Prompt $i: outputs match"
+        else
+            log_fail "Prompt $i: outputs diverge"
+            echo "  A: $(cat "$LOG_DIR/phaseA_${i}.txt")"
+            echo "  B: $(cat "$LOG_DIR/phaseB_${i}.txt")"
+            mismatches=$((mismatches + 1))
+        fi
+        i=$((i + 1))
+    done
+
+    log_info "--- Layout metadata comparison ---"
+    python3 "$SCRIPT_DIR/_compare_layout_dumps.py" \
+        "$LOG_DIR/phaseB_prefill.log" \
+        "$LOG_DIR/phaseB_decode.log" || mismatches=$((mismatches + 1))
+
+    if [ $mismatches -eq 0 ]; then
+        echo ""
+        echo "============================================================"
+        log_pass "EQUIVALENCE HARNESS PASSED"
+        echo "============================================================"
+        return 0
+    else
+        echo ""
+        echo "============================================================"
+        log_fail "EQUIVALENCE HARNESS FAILED ($mismatches mismatches)"
+        echo "============================================================"
+        return 1
+    fi
+}
+
+main() {
+    echo "============================================================"
+    echo " kvcached + NIXL PD disagg: Equivalence Harness"
+    echo " $(date)"
+    echo "============================================================"
+
+    phase0_setup || { log_fail "Setup failed"; exit 1; }
+    phaseA_baseline || { log_fail "Phase A failed"; exit 1; }
+    phaseB_kvcached || { log_fail "Phase B failed"; exit 1; }
+    phaseC_compare || exit 1
+}
+
+main "$@"

--- a/experiments/_compare_layout_dumps.py
+++ b/experiments/_compare_layout_dumps.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Compare KVCACHED_LAYOUT_DUMP / KVCACHED_BLOCK_SHA lines across the
+prefill and decode logs of the equivalence harness (experiments/09_equivalence.sh).
+
+Exits 0 on match, 1 on any mismatch.
+"""
+
+import json
+import re
+import sys
+from collections import defaultdict
+
+LAYOUT_RE = re.compile(r"KVCACHED_LAYOUT_DUMP=(\{.*\})\s*$")
+SHA_RE = re.compile(r"KVCACHED_BLOCK_SHA=(\{.*\})\s*$")
+
+# Per-layer fields that can legitimately differ across GPUs (pointer values).
+IGNORED_LAYER_FIELDS = {"data_ptr", "device"}
+
+
+def parse_log(path):
+    layouts = defaultdict(list)  # tag -> [payload...]
+    shas = defaultdict(list)     # (tag, layer, block) -> [sha...]
+    with open(path) as f:
+        for line in f:
+            m = LAYOUT_RE.search(line)
+            if m:
+                try:
+                    p = json.loads(m.group(1))
+                    layouts[p["tag"]].append(p)
+                except Exception:
+                    pass
+                continue
+            m = SHA_RE.search(line)
+            if m:
+                try:
+                    p = json.loads(m.group(1))
+                    shas[(p["tag"], p["layer"], p["block"])].append(p["sha256"])
+                except Exception:
+                    pass
+    return layouts, shas
+
+
+def _strip_ignored(layer_entry):
+    return {k: v for k, v in layer_entry.items() if k not in IGNORED_LAYER_FIELDS}
+
+
+def compare_layouts(a_payload, b_payload, tag, side_a, side_b):
+    issues = []
+    if a_payload["num_layers"] != b_payload["num_layers"]:
+        issues.append(
+            f"[{tag}] num_layers differs: {side_a}={a_payload['num_layers']} vs {side_b}={b_payload['num_layers']}"
+        )
+    if a_payload.get("blocks_dim_idx") != b_payload.get("blocks_dim_idx"):
+        issues.append(
+            f"[{tag}] blocks_dim_idx differs: {side_a}={a_payload.get('blocks_dim_idx')} vs {side_b}={b_payload.get('blocks_dim_idx')}"
+        )
+    for al, bl in zip(a_payload["layers"], b_payload["layers"]):
+        if _strip_ignored(al) != _strip_ignored(bl):
+            issues.append(
+                f"[{tag}] layer {al.get('layer')} metadata differs: {side_a}={_strip_ignored(al)} vs {side_b}={_strip_ignored(bl)}"
+            )
+    a_extra = a_payload.get("extra", {})
+    b_extra = b_payload.get("extra", {})
+    for k in set(a_extra) | set(b_extra):
+        if a_extra.get(k) != b_extra.get(k):
+            issues.append(
+                f"[{tag}] extra.{k} differs: {side_a}={a_extra.get(k)} vs {side_b}={b_extra.get(k)}"
+            )
+    return issues
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: _compare_layout_dumps.py <prefill_log> <decode_log>", file=sys.stderr)
+        return 2
+    prefill_log, decode_log = sys.argv[1], sys.argv[2]
+
+    p_layouts, p_shas = parse_log(prefill_log)
+    d_layouts, d_shas = parse_log(decode_log)
+
+    if not p_layouts:
+        print(f"FAIL: no KVCACHED_LAYOUT_DUMP lines in {prefill_log}")
+        print("      (is KVCACHED_DUMP_LAYOUT=1 set on the vllm serve invocation?)")
+        return 1
+    if not d_layouts:
+        print(f"FAIL: no KVCACHED_LAYOUT_DUMP lines in {decode_log}")
+        return 1
+
+    all_issues = []
+    for tag in sorted(set(p_layouts) | set(d_layouts)):
+        p_entries = p_layouts.get(tag, [])
+        d_entries = d_layouts.get(tag, [])
+        if not p_entries:
+            all_issues.append(f"[{tag}] missing from prefill log")
+            continue
+        if not d_entries:
+            all_issues.append(f"[{tag}] missing from decode log")
+            continue
+        # Compare the first occurrence on each side.
+        all_issues.extend(compare_layouts(p_entries[0], d_entries[0], tag, "prefill", "decode"))
+
+    # SHA comparison: for tags present in both logs at the same (tag, layer, block),
+    # every prefill SHA must have a matching decode SHA.
+    common_keys = set(p_shas) & set(d_shas)
+    if not common_keys:
+        print("INFO: no (tag, layer, block) SHA entries overlap between prefill and decode")
+    for key in sorted(common_keys):
+        tag, layer, block = key
+        # Compare the set of distinct observed SHAs. One side may poll a hook
+        # more times than the other, which is fine as long as the set of
+        # byte-states seen on each side agrees.
+        pa, da = set(p_shas[key]), set(d_shas[key])
+        if pa != da:
+            all_issues.append(
+                f"[{tag}] layer {layer} block {block} SHA set differs: "
+                f"prefill_only={sorted(pa - da)} decode_only={sorted(da - pa)}"
+            )
+
+    if all_issues:
+        print("FAIL: layout/SHA mismatches:")
+        for issue in all_issues:
+            print(f"  - {issue}")
+        return 1
+
+    print(f"PASS: {len(p_layouts)} tag(s) compared, {len(common_keys)} SHA key(s) matched")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kvcached/integration/vllm/autopatch.py
+++ b/kvcached/integration/vllm/autopatch.py
@@ -7,6 +7,7 @@ import types
 from wrapt.importer import when_imported
 
 from kvcached.integration.patch_base import PatchManager, log_patch_results
+from kvcached.integration.patch_base import enable_kvcached
 from kvcached.integration.vllm.patches import (
     VLLM_ALL_RANGE,
     VLLM_V8_RANGE,
@@ -50,5 +51,168 @@ def _patch_vllm(_vllm: types.ModuleType) -> None:
     # Apply all patches
     results = patch_manager.apply_all_patches()
 
+    # Patch NixlConnector for kvcached compatibility (two bugs).
+    # Done eagerly here because get_required_kvcache_layout() is a classmethod
+    # called during create_engine_config(), before deferred module patches fire.
+    _patch_nixl_connector()
+
     # Log results
     log_patch_results("vllm", results)
+
+
+def _patch_nixl_connector() -> None:
+    """Patch NixlConnector for kvcached PD disaggregation compatibility.
+
+    Bug 1: NixlConnector asserts tensor shape[0] == num_blocks. kvcached's
+    tensors have a larger blocks dimension (virtual capacity vs physical budget).
+    Fix: set num_blocks to match the tensor's blocks dimension before the
+    assertion runs.
+
+    Bug 2: NixlConnector forces HND layout, but kvcached's from_blob tensors
+    don't support set_stride (needed for NHD->HND permutation).
+    Fix: override get_required_kvcache_layout() to return None (use NHD).
+    """
+    try:
+        from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
+            NixlConnector,
+            NixlConnectorWorker,
+        )
+    except ImportError:
+        return  # NIXL not installed
+
+    # Bug 2: force NHD layout
+    @classmethod  # type: ignore[misc]
+    def _kvcached_layout(cls, *args, **kwargs):
+        if not enable_kvcached():
+            return NixlConnector._original_get_layout(*args, **kwargs)
+        logger.info("kvcached: NixlConnector layout overridden to NHD")
+        return None
+
+    NixlConnector._original_get_layout = NixlConnector.get_required_kvcache_layout
+    NixlConnector.get_required_kvcache_layout = _kvcached_layout
+
+    # Bug 1: relax block count assertion
+    _original_register = NixlConnectorWorker.register_kv_caches
+
+    def _patched_register(self, kv_caches, *args, **kwargs):
+        if not enable_kvcached():
+            return _original_register(self, kv_caches, *args, **kwargs)
+
+        from kvcached.integration.vllm.interfaces import _num_blocks_per_layer
+        num_blocks_before = self.num_blocks
+        if _num_blocks_per_layer > self.num_blocks:
+            logger.info(
+                "kvcached: NixlConnector num_blocks %d -> %d",
+                self.num_blocks, _num_blocks_per_layer,
+            )
+            self.num_blocks = _num_blocks_per_layer
+
+        from kvcached.integration.vllm.debug_layout import dump_kv_layout
+        tensors_for_dump = list(kv_caches.values()) if hasattr(kv_caches, "values") else list(kv_caches)
+        dump_kv_layout(
+            tag="nixl_register_pre",
+            kv_tensors=tensors_for_dump,
+            extra={
+                "num_blocks_before": num_blocks_before,
+                "num_blocks_after": self.num_blocks,
+            },
+        )
+        self._kvcached_kv_caches = tensors_for_dump
+        result = _original_register(self, kv_caches, *args, **kwargs)
+        dump_kv_layout(
+            tag="nixl_register_post",
+            kv_tensors=tensors_for_dump,
+            blocks_dim_idx=_guess_blocks_dim_idx(tensors_for_dump),
+            extra={"num_blocks_after": self.num_blocks},
+            sha_blocks=(0, 2),
+        )
+        return result
+
+    NixlConnectorWorker.register_kv_caches = _patched_register
+
+    _wrap_nixl_lifecycle_hooks(NixlConnectorWorker)
+
+    logger.info("Patched NixlConnector for kvcached PD disagg compatibility")
+
+
+def _guess_blocks_dim_idx(kv_tensors) -> int:
+    """Best-effort recovery of blocks_dim_idx from tensor shape.
+
+    Mirrors the logic in interfaces.alloc_kv_cache: FlashAttn puts K/V
+    count at dim 0 (blocks at dim 1); FlashInfer/MLA puts blocks at dim 0.
+    """
+    if not kv_tensors:
+        return 0
+    shape = list(kv_tensors[0].shape)
+    # FlashAttn: first dim is 2 (or 1 for MLA K/V-combined) and small.
+    if len(shape) >= 2 and shape[0] <= 2:
+        return 1
+    return 0
+
+
+def _wrap_nixl_lifecycle_hooks(worker_cls) -> None:
+    """Introspect NixlConnectorWorker and wrap known lifecycle methods
+    with content-SHA dumps. Gated at runtime on KVCACHED_DUMP_LAYOUT=1.
+
+    We don't know which methods exist on every vLLM version, so we log
+    the full list of save/recv/load/send/wait/start/finish methods
+    we find, then wrap each with a generic around-hook that logs SHAs
+    of layer-0 block 0 and block 1 at entry and exit. Runtime logs then
+    reveal which hooks fired for prefill vs decode.
+    """
+    import json as _json
+
+    # get_finished is excluded: it's polled every scheduler tick and would
+    # spam hundreds of redundant SHA lines per request.
+    candidate_patterns = (
+        "save_kv_layer",
+        "save_kv_caches",
+        "send_kv_caches",
+        "recv_kv_caches",
+        "load_kv_caches",
+        "start_load_kv",
+        "wait_for_save",
+        "wait_for_load",
+    )
+
+    found = sorted(
+        name for name in dir(worker_cls)
+        if any(pat in name for pat in candidate_patterns)
+        and callable(getattr(worker_cls, name, None))
+        and not name.startswith("_")
+    )
+    logger.info("KVCACHED_NIXL_INTROSPECT=%s", _json.dumps({"methods": found}))
+
+    for name in found:
+        _install_content_hook(worker_cls, name)
+
+
+def _install_content_hook(worker_cls, method_name: str) -> None:
+    original = getattr(worker_cls, method_name)
+
+    def _hooked(self, *args, **kwargs):
+        from kvcached.integration.vllm.debug_layout import (
+            _enabled, dump_active_blocks_sha,
+        )
+        kv_tensors = getattr(self, "_kvcached_kv_caches", None)
+        if _enabled() and kv_tensors:
+            blocks_dim_idx = _guess_blocks_dim_idx(kv_tensors)
+            dump_active_blocks_sha(
+                tag=f"{method_name}_enter",
+                kv_tensors=kv_tensors,
+                blocks_dim_idx=blocks_dim_idx,
+                block_ids=(0, 1),
+            )
+        result = original(self, *args, **kwargs)
+        if _enabled() and kv_tensors:
+            blocks_dim_idx = _guess_blocks_dim_idx(kv_tensors)
+            dump_active_blocks_sha(
+                tag=f"{method_name}_exit",
+                kv_tensors=kv_tensors,
+                blocks_dim_idx=blocks_dim_idx,
+                block_ids=(0, 1),
+            )
+        return result
+
+    _hooked.__name__ = method_name
+    setattr(worker_cls, method_name, _hooked)

--- a/kvcached/integration/vllm/debug_layout.py
+++ b/kvcached/integration/vllm/debug_layout.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""KV tensor layout dump + per-block SHA helpers.
+
+No-op unless KVCACHED_DUMP_LAYOUT=1. Emits tagged JSON log lines so the
+validation harness can grep both prefill and decode logs and compare.
+"""
+
+import hashlib
+import json
+import os
+from typing import Iterable, Optional, Sequence, Tuple
+
+import torch
+
+from kvcached.utils import get_kvcached_logger
+
+logger = get_kvcached_logger()
+
+_LAYOUT_TAG = "KVCACHED_LAYOUT_DUMP"
+_BLOCK_SHA_TAG = "KVCACHED_BLOCK_SHA"
+
+
+def _enabled() -> bool:
+    return os.getenv("KVCACHED_DUMP_LAYOUT", "0").lower() in ("1", "true", "yes")
+
+
+def _sha_block(t: torch.Tensor, blocks_dim_idx: int, block_idx: int) -> str:
+    idx: list = [slice(None)] * t.ndim
+    idx[blocks_dim_idx] = block_idx
+    block = t[tuple(idx)].contiguous()
+    u8 = block.view(torch.uint8)
+    return hashlib.sha256(u8.cpu().numpy().tobytes()).hexdigest()
+
+
+def dump_kv_layout(
+    *,
+    tag: str,
+    kv_tensors: Sequence[torch.Tensor],
+    blocks_dim_idx: Optional[int] = None,
+    extra: Optional[dict] = None,
+    sha_blocks: Optional[Tuple[int, int]] = None,
+) -> None:
+    if not _enabled():
+        return
+
+    tensors = list(kv_tensors)
+    if not tensors:
+        return
+
+    layers = []
+    for i, t in enumerate(tensors):
+        layers.append({
+            "layer": i,
+            "shape": list(t.shape),
+            "stride": list(t.stride()),
+            "dtype": str(t.dtype).replace("torch.", ""),
+            "device": str(t.device),
+            "data_ptr": hex(t.data_ptr()),
+        })
+
+    payload = {
+        "tag": tag,
+        "pid": os.getpid(),
+        "num_layers": len(tensors),
+        "blocks_dim_idx": blocks_dim_idx,
+        "layers": layers,
+    }
+    if extra is not None:
+        payload["extra"] = extra
+
+    logger.info("%s=%s", _LAYOUT_TAG, json.dumps(payload, sort_keys=True))
+
+    if sha_blocks is not None and blocks_dim_idx is not None:
+        start, end = sha_blocks
+        for b in range(start, end):
+            try:
+                sha = _sha_block(tensors[0], blocks_dim_idx, b)
+            except Exception as e:
+                logger.warning("kvcached dump: block %d SHA failed: %s", b, e)
+                continue
+            logger.info(
+                "%s=%s",
+                _BLOCK_SHA_TAG,
+                json.dumps({
+                    "tag": tag,
+                    "pid": os.getpid(),
+                    "layer": 0,
+                    "block": b,
+                    "sha256": sha,
+                }),
+            )
+
+
+def dump_active_blocks_sha(
+    *,
+    tag: str,
+    kv_tensors: Sequence[torch.Tensor],
+    blocks_dim_idx: int,
+    block_ids: Iterable[int],
+    layer: int = 0,
+) -> None:
+    if not _enabled():
+        return
+    tensors = list(kv_tensors)
+    if not tensors or layer >= len(tensors):
+        return
+    t = tensors[layer]
+    for b in block_ids:
+        try:
+            sha = _sha_block(t, blocks_dim_idx, b)
+        except Exception as e:
+            logger.warning("kvcached dump: block %d SHA failed: %s", b, e)
+            continue
+        logger.info(
+            "%s=%s",
+            _BLOCK_SHA_TAG,
+            json.dumps({
+                "tag": tag,
+                "pid": os.getpid(),
+                "layer": layer,
+                "block": b,
+                "sha256": sha,
+            }),
+        )

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -24,6 +24,7 @@ _world_size: int = 1
 _pp_rank: int = 0
 _contiguous_layout: bool = CONTIGUOUS_LAYOUT
 _is_worker: bool = False
+_num_blocks_per_layer: int = 0
 
 
 def should_use_worker_ipc() -> bool:
@@ -203,7 +204,9 @@ def alloc_kv_cache(
     # round down to page size
     gpu_mem_bytes_per_layer_k_or_v = (gpu_mem_bytes_per_layer_k_or_v // PAGE_SIZE) * PAGE_SIZE
 
+    global _num_blocks_per_layer
     num_blocks_per_layer = gpu_mem_bytes_per_layer_k_or_v // block_mem_bytes
+    _num_blocks_per_layer = num_blocks_per_layer
     if requested_num_blocks > num_blocks_per_layer:
         logger.warning(
             f"Requested {requested_num_blocks} blocks, but only {num_blocks_per_layer} blocks are available."
@@ -293,6 +296,22 @@ def alloc_kv_cache(
         kv_tensors = [
             contiguous_tensor[:, i].permute(*permute_order) for i in range(num_layers)
         ]
+
+    from kvcached.integration.vllm.debug_layout import dump_kv_layout
+    dump_kv_layout(
+        tag="alloc",
+        kv_tensors=kv_tensors,
+        blocks_dim_idx=blocks_dim_idx,
+        extra={
+            "_num_blocks_per_layer": _num_blocks_per_layer,
+            "requested_num_blocks": requested_num_blocks,
+            "block_mem_bytes": block_mem_bytes,
+            "attention_type": attention_type,
+            "kv_layout": kv_layout,
+            "group_id": group_id,
+            "contiguous_layout": _contiguous_layout,
+        },
+    )
 
     if not unified_pool:
         return kv_tensors


### PR DESCRIPTION
## TL;DR

Two small bugs in vLLM's `NixlConnector` prevented kvcached from working under prefill/decode disaggregation. This PR patches both in `kvcached/integration/vllm/autopatch.py` and adds an equivalence-harness (`experiments/09_equivalence.sh`) that proves, on real hardware, that:

1. Greedy outputs are **byte-identical** with and without kvcached (same NIXL disagg setup).
2. Every piece of KV tensor metadata agrees across the prefill and decode GPUs (shape, stride, dtype, blocks-dim index, NIXL-registered region).
3. Post-register zero-page SHA fingerprints match across GPUs.

Validated on RunPod 2×A100 80GB SXM, Qwen2.5-1.5B-Instruct, vLLM 0.19.0.

---

## The bugs

### Bug 1: layout mismatch

`NixlConnector.get_required_kvcache_layout()` returns `"HND"`, which causes vLLM to call `set_stride()` on the KV tensor. kvcached allocates tensors via `torch.from_blob` on a CUDA VMM region, and those tensors don't support `set_stride()`. Result: crash at engine init before any inference runs.

### Bug 2: block-count assertion

`NixlConnectorWorker.register_kv_caches()` asserts `tensor.shape[blocks_dim] == self.num_blocks`. kvcached over-allocates a virtual address region so blocks can grow elastically, so the tensor's blocks dimension (`_num_blocks_per_layer`, e.g. 185344) is larger than vLLM's planned physical budget (`self.num_blocks`, e.g. 139694). The assertion fires and the connector refuses to register.

## The fix

In `kvcached/integration/vllm/autopatch.py`:

- **Bug 1**: override `NixlConnector.get_required_kvcache_layout` to return `None`, which signals vLLM to use NHD (kvcached's native layout). Only applied when `ENABLE_KVCACHED=true`; the original classmethod is preserved and restored otherwise.
- **Bug 2**: wrap `NixlConnectorWorker.register_kv_caches`: before calling the original, set `self.num_blocks = _num_blocks_per_layer` when the kvcached-side capacity is larger, so the assertion sees consistent values.

The patches are applied eagerly from `_patch_vllm()` because `get_required_kvcache_layout` is a classmethod consulted during `create_engine_config()`, which runs before deferred module patches fire.

---

## Validation harness

`experiments/09_equivalence.sh` is a self-contained two-phase harness:

| Phase | What it does | kvcached? |
|---|---|---|
| A | NIXL-disagg prefill + decode, 4 fixed prompts, greedy (`temperature=0`) | off |
| B | Same config as A, plus `KVCACHED_DUMP_LAYOUT=1` | on |
| C | Byte-diff outputs prompt-by-prompt and compare Phase B's prefill/decode layout dumps + block SHAs | n/a |

Env isolation: Phase A explicitly sets `ENABLE_KVCACHED=false`, `KVCACHED_AUTOPATCH=false`, `KVCACHED_DUMP_LAYOUT=0` so a stray `export` from the operator's shell cannot contaminate the baseline.

Layout dumps come from `kvcached/integration/vllm/debug_layout.py`, which emits tagged JSON log lines (`KVCACHED_LAYOUT_DUMP=…`, `KVCACHED_BLOCK_SHA=…`). `experiments/_compare_layout_dumps.py` parses those and exits non-zero on any mismatch.

---

## Results

Run on RunPod 2×A100 80GB SXM. vLLM 0.19.0, Qwen2.5-1.5B-Instruct, `max_model_len=1024`, `gpu_memory_utilization=0.8`.

### 1. Black-box output equivalence

All four prompts produce byte-identical greedy completions between Phase A (no kvcached) and Phase B (with kvcached).

| Prompt | Phase A (no kvcached) | Phase B (with kvcached) | Diff |
|---|---|---|---|
| `The capital of France is` | ` Paris. The capital of Italy is Rome. What is the capital of Spain?\nA) Madrid` | same | identical |
| `List three primary colors:` | ` red, blue, and green. Additionally, provide a brief explanation of how these colors are used in` | same | identical |
| `Two plus two equals` | ` four, but what if you have three apples and add one more? You still end up with four` | same | identical |
| `The first president of the United States was` | ` George Washington. He served from 1789 to 1797 and is often` | same | identical |

### 2. KV tensor metadata across GPUs

Every per-layer field matches between prefill (GPU 0) and decode (GPU 1). Source: `KVCACHED_LAYOUT_DUMP` entries in Phase B logs.

| Field | Prefill GPU | Decode GPU | Agree |
|---|---|---|---|
| dtype | `bfloat16` | `bfloat16` | yes |
| shape | `[2, 185344, 16, 2, 128]` | `[2, 185344, 16, 2, 128]` | yes |
| stride | `[4096, 229376, 256, 128, 1]` | `[4096, 229376, 256, 128, 1]` | yes |
| `blocks_dim_idx` | `1` (FlashAttn K/V-major) | `1` | yes |
| `num_layers` | 28 | 28 | yes |
| per-layer view size | 3.04 GB | 3.04 GB | yes |
| `layer_stride` | 16384 B | 16384 B | yes |

All 28 layers checked; agreement holds for every layer.

### 3. NIXL-registered virtual region

| | Prefill GPU | Decode GPU |
|---|---|---|
| base addr | `0x1f0000000000` | `0x1f0000000000` |
| total virtual allocation | 85.03 GB | 85.03 GB |
| layers interleaved | 28 | 28 |
| layer stride (bytes) | 16384 | 16384 |

kvcached's `contiguous_layout=True` packs all 28 layers into a single VMM allocation; per-layer views stride through the region by one block (16384 B for this model shape).

### 4. `num_blocks` patch activated

Log line confirming Bug 2's fix fired at runtime:

```
kvcached: NixlConnector num_blocks 139694 -> 185344
```

vLLM computed 139694 blocks for its planned budget; kvcached's virtual capacity is 185344. The patch overrides `self.num_blocks` so NIXL's assertion sees the tensor's actual blocks dimension.

### 5. Post-register zero-page SHA fingerprint

Before any prompt runs, kvcached hashes layer 0 block 0 and block 1 on both GPUs. Because kvcached's VMM allocation starts zero-filled, both sides see the same SHA, confirming that layout and stride interpretation agree at the byte level.

| Key | Prefill SHA (first 10 chars) | Decode SHA | Match |
|---|---|---|---|
| `nixl_register_post` L0 B0 | `4fe7b59af6…` | `4fe7b59af6…` | yes |
| `nixl_register_post` L0 B1 | `4fe7b59af6…` | `4fe7b59af6…` | yes |

### 6. NixlConnectorWorker lifecycle introspection

The harness discovers and wraps `NixlConnectorWorker` lifecycle methods automatically. On vLLM 0.19.0, the discovered methods (logged as `KVCACHED_NIXL_INTROSPECT=…`) were:

- `start_load_kv`: wrapped with entry/exit content SHA
- `get_finished`: **excluded** (polled every scheduler tick, would spam logs)

The `start_load_kv` wrapper fires ~88 times per decode-side request; SHAs at layer 0 block 0/1 are consistent across calls (those blocks are untouched by the scheduler's request-specific allocation, so the zero-page fingerprint persists).

### 7. Harness final output

```
[PASS] Phase A prompt 0 captured
[PASS] Phase A prompt 1 captured
[PASS] Phase A prompt 2 captured
[PASS] Phase A prompt 3 captured
[PASS] Phase B prompt 0 captured
[PASS] Phase B prompt 1 captured
[PASS] Phase B prompt 2 captured
[PASS] Phase B prompt 3 captured
[PASS] Prompt 0: outputs match
[PASS] Prompt 1: outputs match
[PASS] Prompt 2: outputs match
[PASS] Prompt 3: outputs match
PASS: 3 tag(s) compared, 6 SHA key(s) matched

============================================================
[PASS] EQUIVALENCE HARNESS PASSED
============================================================
```

---

## How to reproduce

Fresh 2×A100 node:

```
git clone https://github.com/AAbouzeid/kvcached.git
cd kvcached
git checkout fix/pd-disagg-nixl-connector
chmod +x experiments/09_equivalence.sh
./experiments/09_equivalence.sh
```

Phase 0 inside the script installs vLLM, NIXL, aiohttp, and kvcached, and downloads the model. First run is ~10 min (mostly install + model download). Logs land in `experiments/logs_eq/`.

Negative control (to confirm the harness actually catches divergence): comment out the `NixlConnector.get_required_kvcache_layout = _kvcached_layout` line in `kvcached/integration/vllm/autopatch.py` and rerun. The harness should fail.
