### PR TITLE
improve: honor in-script ENABLE_KVCACHED by deferring the autopatch gate to import time

### DIFF
--- a/kvcached/integration/sglang/autopatch.py
+++ b/kvcached/integration/sglang/autopatch.py
@@ -23,7 +23,10 @@ logger = get_kvcached_logger()
 
 
 def _env_enabled() -> bool:
-    return os.getenv("KVCACHED_AUTOPATCH", "false").lower() in ("true", "1")
+    autopatch = os.getenv("KVCACHED_AUTOPATCH")
+    if autopatch is not None:
+        return autopatch.lower() in ("true", "1")
+    return os.getenv("ENABLE_KVCACHED", "false").lower() in ("true", "1")
 
 
 @when_imported("sglang")

--- a/kvcached/integration/vllm/autopatch.py
+++ b/kvcached/integration/vllm/autopatch.py
@@ -24,7 +24,10 @@ logger = get_kvcached_logger()
 
 
 def _env_enabled() -> bool:
-    return os.getenv("KVCACHED_AUTOPATCH", "false").lower() in ("true", "1")
+    autopatch = os.getenv("KVCACHED_AUTOPATCH")
+    if autopatch is not None:
+        return autopatch.lower() in ("true", "1")
+    return os.getenv("ENABLE_KVCACHED", "false").lower() in ("true", "1")
 
 
 @when_imported("vllm")

--- a/kvcached_autopatch.pth
+++ b/kvcached_autopatch.pth
@@ -1,1 +1,1 @@
-import os, importlib, importlib.util; (os.environ.setdefault("KVCACHED_AUTOPATCH", "1"), getattr(importlib.import_module("kvcached.autopatch"), "autopatch_all", lambda: None)()) if os.getenv("ENABLE_KVCACHED", "false").lower() in ("true", "1") and importlib.util.find_spec("kvcached.autopatch") is not None else None
+import importlib, importlib.util; (getattr(importlib.import_module("kvcached.autopatch"), "autopatch_all", lambda: None)()) if importlib.util.find_spec("kvcached.autopatch") is not None else None


### PR DESCRIPTION
## Summary
- Make the autopatch hook registration unconditional in `kvcached_autopatch.pth` so `vllm`/`sglang` `@when_imported` hooks are always wired up at interpreter startup.
- Move the enablement check into `_env_enabled()` at hook-fire time: explicit `KVCACHED_AUTOPATCH` wins, otherwise fall back to `ENABLE_KVCACHED`.

Improves pr https://github.com/ovg-project/kvcached/pull/322 and fixes issue #320.

## Behavior matrix
| `ENABLE_KVCACHED` | `KVCACHED_AUTOPATCH` | Before | After |
|---|---|---|---|
| `1` | `1` or unset | patches ✓ | patches ✓ |
| `1` (set in-script) |  `1` or unset | **broken** | patches ✓ |
| `1` | `0` (vendored fork opt-out) | no patch ✓ | no patch ✓ |
| unset | unset | no patch ✓ | no patch ✓ |
