### PR TITLE
Fix illegal memory access caused by missing _kernel_block_sizes attribute in some vLLM versions

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -1061,6 +1061,7 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
 
         # Capture patch instance for version-aware access
         patch_instance = self
+        logger = self.logger  # Capture logger in closure
 
         def _allocate_kv_cache_from_kvcached(self, kv_cache_config):
             import torch
@@ -1161,6 +1162,71 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 if kernel_block_sizes is not None
                 and first_attn_group_id < len(kernel_block_sizes)
                 else None)
+
+            if kernel_block_size is None:
+                logger.warning("kernel_block_size is None, try to compute from the attention backend's supported block sizes")
+                try:
+                    # Try to compute kernel_block_size from the attention backend's
+                    # supported block sizes, mirroring vLLM's
+                    # prepare_kernel_block_sizes / select_common_block_size logic.
+                    kv_manager_block_size = kv_cache_spec.block_size
+                    supported_sizes = None
+                    if hasattr(attn_backend_cls, 'get_supported_kernel_block_sizes'):
+                        supported_sizes = attn_backend_cls.get_supported_kernel_block_sizes()
+                    elif hasattr(attn_backend_cls, 'get_supported_block_sizes'):
+                        supported_sizes = attn_backend_cls.get_supported_block_sizes()
+
+                    if supported_sizes:
+                        # Import MultipleOf for isinstance checks
+                        try:
+                            from vllm.v1.attention.backend import MultipleOf as _MultipleOf
+                        except ImportError:
+                            _MultipleOf = None  # type: ignore[misc]
+
+                        # Check if the kv_manager_block_size is directly supported
+                        directly_supported = False
+                        for s in supported_sizes:
+                            if isinstance(s, int) and s == kv_manager_block_size:
+                                directly_supported = True
+                                break
+                            elif isinstance(s, range) and kv_manager_block_size in s:
+                                directly_supported = True
+                                break
+                            elif (_MultipleOf is not None
+                                and isinstance(s, _MultipleOf)
+                                and kv_manager_block_size % s.base == 0):
+                                directly_supported = True
+                                break
+                        if not directly_supported:
+                            # Pick the largest supported size that divides kv_manager_block_size
+                            candidates = []
+                            for s in supported_sizes:
+                                if isinstance(s, int):
+                                    if kv_manager_block_size % s == 0:
+                                        candidates.append(s)
+                                elif isinstance(s, range):
+                                    for v in s:
+                                        if kv_manager_block_size % v == 0:
+                                            candidates.append(v)
+                                elif (_MultipleOf is not None
+                                    and isinstance(s, _MultipleOf)):
+                                    if kv_manager_block_size % s.base == 0:
+                                        candidates.append(kv_manager_block_size)
+                            if candidates:
+                                kernel_block_size = max(candidates)
+                except Exception:
+                    pass
+            # Fallback: try prepare_kernel_block_sizes if available
+            if kernel_block_size is None:
+                try:
+                    from vllm.v1.worker.utils import prepare_kernel_block_sizes as _prep_kbs
+                    _attn_groups = getattr(self, "attn_groups", None)
+                    if _attn_groups is not None:
+                        _kbs_list = _prep_kbs(kv_cache_config, _attn_groups)
+                        if first_attn_group_id < len(_kbs_list):
+                            kernel_block_size = _kbs_list[first_attn_group_id]
+                except Exception:
+                    pass
 
             alloc_result = kvi.alloc_kv_cache(
                 kv_cache_shape,

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -1061,7 +1061,6 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
 
         # Capture patch instance for version-aware access
         patch_instance = self
-        logger = self.logger  # Capture logger in closure
 
         def _allocate_kv_cache_from_kvcached(self, kv_cache_config):
             import torch
@@ -1157,76 +1156,40 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             # by kernel-block stride. Forward kernel_block_size so we build the
             # per-layer tensor at kernel granularity.
             kernel_block_sizes = getattr(self, "_kernel_block_sizes", None)
+            has_kernel_block_size_source = kernel_block_sizes is not None
+            if kernel_block_sizes is None:
+                prepare_kernel_block_sizes = getattr(
+                    self, "_prepare_kernel_block_sizes", None
+                )
+                if prepare_kernel_block_sizes is not None:
+                    has_kernel_block_size_source = True
+                    kernel_block_sizes = prepare_kernel_block_sizes(kv_cache_config)
+
+            if kernel_block_sizes is None:
+                try:
+                    from vllm.v1.worker.utils import prepare_kernel_block_sizes
+                except ImportError:
+                    pass
+                else:
+                    attn_groups = getattr(self, "attn_groups", None)
+                    if attn_groups is not None:
+                        has_kernel_block_size_source = True
+                        kernel_block_sizes = prepare_kernel_block_sizes(
+                            kv_cache_config, attn_groups
+                        )
+
             kernel_block_size = (
                 kernel_block_sizes[first_attn_group_id]
                 if kernel_block_sizes is not None
                 and first_attn_group_id < len(kernel_block_sizes)
                 else None)
-
-            if kernel_block_size is None:
-                logger.warning("kernel_block_size is None, try to compute from the attention backend's supported block sizes")
-                try:
-                    # Try to compute kernel_block_size from the attention backend's
-                    # supported block sizes, mirroring vLLM's
-                    # prepare_kernel_block_sizes / select_common_block_size logic.
-                    kv_manager_block_size = kv_cache_spec.block_size
-                    supported_sizes = None
-                    if hasattr(attn_backend_cls, 'get_supported_kernel_block_sizes'):
-                        supported_sizes = attn_backend_cls.get_supported_kernel_block_sizes()
-                    elif hasattr(attn_backend_cls, 'get_supported_block_sizes'):
-                        supported_sizes = attn_backend_cls.get_supported_block_sizes()
-
-                    if supported_sizes:
-                        # Import MultipleOf for isinstance checks
-                        try:
-                            from vllm.v1.attention.backend import MultipleOf as _MultipleOf
-                        except ImportError:
-                            _MultipleOf = None  # type: ignore[misc]
-
-                        # Check if the kv_manager_block_size is directly supported
-                        directly_supported = False
-                        for s in supported_sizes:
-                            if isinstance(s, int) and s == kv_manager_block_size:
-                                directly_supported = True
-                                break
-                            elif isinstance(s, range) and kv_manager_block_size in s:
-                                directly_supported = True
-                                break
-                            elif (_MultipleOf is not None
-                                and isinstance(s, _MultipleOf)
-                                and kv_manager_block_size % s.base == 0):
-                                directly_supported = True
-                                break
-                        if not directly_supported:
-                            # Pick the largest supported size that divides kv_manager_block_size
-                            candidates = []
-                            for s in supported_sizes:
-                                if isinstance(s, int):
-                                    if kv_manager_block_size % s == 0:
-                                        candidates.append(s)
-                                elif isinstance(s, range):
-                                    for v in s:
-                                        if kv_manager_block_size % v == 0:
-                                            candidates.append(v)
-                                elif (_MultipleOf is not None
-                                    and isinstance(s, _MultipleOf)):
-                                    if kv_manager_block_size % s.base == 0:
-                                        candidates.append(kv_manager_block_size)
-                            if candidates:
-                                kernel_block_size = max(candidates)
-                except Exception:
-                    pass
-            # Fallback: try prepare_kernel_block_sizes if available
-            if kernel_block_size is None:
-                try:
-                    from vllm.v1.worker.utils import prepare_kernel_block_sizes as _prep_kbs
-                    _attn_groups = getattr(self, "attn_groups", None)
-                    if _attn_groups is not None:
-                        _kbs_list = _prep_kbs(kv_cache_config, _attn_groups)
-                        if first_attn_group_id < len(_kbs_list):
-                            kernel_block_size = _kbs_list[first_attn_group_id]
-                except Exception:
-                    pass
+            if kernel_block_size is None and has_kernel_block_size_source:
+                raise RuntimeError(
+                    "kvcached could not determine the vLLM kernel block size. "
+                    "This value is required when vLLM splits a virtual KV block "
+                    "into smaller kernel blocks; falling back to block_size can "
+                    "produce invalid KV cache strides."
+                )
 
             alloc_result = kvi.alloc_kv_cache(
                 kv_cache_shape,

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -1158,23 +1158,27 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             kernel_block_sizes = getattr(self, "_kernel_block_sizes", None)
             has_kernel_block_size_source = kernel_block_sizes is not None
             if kernel_block_sizes is None:
-                prepare_kernel_block_sizes = getattr(
+                prepare_kernel_block_sizes_method = getattr(
                     self, "_prepare_kernel_block_sizes", None
                 )
-                if prepare_kernel_block_sizes is not None:
+                if prepare_kernel_block_sizes_method is not None:
                     has_kernel_block_size_source = True
-                    kernel_block_sizes = prepare_kernel_block_sizes(kv_cache_config)
+                    kernel_block_sizes = prepare_kernel_block_sizes_method(
+                        kv_cache_config
+                    )
 
             if kernel_block_sizes is None:
                 try:
-                    from vllm.v1.worker.utils import prepare_kernel_block_sizes
+                    from vllm.v1.worker.utils import (
+                        prepare_kernel_block_sizes as prepare_kernel_block_sizes_fn,
+                    )
                 except ImportError:
                     pass
                 else:
                     attn_groups = getattr(self, "attn_groups", None)
                     if attn_groups is not None:
                         has_kernel_block_size_source = True
-                        kernel_block_sizes = prepare_kernel_block_sizes(
+                        kernel_block_sizes = prepare_kernel_block_sizes_fn(
                             kv_cache_config, attn_groups
                         )
 


### PR DESCRIPTION
In vLLM 0.16, gpu_model_runner does not have the `self._kernel_block_sizes` attribute. As a result, kernel_block_sizes = getattr(self, "_kernel_block_sizes", None) returns None, which causes kvcached to incorrectly assume ratio = 1. This leads to an excessively large stride value being computed, ultimately resulting in an illegal memory access error.

For example:

| Variable | Value |
|----------|-------|
| Model | Qwen3.5-9B hybrid architecture |
| kv_cache_group[0,1,2] | MambaSpec |
| kv_cache_group[3] | FullAttentionSpec, layers=8, block_size=528 |
| num_kv_heads | 4 |
| head_size | 256 |
| page_size_bytes | 2,162,688 > 2MB |
| virtual block size | 528 |
| FA3 kernel_block_size | 16 (determined by get_supported_kernel_block_sizes()) |


| Variable | Incorrect Value | Correct Value |
|----------|----------------|---------------|
| kernel_block_size | 528 | 16 |
| ratio | 1 | 33 (= 528 ÷ 16) |
| kernel_kvcache_shape | [2, **2699**, 528, 4, 256] | [2, **89067**, 16, 4, 256] |
| kvcached's perspective | One FA3 kernel block holds 528 tokens, up to **2,699** blocks | One FA3 kernel block holds 16 tokens, up to **89,067** blocks |
| vllm's perspective | One FA3 kernel block holds 16 tokens, up to **89,067** blocks | One FA3 kernel block holds 16 tokens, up to **89,067** blocks |
| block dimension stride | **1,081,344 illegal memory access!!!** (=528\*4\*256\*2) | 32,768 (=2\*16\*4\*256) |



This PR adds proper handling for the case where _kernel_block_sizes is not defined, ensuring the stride is computed correctly across different vLLM versions.