### PR TITLE
fix: honor ENABLE_KVCACHED in autopatch enable check

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,18 @@ The documentation covers:
 
 ## Testing
 
-kvcached can be enabled by setting the following environmental variables:
+kvcached can be enabled by setting `ENABLE_KVCACHED` either in the shell:
 
 ```bash
 export ENABLE_KVCACHED=true
-export KVCACHED_AUTOPATCH=1
+```
+
+or from Python script (before `import vllm` / `import sglang`):
+
+```python
+import os
+os.environ["ENABLE_KVCACHED"] = "true"
+from kvcached import autopatch  # required when setting from Python;
 ```
 
 If you are using the engine-specific dockers, you can test kvcached by running the original engines' benchmark scripts. For example:

--- a/kvcached/integration/sglang/autopatch.py
+++ b/kvcached/integration/sglang/autopatch.py
@@ -23,7 +23,10 @@ logger = get_kvcached_logger()
 
 
 def _env_enabled() -> bool:
-    return os.getenv("KVCACHED_AUTOPATCH", "false").lower() in ("true", "1")
+    return (
+        os.getenv("ENABLE_KVCACHED", "false").lower() in ("true", "1")
+        or os.getenv("KVCACHED_AUTOPATCH", "false").lower() in ("true", "1")
+    )
 
 
 @when_imported("sglang")

--- a/kvcached/integration/vllm/autopatch.py
+++ b/kvcached/integration/vllm/autopatch.py
@@ -24,7 +24,10 @@ logger = get_kvcached_logger()
 
 
 def _env_enabled() -> bool:
-    return os.getenv("KVCACHED_AUTOPATCH", "false").lower() in ("true", "1")
+    return (
+        os.getenv("ENABLE_KVCACHED", "false").lower() in ("true", "1")
+        or os.getenv("KVCACHED_AUTOPATCH", "false").lower() in ("true", "1")
+    )
 
 
 @when_imported("vllm")


### PR DESCRIPTION
To solve the issue https://github.com/ovg-project/kvcached/issues/320, https://github.com/ovg-project/kvcached/issues/317 and https://github.com/ovg-project/kvcached/issues/316, by setting kvcached using unified arg `ENABLE_KVCACHED`.