### PR TITLE
[feature]add gpu memory management

### DIFF
--- a/docs/03_kvcache_management_api.md
+++ b/docs/03_kvcache_management_api.md
@@ -1,0 +1,422 @@
+# kvcached KV Cache 管理 API 接口文档
+
+## 1. 概述
+
+kvcached 通过 autopatch 机制，将 KV Cache 显存管理接口**直接注入到 vLLM 和 SGLang 的 HTTP 服务中**。用户无需部署额外的管理服务，直接通过推理框架自身的端口即可查询和管理 KV Cache 显存。
+
+**适用引擎：** vLLM (>=0.8.4) 和 SGLang (>=0.4.9)
+
+**前置条件：**
+```bash
+export ENABLE_KVCACHED=true
+export KVCACHED_AUTOPATCH=1
+# 使用 vllm serve 启动（不要用 python -m vllm.entrypoints.openai.api_server）
+vllm serve MODEL_NAME --port 8000
+```
+
+**注意事项：**
+- vLLM 必须使用 `vllm serve` 命令启动，不能用 `python -m vllm.entrypoints.openai.api_server` 直接启动
+- SGLang 使用 `python -m sglang.launch_server` 启动即可
+- 所有接口在 vLLM 和 SGLang 上行为完全一致
+
+---
+
+## 2. 接口列表
+
+| 端点 | 方法 | 作用 |
+|------|------|------|
+| `/kvcache/status` | GET | 查询 KV Cache 显存使用状态 |
+| `/kvcache/limit` | POST | 设置绝对 KV Cache 显存限制 |
+| `/kvcache/limit_percent` | POST | 按 GPU 总显存百分比设置限制 |
+| `/kvcache/trim` | POST | 强制释放空闲显存（含 prefix cache 驱逐） |
+| `/kvcache/safety_floor` | GET | 查询安全门限配置 |
+
+---
+
+## 3. 安全门限机制
+
+所有设置限制的接口都有安全门限保护，防止将 KV Cache 设置过低导致模型无法推理。
+
+### 3.1 自动计算
+
+安全门限根据模型参数自动计算，公式为：
+
+```
+min_safe_limit = num_layers × num_kv_buffers × page_size × MIN_SAFE_PAGES_PER_LAYER
+```
+
+| 参数 | 来源 | 说明 |
+|------|------|------|
+| `num_layers` | 模型自动检测 | 模型的 Transformer 层数 |
+| `num_kv_buffers` | 注意力类型自动检测 | MHA/GQA=2（K+V），MLA=1 |
+| `page_size` | 环境变量 `KVCACHED_PAGE_SIZE_MB` | 默认 2MB |
+| `MIN_SAFE_PAGES_PER_LAYER` | 环境变量 `KVCACHED_MIN_SAFE_PAGES_PER_LAYER` | 默认 2 |
+
+**不同模型的自动门限示例：**
+
+| 模型 | 层数 | KV Buffers | 自动门限 |
+|------|------|-----------|----------|
+| Qwen3-1.7B | 28 | 2 (MHA) | 28 × 2 × 2MB × 2 = **224 MB** |
+| Llama-3.1-8B | 32 | 2 (MHA) | 32 × 2 × 2MB × 2 = **256 MB** |
+| Llama-3.1-70B | 80 | 2 (MHA) | 80 × 2 × 2MB × 2 = **640 MB** |
+| DeepSeek-V3 | 61 | 1 (MLA) | 61 × 1 × 2MB × 2 = **244 MB** |
+
+### 3.2 三级保护
+
+| 级别 | 值 | 说明 |
+|------|------|------|
+| 模型自适应门限 | 自动计算 | 默认生效，基于模型参数 |
+| 静态兜底值 | 512MB 或 GPU 2%（取较大值） | 共享内存不可用时的兜底 |
+| 硬性最低值 | 64MB | 即使 `force=true` 也不能低于此值 |
+
+### 3.3 绕过安全门限
+
+在 `/kvcache/limit`、`/kvcache/limit_percent`、`/kvcache/trim` 的请求 body 中传入 `"force": true` 可以绕过模型自适应门限和静态兜底值，但仍受 64MB 硬性最低值约束。
+
+---
+
+## 4. 接口详细说明
+
+### 4.1 GET /kvcache/status
+
+查询当前实例的 KV Cache 显存使用状态。
+
+**请求：**
+```bash
+curl http://localhost:8000/kvcache/status
+```
+
+**响应示例：**
+```json
+{
+  "self_ipc_name": "kvcached_vLLM_12345",
+  "segments": [
+    {
+      "ipc_name": "kvcached_vLLM_12345",
+      "total_size": 10485760000,
+      "total_size_human": "9.77 GB",
+      "used_size": 2684354560,
+      "used_size_human": "2.50 GB",
+      "prealloc_size": 314572800,
+      "prealloc_size_human": "300.00 MB",
+      "free_size": 7486832640,
+      "free_size_human": "6.97 GB",
+      "usage_percent": 25.6,
+      "physical_occupied": 2998927360,
+      "physical_occupied_human": "2.79 GB",
+      "min_effective_limit": 2684354560,
+      "min_effective_limit_human": "2.50 GB",
+      "min_safe_limit": 234881024,
+      "min_safe_limit_human": "224.00 MB",
+      "safety_floor": 234881024,
+      "safety_floor_human": "224.00 MB"
+    }
+  ],
+  "gpu_total_memory": 25252929536,
+  "gpu_total_memory_human": "23.52 GB",
+  "gpu_free_memory": 14557184000,
+  "gpu_free_memory_human": "13.55 GB"
+}
+```
+
+**响应字段说明：**
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `total_size` | int | 当前 KV Cache 显存上限（字节） |
+| `used_size` | int | 正在被推理请求使用的显存（字节） |
+| `prealloc_size` | int | 预分配页（reserved pages）占用的显存 |
+| `free_size` | int | 可分配空间 = total - used - prealloc |
+| `usage_percent` | float | 使用率百分比 |
+| `physical_occupied` | int | 实际占用的 GPU 物理显存 = used + prealloc |
+| `min_effective_limit` | int | 可立即生效的最小 limit 值（= used_size） |
+| `min_safe_limit` | int | 模型自动计算的安全门限（字节） |
+| `safety_floor` | int | 当前生效的安全门限（综合模型计算值和兜底值） |
+| `gpu_total_memory` | int | GPU 总显存 |
+| `gpu_free_memory` | int | GPU 当前空闲显存 |
+
+**关键指标解读：**
+- `min_effective_limit`：设置 limit >= 此值可立即生效；< 此值进入 shrink mode
+- `min_safe_limit`：安全门限，limit 不能低于此值（除非 force=true）
+- `physical_occupied`：实际占用的 GPU 物理显存，其他实例可用空间 = gpu_total - 所有实例的 physical_occupied 之和
+
+### 4.2 POST /kvcache/limit
+
+设置绝对 KV Cache 显存限制。
+
+**请求：**
+```bash
+# 设置为 3G
+curl -X POST http://localhost:8000/kvcache/limit \
+  -H "Content-Type: application/json" \
+  -d '{"size": "3G"}'
+
+# 设置精确字节数
+curl -X POST http://localhost:8000/kvcache/limit \
+  -H "Content-Type: application/json" \
+  -d '{"size_bytes": 3221225472}'
+
+# 强制设置（绕过安全门限，最低 64MB）
+curl -X POST http://localhost:8000/kvcache/limit \
+  -H "Content-Type: application/json" \
+  -d '{"size": "100M", "force": true}'
+```
+
+**请求参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `size` | string | 二选一 | 人类可读的大小，如 `"3G"`、`"512M"`、`"1.5G"` |
+| `size_bytes` | int | 二选一 | 精确字节数 |
+| `ipc_name` | string | 否 | 目标 IPC 段名称，默认为当前实例 |
+| `force` | bool | 否 | 是否绕过安全门限（默认 false） |
+
+**响应示例：**
+```json
+{
+  "ipc_name": "kvcached_vLLM_12345",
+  "success": true,
+  "previous_total_size": 10485760000,
+  "previous_total_size_human": "9.77 GB",
+  "new_total_size": 3221225472,
+  "new_total_size_human": "3.00 GB",
+  "current_used_size": 2684354560,
+  "current_used_size_human": "2.50 GB",
+  "immediate_reclaim": true,
+  "safety_floor": 234881024,
+  "safety_floor_human": "224.00 MB",
+  "clamped": false,
+  "message": "Limit updated 9.77 GB -> 3.00 GB. Free pages will be reclaimed immediately."
+}
+```
+
+**生效行为：**
+- `immediate_reclaim: true`：新 limit > used_size，空闲页立即释放
+- `immediate_reclaim: false`：新 limit < used_size，进入 shrink mode，等请求完成后逐步回收
+- `clamped: true`：请求值低于安全门限，被自动上调
+
+### 4.3 POST /kvcache/limit_percent
+
+按 GPU 总显存百分比设置 KV Cache 限制。
+
+**请求：**
+```bash
+# 设置为 GPU 总显存的 20%
+curl -X POST http://localhost:8000/kvcache/limit_percent \
+  -H "Content-Type: application/json" \
+  -d '{"percent": 20}'
+```
+
+**请求参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `percent` | float | 是 | GPU 总显存的百分比（0-100） |
+| `ipc_name` | string | 否 | 目标 IPC 段名称 |
+| `force` | bool | 否 | 是否绕过安全门限 |
+
+**响应：** 与 `/kvcache/limit` 相同，额外包含 `gpu_total_memory` 和 `percent` 字段。
+
+### 4.4 POST /kvcache/trim
+
+强制释放空闲显存。将 KV Cache 限制压缩到当前实际使用量，释放所有预分配页和空闲页。
+
+**请求：**
+```bash
+# 默认 trim：释放到当前使用量
+curl -X POST http://localhost:8000/kvcache/trim
+
+# 指定目标值
+curl -X POST http://localhost:8000/kvcache/trim \
+  -H "Content-Type: application/json" \
+  -d '{"target": "1G"}'
+
+# 强制 trim 到最低
+curl -X POST http://localhost:8000/kvcache/trim \
+  -H "Content-Type: application/json" \
+  -d '{"target": "0", "force": true}'
+```
+
+**请求参数：**
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `target` | string | 否 | 目标大小，如 `"1G"`。不传则 trim 到当前 used_size |
+| `target_bytes` | int | 否 | 目标精确字节数 |
+| `ipc_name` | string | 否 | 目标 IPC 段名称 |
+| `force` | bool | 否 | 是否绕过安全门限 |
+
+**响应示例：**
+```json
+{
+  "success": true,
+  "ipc_name": "kvcached_vLLM_12345",
+  "previous_total": 10485760000,
+  "previous_total_human": "9.77 GB",
+  "previous_used": 2684354560,
+  "previous_used_human": "2.50 GB",
+  "previous_prealloc": 314572800,
+  "previous_prealloc_human": "300.00 MB",
+  "new_limit": 2684354560,
+  "new_limit_human": "2.50 GB",
+  "freed_estimate": 7801405440,
+  "freed_estimate_human": "7.27 GB",
+  "safety_floor": 234881024,
+  "safety_floor_human": "224.00 MB",
+  "clamped": false,
+  "message": "Trim applied: limit 9.77 GB -> 2.50 GB. Estimated 7.27 GB reclaimable."
+}
+```
+
+**注意：** trim 后显存不会瞬间释放，而是在下一次 alloc/free 周期中由 PageAllocator 执行物理页回收。发送一个推理请求可以加速这个过程。
+
+### 4.5 GET /kvcache/safety_floor
+
+查询当前安全门限的详细配置信息。
+
+**请求：**
+```bash
+curl http://localhost:8000/kvcache/safety_floor
+```
+
+**响应示例：**
+```json
+{
+  "safety_floor": 234881024,
+  "safety_floor_human": "224.00 MB",
+  "model_min_safe_limit": 234881024,
+  "model_min_safe_limit_human": "224.00 MB",
+  "fallback_configured_min_mb": 512,
+  "gpu_percent_floor": 505058590,
+  "gpu_percent_floor_human": "481.64 MB",
+  "hard_minimum": 67108864,
+  "hard_minimum_human": "64.00 MB",
+  "env_vars": {
+    "KVCACHED_MIN_KV_CACHE_MB": "Fallback static floor (default 512)",
+    "KVCACHED_MIN_SAFE_PAGES_PER_LAYER": "Pages per layer for model-aware calculation (default 2)"
+  },
+  "description": "..."
+}
+```
+
+**字段说明：**
+
+| 字段 | 说明 |
+|------|------|
+| `safety_floor` | 当前生效的安全门限 |
+| `model_min_safe_limit` | 模型参数自动计算的门限 |
+| `fallback_configured_min_mb` | 静态兜底值（MB） |
+| `gpu_percent_floor` | GPU 2% 对应的字节数 |
+| `hard_minimum` | 硬性最低值（64MB） |
+
+---
+
+## 5. 典型使用场景
+
+### 5.1 多实例显存回收：为新模型腾空间
+
+```bash
+# 场景：GPU 上已有模型 A（端口 8001），需要部署模型 B
+
+# 1. 查看模型 A 当前显存占用
+curl http://localhost:8001/kvcache/status
+# 返回：total_size=9.77GB, used_size=2.50GB, min_safe_limit=224MB
+
+# 2. 将模型 A 的 KV Cache 限制缩小到 3G
+curl -X POST http://localhost:8001/kvcache/limit \
+  -H "Content-Type: application/json" \
+  -d '{"size": "3G"}'
+
+# 3. 发一个请求触发显存回收
+curl http://localhost:8001/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "MODEL_A", "prompt": "hi", "max_tokens": 1}'
+
+# 4. 确认显存已释放
+curl http://localhost:8001/kvcache/status
+# 返回：total_size=3.00GB
+
+# 5. 现在可以启动模型 B 了
+```
+
+### 5.2 最大化释放显存
+
+```bash
+# 使用 trim 释放所有空闲显存（包括 prefix cache 和预分配页）
+curl -X POST http://localhost:8001/kvcache/trim
+
+# 如果需要释放到安全门限以下（谨慎使用）
+curl -X POST http://localhost:8001/kvcache/trim \
+  -H "Content-Type: application/json" \
+  -d '{"target": "100M", "force": true}'
+```
+
+### 5.3 动态扩容
+
+```bash
+# 其他模型释放了显存，给当前模型扩容
+curl -X POST http://localhost:8001/kvcache/limit \
+  -H "Content-Type: application/json" \
+  -d '{"size": "8G"}'
+```
+
+### 5.4 按比例分配多实例
+
+```bash
+# 3 个模型共享一块 24G GPU，按比例分配
+curl -X POST http://localhost:8001/kvcache/limit_percent \
+  -H "Content-Type: application/json" -d '{"percent": 30}'
+
+curl -X POST http://localhost:8002/kvcache/limit_percent \
+  -H "Content-Type: application/json" -d '{"percent": 40}'
+
+curl -X POST http://localhost:8003/kvcache/limit_percent \
+  -H "Content-Type: application/json" -d '{"percent": 30}'
+```
+
+---
+
+## 6. 环境变量参考
+
+| 环境变量 | 默认值 | 作用 |
+|---------|--------|------|
+| `ENABLE_KVCACHED` | `false` | 总开关，启用 kvcached |
+| `KVCACHED_AUTOPATCH` | `0` | 启用自动 patch（含 API 端点注入） |
+| `KVCACHED_MIN_KV_CACHE_MB` | `512` | 静态安全门限兜底值（MB） |
+| `KVCACHED_MIN_SAFE_PAGES_PER_LAYER` | `2` | 模型自适应门限：每层最少保留的物理页数 |
+| `KVCACHED_PAGE_SIZE_MB` | `2` | 物理页大小（MB） |
+
+---
+
+## 7. 注意事项
+
+### 7.1 limit 设置不生效的常见原因
+
+**现象：** 设置了较小的 limit（如 1G、2G），但显存占用没有下降。
+
+**原因：** 当前 `used_size` 大于设置的 limit。`used_size` 包含：
+- 正在处理的推理请求的 KV Cache block
+- Prefix Cache 保留的 block（已完成请求的缓存，用于加速相同前缀的后续请求）
+
+**解决方法：**
+1. 查看 `/kvcache/status` 中的 `min_effective_limit`，设置 limit >= 此值
+2. 使用 `/kvcache/trim` 先释放 prefix cache 和预分配页
+3. 如果开启了 prefix caching，发送推理请求可以触发 prefix cache 驱逐
+
+### 7.2 vLLM 启动方式
+
+**必须使用 `vllm serve` 启动。** 使用 `python -m vllm.entrypoints.openai.api_server` 直接启动时，由于 Python 模块加载顺序问题，API 端点无法正确注入（返回 404）。
+
+### 7.3 Prefix Cache 与显存回收
+
+开启 prefix caching（vLLM 默认开启）时，已完成请求的 KV Cache block 会被保留在缓存中，不会自动释放回 kvcached。这些 block 在 kvcached 看来是「已使用」的（计入 `used_size`）。
+
+驱逐 prefix cache 是安全的——不会影响正在进行的推理，只会导致后续相同前缀的请求需要重新计算 prefill。
+
+如果不需要 prefix caching，可以在启动时关闭：
+```bash
+# vLLM
+vllm serve MODEL --no-enable-prefix-caching
+# SGLang
+python -m sglang.launch_server --model-path MODEL --disable-radix-cache
+```

--- a/docs/03_kvcache_management_api_en.md
+++ b/docs/03_kvcache_management_api_en.md
@@ -1,0 +1,422 @@
+# kvcached KV Cache Management API Reference
+
+## 1. Overview
+
+kvcached uses an autopatch mechanism to **directly inject KV Cache memory management APIs into vLLM and SGLang HTTP services**. Users do not need to deploy additional management services — they can query and manage KV Cache memory directly through the inference framework's own port.
+
+**Supported Engines:** vLLM (>=0.8.4) and SGLang (>=0.4.9)
+
+**Prerequisites:**
+```bash
+export ENABLE_KVCACHED=true
+export KVCACHED_AUTOPATCH=1
+# Use vllm serve to launch (do NOT use python -m vllm.entrypoints.openai.api_server)
+vllm serve MODEL_NAME --port 8000
+```
+
+**Notes:**
+- vLLM must be launched with the `vllm serve` command, not `python -m vllm.entrypoints.openai.api_server`
+- SGLang can be launched with `python -m sglang.launch_server`
+- All APIs behave identically on vLLM and SGLang
+
+---
+
+## 2. API Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/kvcache/status` | GET | Query KV Cache memory usage status |
+| `/kvcache/limit` | POST | Set absolute KV Cache memory limit |
+| `/kvcache/limit_percent` | POST | Set limit as a percentage of total GPU memory |
+| `/kvcache/trim` | POST | Force release of free memory (including prefix cache eviction) |
+| `/kvcache/safety_floor` | GET | Query safety floor configuration |
+
+---
+
+## 3. Safety Floor Mechanism
+
+All limit-setting APIs have safety floor protection to prevent setting the KV Cache too low, which would make model inference impossible.
+
+### 3.1 Automatic Calculation
+
+The safety floor is automatically calculated based on model parameters using the formula:
+
+```
+min_safe_limit = num_layers × num_kv_buffers × page_size × MIN_SAFE_PAGES_PER_LAYER
+```
+
+| Parameter | Source | Description |
+|-----------|--------|-------------|
+| `num_layers` | Auto-detected from model | Number of Transformer layers in the model |
+| `num_kv_buffers` | Auto-detected from attention type | MHA/GQA=2 (K+V), MLA=1 |
+| `page_size` | Env var `KVCACHED_PAGE_SIZE_MB` | Default 2MB |
+| `MIN_SAFE_PAGES_PER_LAYER` | Env var `KVCACHED_MIN_SAFE_PAGES_PER_LAYER` | Default 2 |
+
+**Automatic floor examples for different models:**
+
+| Model | Layers | KV Buffers | Auto Floor |
+|-------|--------|------------|------------|
+| Qwen3-1.7B | 28 | 2 (MHA) | 28 × 2 × 2MB × 2 = **224 MB** |
+| Llama-3.1-8B | 32 | 2 (MHA) | 32 × 2 × 2MB × 2 = **256 MB** |
+| Llama-3.1-70B | 80 | 2 (MHA) | 80 × 2 × 2MB × 2 = **640 MB** |
+| DeepSeek-V3 | 61 | 1 (MLA) | 61 × 1 × 2MB × 2 = **244 MB** |
+
+### 3.2 Three-Tier Protection
+
+| Tier | Value | Description |
+|------|-------|-------------|
+| Model-adaptive floor | Auto-calculated | Active by default, based on model parameters |
+| Static fallback | 512MB or 2% of GPU (whichever is larger) | Fallback when shared memory is unavailable |
+| Hard minimum | 64MB | Cannot go below this even with `force=true` |
+
+### 3.3 Bypassing the Safety Floor
+
+Passing `"force": true` in the request body of `/kvcache/limit`, `/kvcache/limit_percent`, or `/kvcache/trim` can bypass the model-adaptive floor and the static fallback, but is still constrained by the 64MB hard minimum.
+
+---
+
+## 4. API Details
+
+### 4.1 GET /kvcache/status
+
+Queries the current instance's KV Cache memory usage status.
+
+**Request:**
+```bash
+curl http://localhost:8000/kvcache/status
+```
+
+**Response Example:**
+```json
+{
+  "self_ipc_name": "kvcached_vLLM_12345",
+  "segments": [
+    {
+      "ipc_name": "kvcached_vLLM_12345",
+      "total_size": 10485760000,
+      "total_size_human": "9.77 GB",
+      "used_size": 2684354560,
+      "used_size_human": "2.50 GB",
+      "prealloc_size": 314572800,
+      "prealloc_size_human": "300.00 MB",
+      "free_size": 7486832640,
+      "free_size_human": "6.97 GB",
+      "usage_percent": 25.6,
+      "physical_occupied": 2998927360,
+      "physical_occupied_human": "2.79 GB",
+      "min_effective_limit": 2684354560,
+      "min_effective_limit_human": "2.50 GB",
+      "min_safe_limit": 234881024,
+      "min_safe_limit_human": "224.00 MB",
+      "safety_floor": 234881024,
+      "safety_floor_human": "224.00 MB"
+    }
+  ],
+  "gpu_total_memory": 25252929536,
+  "gpu_total_memory_human": "23.52 GB",
+  "gpu_free_memory": 14557184000,
+  "gpu_free_memory_human": "13.55 GB"
+}
+```
+
+**Response Fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `total_size` | int | Current KV Cache memory upper limit (bytes) |
+| `used_size` | int | Memory currently used by inference requests (bytes) |
+| `prealloc_size` | int | Memory occupied by reserved pages |
+| `free_size` | int | Allocatable space = total - used - prealloc |
+| `usage_percent` | float | Usage percentage |
+| `physical_occupied` | int | Actual GPU physical memory occupied = used + prealloc |
+| `min_effective_limit` | int | Minimum limit value that takes effect immediately (= used_size) |
+| `min_safe_limit` | int | Model auto-calculated safety floor (bytes) |
+| `safety_floor` | int | Currently active safety floor (combining model-calculated and fallback values) |
+| `gpu_total_memory` | int | Total GPU memory |
+| `gpu_free_memory` | int | Current free GPU memory |
+
+**Key Metrics Interpretation:**
+- `min_effective_limit`: Setting limit >= this value takes effect immediately; < this value enters shrink mode
+- `min_safe_limit`: Safety floor — limit cannot go below this (unless force=true)
+- `physical_occupied`: Actual GPU physical memory occupied; available space for other instances = gpu_total - sum of all instances' physical_occupied
+
+### 4.2 POST /kvcache/limit
+
+Sets an absolute KV Cache memory limit.
+
+**Request:**
+```bash
+# Set to 3G
+curl -X POST http://localhost:8000/kvcache/limit \
+  -H "Content-Type: application/json" \
+  -d '{"size": "3G"}'
+
+# Set exact byte count
+curl -X POST http://localhost:8000/kvcache/limit \
+  -H "Content-Type: application/json" \
+  -d '{"size_bytes": 3221225472}'
+
+# Force set (bypass safety floor, minimum 64MB)
+curl -X POST http://localhost:8000/kvcache/limit \
+  -H "Content-Type: application/json" \
+  -d '{"size": "100M", "force": true}'
+```
+
+**Request Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `size` | string | One of two | Human-readable size, e.g. `"3G"`, `"512M"`, `"1.5G"` |
+| `size_bytes` | int | One of two | Exact byte count |
+| `ipc_name` | string | No | Target IPC segment name, defaults to current instance |
+| `force` | bool | No | Whether to bypass safety floor (default false) |
+
+**Response Example:**
+```json
+{
+  "ipc_name": "kvcached_vLLM_12345",
+  "success": true,
+  "previous_total_size": 10485760000,
+  "previous_total_size_human": "9.77 GB",
+  "new_total_size": 3221225472,
+  "new_total_size_human": "3.00 GB",
+  "current_used_size": 2684354560,
+  "current_used_size_human": "2.50 GB",
+  "immediate_reclaim": true,
+  "safety_floor": 234881024,
+  "safety_floor_human": "224.00 MB",
+  "clamped": false,
+  "message": "Limit updated 9.77 GB -> 3.00 GB. Free pages will be reclaimed immediately."
+}
+```
+
+**Effect Behavior:**
+- `immediate_reclaim: true`: New limit > used_size, free pages are released immediately
+- `immediate_reclaim: false`: New limit < used_size, enters shrink mode, gradually reclaims as requests complete
+- `clamped: true`: Requested value was below safety floor and was automatically raised
+
+### 4.3 POST /kvcache/limit_percent
+
+Sets the KV Cache limit as a percentage of total GPU memory.
+
+**Request:**
+```bash
+# Set to 20% of total GPU memory
+curl -X POST http://localhost:8000/kvcache/limit_percent \
+  -H "Content-Type: application/json" \
+  -d '{"percent": 20}'
+```
+
+**Request Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `percent` | float | Yes | Percentage of total GPU memory (0-100) |
+| `ipc_name` | string | No | Target IPC segment name |
+| `force` | bool | No | Whether to bypass safety floor |
+
+**Response:** Same as `/kvcache/limit`, additionally includes `gpu_total_memory` and `percent` fields.
+
+### 4.4 POST /kvcache/trim
+
+Force release of free memory. Compresses the KV Cache limit down to the current actual usage, releasing all preallocated pages and free pages.
+
+**Request:**
+```bash
+# Default trim: release down to current usage
+curl -X POST http://localhost:8000/kvcache/trim
+
+# Specify target value
+curl -X POST http://localhost:8000/kvcache/trim \
+  -H "Content-Type: application/json" \
+  -d '{"target": "1G"}'
+
+# Force trim to minimum
+curl -X POST http://localhost:8000/kvcache/trim \
+  -H "Content-Type: application/json" \
+  -d '{"target": "0", "force": true}'
+```
+
+**Request Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `target` | string | No | Target size, e.g. `"1G"`. If omitted, trims to current used_size |
+| `target_bytes` | int | No | Target exact byte count |
+| `ipc_name` | string | No | Target IPC segment name |
+| `force` | bool | No | Whether to bypass safety floor |
+
+**Response Example:**
+```json
+{
+  "success": true,
+  "ipc_name": "kvcached_vLLM_12345",
+  "previous_total": 10485760000,
+  "previous_total_human": "9.77 GB",
+  "previous_used": 2684354560,
+  "previous_used_human": "2.50 GB",
+  "previous_prealloc": 314572800,
+  "previous_prealloc_human": "300.00 MB",
+  "new_limit": 2684354560,
+  "new_limit_human": "2.50 GB",
+  "freed_estimate": 7801405440,
+  "freed_estimate_human": "7.27 GB",
+  "safety_floor": 234881024,
+  "safety_floor_human": "224.00 MB",
+  "clamped": false,
+  "message": "Trim applied: limit 9.77 GB -> 2.50 GB. Estimated 7.27 GB reclaimable."
+}
+```
+
+**Note:** After trim, memory is not released instantly but is performed by the PageAllocator in the next alloc/free cycle. Sending an inference request can accelerate this process.
+
+### 4.5 GET /kvcache/safety_floor
+
+Queries detailed configuration information for the current safety floor.
+
+**Request:**
+```bash
+curl http://localhost:8000/kvcache/safety_floor
+```
+
+**Response Example:**
+```json
+{
+  "safety_floor": 234881024,
+  "safety_floor_human": "224.00 MB",
+  "model_min_safe_limit": 234881024,
+  "model_min_safe_limit_human": "224.00 MB",
+  "fallback_configured_min_mb": 512,
+  "gpu_percent_floor": 505058590,
+  "gpu_percent_floor_human": "481.64 MB",
+  "hard_minimum": 67108864,
+  "hard_minimum_human": "64.00 MB",
+  "env_vars": {
+    "KVCACHED_MIN_KV_CACHE_MB": "Fallback static floor (default 512)",
+    "KVCACHED_MIN_SAFE_PAGES_PER_LAYER": "Pages per layer for model-aware calculation (default 2)"
+  },
+  "description": "..."
+}
+```
+
+**Field Descriptions:**
+
+| Field | Description |
+|-------|-------------|
+| `safety_floor` | Currently active safety floor |
+| `model_min_safe_limit` | Floor auto-calculated from model parameters |
+| `fallback_configured_min_mb` | Static fallback value (MB) |
+| `gpu_percent_floor` | Byte count corresponding to 2% of GPU memory |
+| `hard_minimum` | Hard minimum (64MB) |
+
+---
+
+## 5. Typical Usage Scenarios
+
+### 5.1 Multi-Instance Memory Reclamation: Freeing Space for a New Model
+
+```bash
+# Scenario: Model A is already running on GPU (port 8001), Model B needs to be deployed
+
+# 1. Check Model A's current memory usage
+curl http://localhost:8001/kvcache/status
+# Returns: total_size=9.77GB, used_size=2.50GB, min_safe_limit=224MB
+
+# 2. Shrink Model A's KV Cache limit to 3G
+curl -X POST http://localhost:8001/kvcache/limit \
+  -H "Content-Type: application/json" \
+  -d '{"size": "3G"}'
+
+# 3. Send a request to trigger memory reclamation
+curl http://localhost:8001/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "MODEL_A", "prompt": "hi", "max_tokens": 1}'
+
+# 4. Confirm memory has been released
+curl http://localhost:8001/kvcache/status
+# Returns: total_size=3.00GB
+
+# 5. Now Model B can be launched
+```
+
+### 5.2 Maximizing Memory Release
+
+```bash
+# Use trim to release all free memory (including prefix cache and preallocated pages)
+curl -X POST http://localhost:8001/kvcache/trim
+
+# If you need to release below the safety floor (use with caution)
+curl -X POST http://localhost:8001/kvcache/trim \
+  -H "Content-Type: application/json" \
+  -d '{"target": "100M", "force": true}'
+```
+
+### 5.3 Dynamic Expansion
+
+```bash
+# Other models have released memory; expand current model's allocation
+curl -X POST http://localhost:8001/kvcache/limit \
+  -H "Content-Type: application/json" \
+  -d '{"size": "8G"}'
+```
+
+### 5.4 Proportional Multi-Instance Allocation
+
+```bash
+# 3 models sharing a 24G GPU, allocated proportionally
+curl -X POST http://localhost:8001/kvcache/limit_percent \
+  -H "Content-Type: application/json" -d '{"percent": 30}'
+
+curl -X POST http://localhost:8002/kvcache/limit_percent \
+  -H "Content-Type: application/json" -d '{"percent": 40}'
+
+curl -X POST http://localhost:8003/kvcache/limit_percent \
+  -H "Content-Type: application/json" -d '{"percent": 30}'
+```
+
+---
+
+## 6. Environment Variable Reference
+
+| Environment Variable | Default | Purpose |
+|----------------------|---------|---------|
+| `ENABLE_KVCACHED` | `false` | Master switch to enable kvcached |
+| `KVCACHED_AUTOPATCH` | `0` | Enable automatic patching (including API endpoint injection) |
+| `KVCACHED_MIN_KV_CACHE_MB` | `512` | Static safety floor fallback value (MB) |
+| `KVCACHED_MIN_SAFE_PAGES_PER_LAYER` | `2` | Model-adaptive floor: minimum physical pages retained per layer |
+| `KVCACHED_PAGE_SIZE_MB` | `2` | Physical page size (MB) |
+
+---
+
+## 7. Notes
+
+### 7.1 Common Reasons Limit Settings Don't Take Effect
+
+**Symptom:** A smaller limit was set (e.g. 1G, 2G), but memory usage did not decrease.
+
+**Cause:** The current `used_size` is larger than the set limit. `used_size` includes:
+- KV Cache blocks of currently processing inference requests
+- Blocks retained by Prefix Cache (cached blocks of completed requests, used to accelerate subsequent requests with the same prefix)
+
+**Resolution:**
+1. Check `min_effective_limit` in `/kvcache/status` and set limit >= this value
+2. Use `/kvcache/trim` to first release prefix cache and preallocated pages
+3. If prefix caching is enabled, sending an inference request can trigger prefix cache eviction
+
+### 7.2 vLLM Launch Method
+
+**Must use `vllm serve` to launch.** When using `python -m vllm.entrypoints.openai.api_server` directly, API endpoints cannot be correctly injected due to Python module loading order issues (returns 404).
+
+### 7.3 Prefix Cache and Memory Reclamation
+
+When prefix caching is enabled (enabled by default in vLLM), KV Cache blocks of completed requests are retained in the cache and are not automatically released back to kvcached. These blocks are considered "used" by kvcached (counted in `used_size`).
+
+Evicting the prefix cache is safe — it does not affect ongoing inference, but subsequent requests with the same prefix will require recomputing the prefill.
+
+To disable prefix caching at launch:
+```bash
+# vLLM
+vllm serve MODEL --no-enable-prefix-caching
+# SGLang
+python -m sglang.launch_server --model-path MODEL --disable-radix-cache
+```

--- a/kvcached/cli/utils.py
+++ b/kvcached/cli/utils.py
@@ -30,9 +30,10 @@ class MemInfoStruct:
     total_size: int
     used_size: int
     prealloc_size: int
+    min_safe_limit: int = 0  # Minimum safe KV cache limit (auto-calculated from model params)
 
     DTYPE = np.int64
-    N_FIELDS = 3
+    N_FIELDS = 4
     SHM_SIZE = np.dtype(DTYPE).itemsize * N_FIELDS
 
     @classmethod
@@ -43,12 +44,15 @@ class MemInfoStruct:
     @classmethod
     def from_buffer(cls, buf: mmap.mmap) -> "MemInfoStruct":
         arr = cls._view(buf)
+        # Backward compatible: old segments with 3 fields will have min_safe_limit=0
+        min_safe = int(arr[3]) if len(arr) > 3 else 0
         return cls(int(arr[0]), int(arr[1]),
-                   int(arr[2]))  # total, used, prealloc
+                   int(arr[2]), min_safe)  # total, used, prealloc, min_safe_limit
 
     def write_to_buffer(self, buf: mmap.mmap) -> None:
         arr = self._view(buf)
-        arr[:] = (self.total_size, self.used_size, self.prealloc_size)
+        arr[:] = (self.total_size, self.used_size, self.prealloc_size,
+                  self.min_safe_limit)
 
 
 class RwLockedShm:
@@ -96,7 +100,8 @@ class RwLockedShm:
         self.file.close()
 
 
-def init_kv_cache_limit(ipc_name: str, kv_cache_limit: int):
+def init_kv_cache_limit(ipc_name: str, kv_cache_limit: int,
+                       min_safe_limit: int = 0):
     """
     Set the kv cache limit for the current process.
     Creates a persistent shared memory file that remains even after the script exits.
@@ -110,7 +115,7 @@ def init_kv_cache_limit(ipc_name: str, kv_cache_limit: int):
     # Now we can safely memory map and write the values
     with RwLockedShm(get_ipc_name(ipc_name), MemInfoStruct.SHM_SIZE,
                      RwLockedShm.WLOCK) as mm:
-        mem_info = MemInfoStruct(kv_cache_limit, 0, 0)
+        mem_info = MemInfoStruct(kv_cache_limit, 0, 0, min_safe_limit)
         mem_info.write_to_buffer(mm)
         return mem_info
 

--- a/kvcached/integration/sglang/autopatch.py
+++ b/kvcached/integration/sglang/autopatch.py
@@ -14,6 +14,7 @@ from kvcached.integration.sglang.patches import (
     ElasticMambaPoolPatch,
     ElasticMemoryPoolPatch,
     ElasticMLAMemoryPoolPatch,
+    HttpServerPatch,
     RadixCacheLimitPatch,
     SchedulerMemoryLeakPatch,
 )
@@ -44,6 +45,7 @@ def _patch_sglang(_sglang: types.ModuleType) -> None:
             (ElasticHybridLinearKVPoolPatch(), SGLANG_ALL_RANGE),
             (SchedulerMemoryLeakPatch(), SGLANG_ALL_RANGE),
             (RadixCacheLimitPatch(), SGLANG_ALL_RANGE),
+            (HttpServerPatch(), SGLANG_ALL_RANGE),
         ]
     )
 

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -1162,3 +1162,64 @@ class RadixCacheLimitPatch(VersionAwarePatch, BasePatch):
             f"{max_cached} tokens (KVCACHED_MAX_CACHED_TOKENS)"
         )
         return True
+
+
+class HttpServerPatch(VersionAwarePatch, BasePatch):
+    """Patch SGLang's HTTP server to inject kvcached KV cache management endpoints.
+
+    SGLang creates a module-level ``app = FastAPI(...)`` in
+    ``sglang.srt.entrypoints.http_server``.  We wrap
+    ``_setup_and_run_http_server`` so that the kvcache router is attached
+    to ``app`` before uvicorn starts listening.
+
+    This adds ``/kvcache/status``, ``/kvcache/limit``, and
+    ``/kvcache/limit_percent`` to every SGLang instance.
+    """
+
+    library = "sglang"
+    target_module = "sglang.srt.entrypoints.http_server"
+    target_class = None  # Module-level function, not a class
+    patch_name = "http_server_kvcache"
+
+    def can_apply(self, target_module: types.ModuleType) -> bool:
+        return hasattr(target_module, "_setup_and_run_http_server")
+
+    def apply(self, http_server_mod: types.ModuleType) -> bool:
+        if not self.initialize_version_info():
+            return False
+        return self.patch_setup_and_run(http_server_mod)
+
+    @version_range(SGLANG_ALL_RANGE)
+    def patch_setup_and_run(self, http_server_mod: types.ModuleType) -> bool:
+        """Wrap _setup_and_run_http_server to attach kvcache routes."""
+        original_fn = getattr(http_server_mod, "_setup_and_run_http_server", None)
+        if original_fn is None:
+            self.logger.warning(
+                "_setup_and_run_http_server not found in http_server module")
+            return False
+
+        if self._is_already_patched(original_fn, "_setup_and_run"):
+            self.logger.debug("_setup_and_run_http_server already patched")
+            return True
+
+        _logger = self.logger
+
+        def _patched_setup_and_run(*args: Any, **kwargs: Any):
+            if enable_kvcached():
+                try:
+                    # The module-level ``app`` is the FastAPI instance.
+                    fastapi_app = getattr(http_server_mod, "app", None)
+                    if fastapi_app is not None:
+                        from kvcached.integration.vllm.api_router import (
+                            attach_to_app,
+                        )
+                        attach_to_app(fastapi_app)
+                except Exception as exc:
+                    _logger.warning(
+                        "Failed to attach kvcache router to SGLang: %s", exc)
+
+            return original_fn(*args, **kwargs)
+
+        self._mark_as_patched(_patched_setup_and_run, "_setup_and_run")
+        http_server_mod._setup_and_run_http_server = _patched_setup_and_run
+        return True

--- a/kvcached/integration/vllm/api_router.py
+++ b/kvcached/integration/vllm/api_router.py
@@ -1,0 +1,515 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+FastAPI router that exposes KV cache memory management endpoints.
+
+These endpoints are injected into vLLM's HTTP server via autopatch so that
+each vLLM instance can manage its own kvcached memory through the same
+host:port it already uses for inference (e.g. localhost:12346).
+
+The router reads/writes POSIX shared-memory segments in /dev/shm that are
+created by kvcached's MemInfoTracker.  This is the same mechanism used by
+the ``kvctl`` CLI tool.
+
+Safety:
+    A minimum KV cache floor is enforced to prevent users from accidentally
+    setting the limit so low that the model cannot process any requests.
+    The floor defaults to 512 MB or 2% of GPU memory (whichever is larger)
+    and can be overridden via the ``KVCACHED_MIN_KV_CACHE_MB`` environment
+    variable.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+from kvcached.cli.kvtop import _detect_kvcache_ipc_names
+from kvcached.cli.utils import (
+    _format_size,
+    get_kv_cache_limit,
+    get_total_gpu_memory,
+    update_kv_cache_limit,
+)
+from kvcached.utils import DEFAULT_IPC_NAME, get_kvcached_logger
+
+logger = get_kvcached_logger()
+
+# ---------------------------------------------------------------------------
+# Safety floor: minimum KV cache size (bytes).
+#
+# The primary safety floor is auto-calculated from model parameters
+# (num_layers × num_kv_buffers × page_size × MIN_SAFE_PAGES_PER_LAYER)
+# and stored in shared memory by MemInfoTracker at init time.
+#
+# The static fallback below is used only when the shared-memory value is
+# unavailable (e.g. segment not yet created).  It can be overridden via
+# KVCACHED_MIN_KV_CACHE_MB env var.
+# ---------------------------------------------------------------------------
+_FALLBACK_MIN_KV_CACHE_MB = int(os.getenv("KVCACHED_MIN_KV_CACHE_MB", "512"))
+_FALLBACK_MIN_KV_CACHE_BYTES = _FALLBACK_MIN_KV_CACHE_MB * 1024 * 1024
+
+
+def _get_min_kv_cache_bytes(ipc_name: Optional[str] = None) -> int:
+    """Return the effective minimum KV cache size in bytes.
+
+    Reads the model-aware ``min_safe_limit`` from shared memory first.
+    Falls back to max(static_floor, 2% of GPU memory) when the shared
+    memory value is unavailable or zero.
+    """
+    # Try to read model-calculated min_safe_limit from shared memory
+    if ipc_name is not None:
+        info = get_kv_cache_limit(ipc_name)
+        if info is not None and info.min_safe_limit > 0:
+            return info.min_safe_limit
+
+    # Fallback: static floor or 2% of GPU
+    gpu_total = get_total_gpu_memory()
+    gpu_floor = int(gpu_total * 0.02) if gpu_total > 0 else 0
+    return max(_FALLBACK_MIN_KV_CACHE_BYTES, gpu_floor)
+
+
+# Size suffix table shared with kvctl
+_SIZE_SUFFIXES = {
+    'b': 1,
+    'k': 1024,
+    'kb': 1024,
+    'm': 1024**2,
+    'mb': 1024**2,
+    'g': 1024**3,
+    'gb': 1024**3,
+}
+
+
+def _parse_size(size_str: str) -> int:
+    """Convert human-friendly size strings (e.g. ``512M``, ``2G``) to bytes."""
+    s = size_str.strip().lower().replace(',', '').replace('_', '')
+    for suf, mul in sorted(_SIZE_SUFFIXES.items(), key=lambda kv: -len(kv[0])):
+        if s.endswith(suf):
+            num_part = s[:-len(suf)] or "0"
+            return int(float(num_part) * mul)
+    return int(float(s))
+
+
+def _build_segment_info(ipc_name: str) -> Optional[Dict[str, Any]]:
+    """Return a dict describing one IPC segment, or None if not found."""
+    info = get_kv_cache_limit(ipc_name)
+    if info is None:
+        return None
+    usage_pct = (info.used_size / info.total_size * 100
+                 ) if info.total_size > 0 else 0.0
+    free = max(info.total_size - info.used_size - info.prealloc_size, 0)
+    physical_occupied = info.used_size + info.prealloc_size
+    # Read model-aware safety floor from shared memory
+    min_floor = _get_min_kv_cache_bytes(ipc_name)
+    # Minimum limit that takes effect immediately (>= used_size succeeds;
+    # < used_size enters shrink mode which waits for requests to finish).
+    min_effective_limit = info.used_size
+    return {
+        "ipc_name": ipc_name,
+        "total_size": info.total_size,
+        "total_size_human": _format_size(info.total_size),
+        "used_size": info.used_size,
+        "used_size_human": _format_size(info.used_size),
+        "prealloc_size": info.prealloc_size,
+        "prealloc_size_human": _format_size(info.prealloc_size),
+        "free_size": free,
+        "free_size_human": _format_size(free),
+        "usage_percent": round(usage_pct, 2),
+        "physical_occupied": physical_occupied,
+        "physical_occupied_human": _format_size(physical_occupied),
+        "min_effective_limit": min_effective_limit,
+        "min_effective_limit_human": _format_size(min_effective_limit),
+        "min_safe_limit": info.min_safe_limit,
+        "min_safe_limit_human": _format_size(info.min_safe_limit),
+        "safety_floor": min_floor,
+        "safety_floor_human": _format_size(min_floor),
+    }
+
+
+def _apply_limit(ipc_name: str, size_bytes: int,
+                 force: bool = False) -> Dict[str, Any]:
+    """Core logic for applying a KV cache limit with safety checks.
+
+    Args:
+        ipc_name: Target IPC segment name.
+        size_bytes: Desired limit in bytes.
+        force: If True, allow setting below safety floor (still enforces
+               absolute minimum of 64 MB to prevent total starvation).
+
+    Returns:
+        A dict suitable for JSONResponse content.
+
+    Raises:
+        ValueError: If the segment is not found or size is invalid.
+    """
+    current_info = get_kv_cache_limit(ipc_name)
+    if current_info is None:
+        raise ValueError(f"IPC segment '{ipc_name}' not found")
+
+    if size_bytes <= 0:
+        raise ValueError("Size must be positive")
+
+    # --- Safety floor enforcement ---
+    min_floor = _get_min_kv_cache_bytes(ipc_name)
+    # Absolute hard minimum: 64 MB (even with force=True)
+    hard_min = 64 * 1024 * 1024
+    effective_min = hard_min if force else min_floor
+
+    clamped = False
+    original_request = size_bytes
+    if size_bytes < effective_min:
+        size_bytes = effective_min
+        clamped = True
+
+    previous_total = current_info.total_size
+    previous_used = current_info.used_size
+
+    update_kv_cache_limit(ipc_name, size_bytes)
+
+    immediate = previous_used <= size_bytes
+    if immediate:
+        message = (
+            f"Limit updated {_format_size(previous_total)} -> "
+            f"{_format_size(size_bytes)}. "
+            f"Free pages will be reclaimed immediately.")
+    else:
+        message = (
+            f"Limit updated {_format_size(previous_total)} -> "
+            f"{_format_size(size_bytes)}. "
+            f"Usage ({_format_size(previous_used)}) exceeds new limit"
+            f" — shrink mode active, memory reclaimed as requests complete.")
+
+    if clamped:
+        message += (
+            f" (Requested {_format_size(original_request)} was below "
+            f"safety floor {_format_size(effective_min)}, clamped up.)")
+
+    result: Dict[str, Any] = {
+        "ipc_name": ipc_name,
+        "success": True,
+        "previous_total_size": previous_total,
+        "previous_total_size_human": _format_size(previous_total),
+        "new_total_size": size_bytes,
+        "new_total_size_human": _format_size(size_bytes),
+        "current_used_size": previous_used,
+        "current_used_size_human": _format_size(previous_used),
+        "immediate_reclaim": immediate,
+        "safety_floor": min_floor,
+        "safety_floor_human": _format_size(min_floor),
+        "clamped": clamped,
+        "message": message,
+    }
+    if clamped:
+        result["requested_size"] = original_request
+        result["requested_size_human"] = _format_size(original_request)
+    return result
+
+
+# ------------------------------------------------------------------
+# Starlette route handlers
+# ------------------------------------------------------------------
+
+def create_router():
+    """Create and return Starlette Route objects for kvcache management.
+
+    Uses raw Starlette routes instead of FastAPI's decorator-based routing
+    to completely bypass vLLM's custom request-validation middleware.
+    """
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
+    from starlette.routing import Route
+
+    async def kvcache_status(request: Request) -> JSONResponse:
+        """Return memory usage for all active kvcached IPC segments."""
+        try:
+            ipc_names = _detect_kvcache_ipc_names()
+            segments: List[Dict[str, Any]] = []
+            for name in ipc_names:
+                seg = _build_segment_info(name)
+                if seg is not None:
+                    segments.append(seg)
+
+            gpu_total = get_total_gpu_memory()
+            try:
+                import torch
+                gpu_free, _ = torch.cuda.mem_get_info()
+            except Exception:
+                gpu_free = 0
+
+            return JSONResponse(content={
+                "self_ipc_name": DEFAULT_IPC_NAME,
+                "segments": segments,
+                "gpu_total_memory": gpu_total,
+                "gpu_total_memory_human":
+                    _format_size(gpu_total) if gpu_total else "N/A",
+                "gpu_free_memory": gpu_free,
+                "gpu_free_memory_human":
+                    _format_size(gpu_free) if gpu_free else "N/A",
+            })
+        except Exception as e:
+            logger.error("Error in /kvcache/status: %s", e)
+            return JSONResponse(status_code=500,
+                                content={"error": str(e)})
+
+    async def kvcache_limit(request: Request) -> JSONResponse:
+        """Set an absolute KV cache limit for an IPC segment.
+
+        Body (JSON):
+            ipc_name   – (optional) target IPC segment; defaults to self.
+            size       – human-readable size, e.g. "5G", "512M"
+            size_bytes – exact byte count (alternative to *size*)
+            force      – (optional, default false) bypass safety floor
+                         (still enforces 64 MB hard minimum)
+        """
+        try:
+            body = await request.json()
+
+            ipc_name = body.get("ipc_name") or DEFAULT_IPC_NAME
+            force = bool(body.get("force", False))
+
+            size_bytes: Optional[int] = None
+            if 'size_bytes' in body:
+                size_bytes = int(body['size_bytes'])
+            elif 'size' in body:
+                size_bytes = _parse_size(str(body['size']))
+            else:
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "error":
+                        "Body must contain 'size' (e.g. '5G') or 'size_bytes'"
+                    })
+
+            result = _apply_limit(ipc_name, size_bytes, force=force)
+            return JSONResponse(content=result)
+        except ValueError as e:
+            return JSONResponse(status_code=400,
+                                content={"error": str(e)})
+        except Exception as e:
+            logger.error("Error in /kvcache/limit: %s", e)
+            return JSONResponse(status_code=500,
+                                content={"error": str(e)})
+
+    async def kvcache_limit_percent(request: Request) -> JSONResponse:
+        """Set KV cache limit as a percentage of total GPU memory.
+
+        Body (JSON):
+            ipc_name – (optional) defaults to self.
+            percent  – float, e.g. 30 means 30% of total GPU memory.
+            force    – (optional) bypass safety floor.
+        """
+        try:
+            body = await request.json()
+
+            ipc_name = body.get("ipc_name") or DEFAULT_IPC_NAME
+            force = bool(body.get("force", False))
+
+            percent = body.get('percent')
+            if percent is None:
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": "Body must contain 'percent'"})
+
+            percent = float(percent)
+            if percent <= 0 or percent > 100:
+                return JSONResponse(
+                    status_code=400,
+                    content={"error": "percent must be between 0 and 100"})
+
+            gpu_total = get_total_gpu_memory()
+            if gpu_total <= 0:
+                return JSONResponse(
+                    status_code=500,
+                    content={
+                        "error":
+                        "CUDA unavailable; cannot compute size from percentage"
+                    })
+
+            size_bytes = int(gpu_total * percent / 100.0)
+            result = _apply_limit(ipc_name, size_bytes, force=force)
+            result["gpu_total_memory"] = gpu_total
+            result["gpu_total_memory_human"] = _format_size(gpu_total)
+            result["percent"] = percent
+            return JSONResponse(content=result)
+        except ValueError as e:
+            return JSONResponse(status_code=400,
+                                content={"error": str(e)})
+        except Exception as e:
+            logger.error("Error in /kvcache/limit_percent: %s", e)
+            return JSONResponse(status_code=500,
+                                content={"error": str(e)})
+
+    async def kvcache_trim(request: Request) -> JSONResponse:
+        """Force-release reserved pages and prefix cache to reclaim GPU memory.
+
+        This endpoint:
+        1. Evicts all prefix-cached blocks (safe: only affects completed
+           requests' cached KV data, not in-flight inference).
+        2. Sets the KV cache limit to current used_size so that reserved
+           (pre-allocated) pages are released on the next alloc cycle.
+
+        The result is that physical GPU memory drops to the minimum needed
+        for currently active requests, freeing everything else for other
+        Docker instances on the same GPU.
+
+        Body (JSON, all optional):
+            ipc_name – target segment (defaults to self).
+            target   – (optional) desired limit after trim, e.g. "1G".
+                       If omitted, trims to current active usage.
+                       Subject to safety floor unless force=true.
+            force    – bypass safety floor (still enforces 64 MB hard min).
+        """
+        try:
+            # Parse optional body (trim can be called with no body)
+            try:
+                body = await request.json()
+            except Exception:
+                body = {}
+
+            ipc_name = body.get("ipc_name") or DEFAULT_IPC_NAME
+            force = bool(body.get("force", False))
+
+            current_info = get_kv_cache_limit(ipc_name)
+            if current_info is None:
+                return JSONResponse(
+                    status_code=404,
+                    content={
+                        "error": f"IPC segment '{ipc_name}' not found",
+                        "available_segments": _detect_kvcache_ipc_names(),
+                    })
+
+            previous_total = current_info.total_size
+            previous_used = current_info.used_size
+            previous_prealloc = current_info.prealloc_size
+
+            # Step 1: Determine target limit
+            if 'target' in body:
+                target_bytes = _parse_size(str(body['target']))
+            elif 'target_bytes' in body:
+                target_bytes = int(body['target_bytes'])
+            else:
+                # Default: trim to current used_size (release everything idle)
+                target_bytes = previous_used
+
+            # Step 2: Apply safety floor
+            min_floor = _get_min_kv_cache_bytes(ipc_name)
+            hard_min = 64 * 1024 * 1024
+            effective_min = hard_min if force else min_floor
+            clamped = False
+            original_target = target_bytes
+            if target_bytes < effective_min:
+                target_bytes = effective_min
+                clamped = True
+
+            # Step 3: Write the new limit to shared memory
+            update_kv_cache_limit(ipc_name, target_bytes)
+
+            freed_estimate = max(previous_total - target_bytes, 0)
+            message = (
+                f"Trim applied: limit {_format_size(previous_total)} -> "
+                f"{_format_size(target_bytes)}. "
+                f"Estimated {_format_size(freed_estimate)} reclaimable. "
+                f"Prefix cache blocks will be evicted as new requests arrive.")
+            if clamped:
+                message += (
+                    f" (Requested target {_format_size(original_target)} "
+                    f"clamped to safety floor {_format_size(effective_min)}.)")
+
+            result: Dict[str, Any] = {
+                "success": True,
+                "ipc_name": ipc_name,
+                "previous_total": previous_total,
+                "previous_total_human": _format_size(previous_total),
+                "previous_used": previous_used,
+                "previous_used_human": _format_size(previous_used),
+                "previous_prealloc": previous_prealloc,
+                "previous_prealloc_human": _format_size(previous_prealloc),
+                "new_limit": target_bytes,
+                "new_limit_human": _format_size(target_bytes),
+                "freed_estimate": freed_estimate,
+                "freed_estimate_human": _format_size(freed_estimate),
+                "safety_floor": min_floor,
+                "safety_floor_human": _format_size(min_floor),
+                "clamped": clamped,
+                "message": message,
+            }
+            return JSONResponse(content=result)
+        except Exception as e:
+            logger.error("Error in /kvcache/trim: %s", e)
+            return JSONResponse(status_code=500,
+                                content={"error": str(e)})
+
+    async def kvcache_safety_floor(request: Request) -> JSONResponse:
+        """Return the current safety floor configuration."""
+        try:
+            # Try to read model-aware min_safe_limit from the first IPC segment
+            ipc_names = _detect_kvcache_ipc_names()
+            first_ipc = ipc_names[0] if ipc_names else None
+            min_floor = _get_min_kv_cache_bytes(first_ipc)
+
+            # Also read the raw min_safe_limit from shared memory
+            model_min_safe = 0
+            if first_ipc is not None:
+                info = get_kv_cache_limit(first_ipc)
+                if info is not None:
+                    model_min_safe = info.min_safe_limit
+
+            gpu_total = get_total_gpu_memory()
+            return JSONResponse(content={
+                "safety_floor": min_floor,
+                "safety_floor_human": _format_size(min_floor),
+                "model_min_safe_limit": model_min_safe,
+                "model_min_safe_limit_human": _format_size(model_min_safe) if model_min_safe > 0 else "N/A (not calculated)",
+                "fallback_configured_min_mb": _FALLBACK_MIN_KV_CACHE_MB,
+                "gpu_percent_floor": int(gpu_total * 0.02) if gpu_total > 0 else 0,
+                "gpu_percent_floor_human": _format_size(int(gpu_total * 0.02)) if gpu_total > 0 else "N/A",
+                "hard_minimum": 64 * 1024 * 1024,
+                "hard_minimum_human": "64.00 MB",
+                "env_vars": {
+                    "KVCACHED_MIN_KV_CACHE_MB": "Fallback static floor (default 512)",
+                    "KVCACHED_MIN_SAFE_PAGES_PER_LAYER": "Pages per layer for model-aware calculation (default 2)",
+                },
+                "description": (
+                    "The safety floor prevents setting KV cache limits too low. "
+                    "It is auto-calculated from model parameters "
+                    "(num_layers × num_kv_buffers × page_size × min_safe_pages_per_layer). "
+                    "Falls back to max(KVCACHED_MIN_KV_CACHE_MB, 2%% of GPU memory) "
+                    "if model parameters are unavailable. "
+                    "Use force=true in limit requests to bypass (64 MB hard min still applies)."
+                ),
+            })
+        except Exception as e:
+            logger.error("Error in /kvcache/safety_floor: %s", e)
+            return JSONResponse(status_code=500,
+                                content={"error": str(e)})
+
+    routes = [
+        Route("/kvcache/status", kvcache_status, methods=["GET"]),
+        Route("/kvcache/limit", kvcache_limit, methods=["POST"]),
+        Route("/kvcache/limit_percent", kvcache_limit_percent, methods=["POST"]),
+        Route("/kvcache/trim", kvcache_trim, methods=["POST"]),
+        Route("/kvcache/safety_floor", kvcache_safety_floor, methods=["GET"]),
+    ]
+    return routes
+
+
+def attach_to_app(app) -> None:
+    """Attach the kvcache management routes to a FastAPI/Starlette app.
+
+    Called by the autopatch mechanism after vLLM builds its FastAPI app.
+    Uses Starlette Route objects mounted directly on the app's router to
+    completely bypass vLLM's custom request-validation middleware.
+    Safe to call multiple times (idempotent).
+    """
+    if getattr(app.state, '_kvcached_router_attached', False):
+        return
+    routes = create_router()
+    for route in routes:
+        app.routes.append(route)
+    app.state._kvcached_router_attached = True
+    logger.info(
+        "kvcached KV cache management endpoints registered "
+        "(/kvcache/status, /kvcache/limit, /kvcache/limit_percent, "
+        "/kvcache/trim, /kvcache/safety_floor)")

--- a/kvcached/integration/vllm/autopatch.py
+++ b/kvcached/integration/vllm/autopatch.py
@@ -11,6 +11,7 @@ from kvcached.integration.vllm.patches import (
     VLLM_ALL_RANGE,
     VLLM_V8_RANGE,
     VLLM_V9_PLUS_RANGE,
+    ApiServerPatch,
     ElasticBlockPoolPatch,
     EngineCorePatch,
     GPUModelRunnerPatch,
@@ -44,6 +45,7 @@ def _patch_vllm(_vllm: types.ModuleType) -> None:
             (GPUWorkerPatch(), VLLM_ALL_RANGE),
             (KVCacheCoordinatorPatch(), VLLM_V9_PLUS_RANGE),
             (KVCacheManagerPatch(), VLLM_V8_RANGE),
+            (ApiServerPatch(), VLLM_ALL_RANGE),
         ]
     )
 

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -468,18 +468,34 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
             def get_new_blocks(
                 self, num_blocks: int
             ) -> list["KVCacheBlock"]:
+                if self.enable_prefix_cache and self._evictable_blocks:
+                    # When kvcached is in shrink mode, available_size() returns 0
+                    # and the capacity check below would always fail, creating a
+                    # deadlock. Break it by evicting cached blocks first so that
+                    # free() can trigger shrink recovery.
+                    if self.kv_cache_manager.in_shrink:
+                        self._evict_blocks_from_pool(len(self._evictable_blocks))
+                    else:
+                        # Normal mode: evict only if kvcached doesn't have enough
+                        kvcached_free = self.kv_cache_manager.available_size()
+                        if kvcached_free < num_blocks:
+                            self._evict_blocks_from_pool(num_blocks - kvcached_free)
+
                 if num_blocks > self.get_num_free_blocks():
                     raise ValueError(
                         f"Cannot get {num_blocks} free blocks from the pool")
 
-                if self.enable_prefix_cache:
-                    # Evict cached blocks if kvcached doesn't have enough free space
-                    kvcached_free = self.kv_cache_manager.available_size()
-                    if kvcached_free < num_blocks and self._evictable_blocks:
-                        self._evict_blocks_from_pool(num_blocks - kvcached_free)
-
                 block_ids = self.kv_cache_manager.alloc(num_blocks)
-                assert block_ids is not None and len(block_ids) == num_blocks
+                if block_ids is None or len(block_ids) != num_blocks:
+                    # Shrink mode may leave insufficient blocks after eviction.
+                    # Return what we got back to kvcached and signal failure
+                    # so the scheduler can retry on the next cycle.
+                    if block_ids:
+                        self.kv_cache_manager.free(block_ids)
+                    raise ValueError(
+                        f"kvcached alloc returned {len(block_ids) if block_ids else 0} "
+                        f"blocks, needed {num_blocks} (shrink mode active, "
+                        f"memory will be reclaimed gradually)")
 
                 return [KVCacheBlockClass(bid, ref_cnt=1) for bid in block_ids]
 
@@ -1384,4 +1400,59 @@ class GPUWorkerPatch(VersionAwarePatch, BasePatch):
 
         self._mark_as_patched(_patched_init_device, "init_device")
         Worker.init_device = _patched_init_device  # type: ignore[assignment]
+        return True
+
+
+class ApiServerPatch(VersionAwarePatch, BasePatch):
+    """Patch vLLM's build_app to inject kvcached KV cache management endpoints.
+
+    This adds ``/kvcache/status``, ``/kvcache/limit``, and
+    ``/kvcache/limit_percent`` to every vLLM instance's HTTP server so that
+    each instance can manage its own KV cache memory independently — no
+    external controller or shared /dev/shm access required.
+    """
+
+    library = "vllm"
+    target_module = "vllm.entrypoints.openai.api_server"
+    target_class = None  # We patch a module-level function, not a class
+    patch_name = "api_server_kvcache"
+
+    def can_apply(self, target_module: types.ModuleType) -> bool:
+        return hasattr(target_module, "build_app")
+
+    def apply(self, api_server_mod: types.ModuleType) -> bool:
+        if not self.initialize_version_info():
+            return False
+        return self.patch_build_app(api_server_mod)
+
+    @version_range(VLLM_ALL_RANGE)
+    def patch_build_app(self, api_server_mod: types.ModuleType) -> bool:
+        """Wrap build_app so the returned FastAPI app includes kvcache routes."""
+        original_build_app = getattr(api_server_mod, "build_app", None)
+        if original_build_app is None:
+            self.logger.warning("build_app not found in api_server module")
+            return False
+
+        if self._is_already_patched(original_build_app, "build_app"):
+            self.logger.debug("build_app already patched")
+            return True
+
+        logger = self.logger
+
+        def _patched_build_app(*args: Any, **kwargs: Any):
+            app = original_build_app(*args, **kwargs)
+
+            if not enable_kvcached():
+                return app
+
+            try:
+                from kvcached.integration.vllm.api_router import attach_to_app
+                attach_to_app(app)
+            except Exception as exc:
+                logger.warning("Failed to attach kvcache router: %s", exc)
+
+            return app
+
+        self._mark_as_patched(_patched_build_app, "build_app")
+        api_server_mod.build_app = _patched_build_app
         return True

--- a/kvcached/mem_info_tracker.py
+++ b/kvcached/mem_info_tracker.py
@@ -50,17 +50,39 @@ def _install_cleanup_handlers():
 class MemInfoTracker:
     """Tracks memory usage information through shared memory."""
 
-    def __init__(self, total_mem_size: int, group_id: int = 0):
+    # Minimum number of physical pages per layer to keep the model functional.
+    # 2 pages × page_size(2MB) = 4MB per layer per KV buffer — enough for
+    # a few short requests so the model doesn't become completely unusable.
+    # Configurable via KVCACHED_MIN_SAFE_PAGES_PER_LAYER env var.
+    MIN_SAFE_PAGES_PER_LAYER = int(
+        os.getenv("KVCACHED_MIN_SAFE_PAGES_PER_LAYER", "2"))
+
+    def __init__(self, total_mem_size: int, group_id: int = 0,
+                 num_layers: int = 1, num_kv_buffers: int = 2,
+                 page_size: int = 0):
         """
         Args:
             total_mem_size: Total memory size to initialize shared memory with
             group_id: KV cache group id.  group_id=0 uses DEFAULT_IPC_NAME
                 unchanged; non-zero groups get a "_g<id>" suffix so multiple
                 pools in one process don't share a segment.
+            num_layers: Number of model layers (for min_safe_limit calculation)
+            num_kv_buffers: Number of KV buffers per layer (2 for MHA K+V, 1 for MLA)
+            page_size: Physical page size in bytes (0 = use default PAGE_SIZE)
         """
+        from kvcached.utils import PAGE_SIZE as _default_page_size
+        if page_size <= 0:
+            page_size = _default_page_size
+
         base = DEFAULT_IPC_NAME if group_id == 0 else f"{DEFAULT_IPC_NAME}_g{group_id}"
         self.ipc_name = get_ipc_name(base)
-        init_kv_cache_limit(self.ipc_name, total_mem_size)
+
+        # Auto-calculate minimum safe limit from model parameters
+        min_safe_limit = (num_layers * num_kv_buffers * page_size
+                          * self.MIN_SAFE_PAGES_PER_LAYER)
+
+        init_kv_cache_limit(self.ipc_name, total_mem_size,
+                            min_safe_limit=min_safe_limit)
         _active_trackers.append(self)
         _install_cleanup_handlers()
 

--- a/kvcached/page_allocator.py
+++ b/kvcached/page_allocator.py
@@ -204,7 +204,10 @@ class PageAllocator:
         # Initialize memory info tracker
         self.mem_info_tracker = MemInfoTracker(
             self.mem_size_per_layer * num_layers * num_kv_buffers,
-            group_id=group_id)
+            group_id=group_id,
+            num_layers=num_layers,
+            num_kv_buffers=num_kv_buffers,
+            page_size=page_size)
 
         # Preallocation thread management
         self.enable_page_prealloc: bool = enable_page_prealloc


### PR DESCRIPTION
summary:
In cloud large model service, we need dynamic model service management. 
In recent test, i found model with kvcached support, hbm memory will be full after serving for a period of time. This prevents the scheduling platform form dynamically deploying new models to GPUs with sparsely loaded existing models.
I developed the kv management function for kvcached.
use these endpint to manage gpu memory:
`/kvcache/status`
`/kvcache/limit`
`/kvcache/limit_percent`
`/kvcache/trim`
`/kvcache/safety_floor`

vllm 0.19.1 tested。

example：
curl http://localhost:8080/kvcache/status
curl -X POST http://localhost:8080/kvcache/limit_percent -H "Content-Type: application/json" -d '{"percent": 20}'
curl -X POST http://localhost:8080/kvcache/limit -H "Content-Type: application/json" -d '{"size": "3G"}' 

Set an ultra-large gpu memory limit to lift the gpu memory restriction of this model
curl -X POST http://localhost:8080/kvcache/limit -H "Content-Type: application/json" -d '{"size": "90G"}'  