### PR TITLE
chore: remove dead contiguous-layout code path from HYBRID_LINEAR mamba reshape

### DIFF
--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -115,14 +115,12 @@ def alloc_kv_cache(
         List[torch.Tensor] for MHA/GQA/MLA.
         For HYBRID_LINEAR, returns (kv_tensors, raw_info) where
         raw_info is a dict with:
-          buffers            - flat int8 tensors (one per pool when
-                               non-contiguous, single base when contiguous)
+          buffers            - flat int8 tensors, one per pool
           num_blocks         - number of blocks per pool
           page_size_bytes    - uniform page size (bytes) shared by all groups
           block_stride_bytes - byte stride between consecutive blocks of the
                                same pool
           num_pools          - number of pools (== num_layers)
-          is_contiguous      - whether contiguous layout is used
     """
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
@@ -282,10 +280,6 @@ def alloc_kv_cache(
                 kv_tensors.append(
                     torch.as_strided(t.view(dtype=dtype), shape, strides))
     else:
-        if ratio > 1:
-            raise NotImplementedError(
-                "Contiguous layout with kernel_block_size != block_size "
-                "is not supported yet.")
         layer_elem_shape = actual_kvcache_shape[:blocks_dim_idx] + actual_kvcache_shape[blocks_dim_idx + 1:]
         contiguous_shape = [num_blocks_per_layer, num_layers] + layer_elem_shape
         num_eles = math.prod(contiguous_shape)
@@ -298,21 +292,15 @@ def alloc_kv_cache(
         return kv_tensors
 
     # --- Build raw int8 buffers for hybrid model (mamba) support ---
-    if not _contiguous_layout:
-        pool_bytes = num_blocks_per_layer * page_size_bytes
-        raw_int8 = [t.view(torch.int8)[:pool_bytes] for t in raw_kv_tensors]
-        block_stride_bytes = page_size_bytes
-    else:
-        raw_int8 = [raw_kv_tensors[0].view(torch.int8)]
-        block_stride_bytes = num_layers * page_size_bytes
+    pool_bytes = num_blocks_per_layer * page_size_bytes
+    raw_int8 = [t.view(torch.int8)[:pool_bytes] for t in raw_kv_tensors]
 
     raw_info = {
         "buffers": raw_int8,
         "num_blocks": num_blocks_per_layer,
         "page_size_bytes": page_size_bytes,
-        "block_stride_bytes": block_stride_bytes,
+        "block_stride_bytes": page_size_bytes,
         "num_pools": num_layers,
-        "is_contiguous": _contiguous_layout,
     }
     return kv_tensors, raw_info  # type: ignore[return-value]
 

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -194,45 +194,6 @@ def _reshape_mamba_non_contiguous(
     return state_tensors
 
 
-def _reshape_mamba_contiguous(
-    mamba_info: dict, kv_cache_spec: Any, pool_idx: int, get_dtype_size: Any,
-) -> list:
-    """Create strided mamba state views from a contiguous interleaved buffer.
-
-    In contiguous layout, block N for pool L sits at byte offset
-    ``(N * num_pools + L) * page_size_bytes`` inside the single base
-    buffer.  The inter-block stride is therefore
-    ``num_pools * page_size_bytes`` bytes, not ``page_size_bytes``.
-    """
-    import torch
-
-    base_buffer = mamba_info["buffers"][0]  # flat int8 buffer
-    num_blocks = mamba_info["num_blocks"]
-    page_size_bytes = mamba_info["page_size_bytes"]
-    block_stride_bytes = mamba_info["block_stride_bytes"]
-
-    layer_offset_bytes = pool_idx * page_size_bytes
-
-    state_tensors: list = []
-    inner_offset_bytes = 0
-    for shape, dtype in zip(kv_cache_spec.shapes, kv_cache_spec.dtypes):
-        dtype_size = get_dtype_size(dtype)
-        block_stride_elems = block_stride_bytes // dtype_size
-        target_shape = (num_blocks, *shape)
-        inner_stride = torch.empty(target_shape).stride()
-        target_stride = (block_stride_elems, *inner_stride[1:])
-        storage_offset = (layer_offset_bytes + inner_offset_bytes) // dtype_size
-        tensor = torch.as_strided(
-            base_buffer.view(dtype),
-            size=target_shape,
-            stride=target_stride,
-            storage_offset=storage_offset,
-        )
-        state_tensors.append(tensor)
-        inner_offset_bytes += inner_stride[0] * dtype_size
-    return state_tensors
-
-
 # Version ranges for vLLM support
 VLLM_V8_RANGE = ">=0.8.4,<0.9.0"  # vLLM 0.8.x versions, need to cover 0.8.5.post1
 VLLM_V9_PLUS_RANGE = ">=0.9.0"  # vLLM 0.9.x and 0.9+.x versions
@@ -1263,15 +1224,10 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                             "available from kvcached"
                         )
                     for pool_idx, layer_name in enumerate(kv_cache_group.layer_names):
-                        if mamba_info["is_contiguous"]:
-                            state_tensors = _reshape_mamba_contiguous(
-                                mamba_info, kv_cache_spec, pool_idx, get_dtype_size,
-                            )
-                        else:
-                            state_tensors = _reshape_mamba_non_contiguous(
-                                mamba_info["buffers"][pool_idx],
-                                kv_cache_spec, get_dtype_size,
-                            )
+                        state_tensors = _reshape_mamba_non_contiguous(
+                            mamba_info["buffers"][pool_idx],
+                            kv_cache_spec, get_dtype_size,
+                        )
                         kv_caches[layer_name] = state_tensors  # type: ignore[assignment]
                 else:
                     for pool_idx, layer_name in enumerate(kv_cache_group.layer_names):


### PR DESCRIPTION
As title.

The kvcached contiguous layout is incompatible with vllm hybrid linear attention.