### PR TITLE
fix: handle str block_hash in prefix cache key encoding

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -349,6 +349,8 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 big-endian group_id so the same content hash is distinct across
                 KV cache groups (e.g. full attention vs sliding window).
                 """
+                if isinstance(block_hash, str):
+                    block_hash = block_hash.encode()
                 return bytes(block_hash) + group_id.to_bytes(4, "big", signed=False)
 
             def get_cached_block(

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -253,6 +253,24 @@ def _get_max_cached_blocks(block_size: int) -> int:
         return 0
     return MAX_CACHED_TOKENS // block_size
 
+
+def _make_cache_key(block_hash: Any, group_id: int) -> bytes:
+    """Pack block_hash + group_id into a composite cache key.
+
+    Mirrors vLLM's make_block_hash_with_group_id: appends a 4-byte big-endian
+    group_id so the same content hash is distinct across KV cache groups
+    (e.g. full attention vs sliding window). ``block_hash`` may arrive as
+    ``bytes`` (the common case) or ``str`` (some vLLM versions pass a hex
+    digest); a str is encoded to bytes so both inputs produce identical keys.
+
+    Module-level (rather than a nested staticmethod) so it is unit-testable
+    without applying the vLLM patch or holding a GPU.
+    """
+    if isinstance(block_hash, str):
+        block_hash = block_hash.encode()
+    return bytes(block_hash) + group_id.to_bytes(4, "big", signed=False)
+
+
 class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
     """Inject ElasticBlockPool into vLLM's block pool module"""
 
@@ -341,18 +359,6 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 # cross-request prefix reuse. Insertion order = LRU order.
                 self._evictable_blocks: OrderedDict[int, KVCacheBlock] = OrderedDict()
 
-            @staticmethod
-            def _make_cache_key(block_hash: Any, group_id: int) -> bytes:
-                """Pack block_hash + group_id into a composite cache key.
-
-                Mirrors vLLM's make_block_hash_with_group_id: appends 4-byte
-                big-endian group_id so the same content hash is distinct across
-                KV cache groups (e.g. full attention vs sliding window).
-                """
-                if isinstance(block_hash, str):
-                    block_hash = block_hash.encode()
-                return bytes(block_hash) + group_id.to_bytes(4, "big", signed=False)
-
             def get_cached_block(
                 self,
                 block_hash: Any,
@@ -367,14 +373,14 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 # - Newer hybrid-attention paths pass multiple group ids and
                 #   expect one block per group.
                 if kv_cache_group_ids is None:
-                    key = self._make_cache_key(block_hash, 0)
+                    key = _make_cache_key(block_hash, 0)
                     return self._cached_blocks.get(key)
                 if isinstance(kv_cache_group_ids, int):
                     kv_cache_group_ids = [int(kv_cache_group_ids)]
 
                 cached_blocks: list[KVCacheBlock] = []
                 for group_id in kv_cache_group_ids:
-                    key = self._make_cache_key(block_hash, int(group_id))
+                    key = _make_cache_key(block_hash, int(group_id))
                     block = self._cached_blocks.get(key)
                     if block is None:
                         # Atomic: all groups must hit or return None
@@ -446,7 +452,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
 
                     block_idx = num_cached_blocks + i
                     block_hash = block_hashes[block_idx]
-                    key = self._make_cache_key(block_hash, kv_cache_group_id)
+                    key = _make_cache_key(block_hash, kv_cache_group_id)
 
                     # Already cached, idempotent
                     if key in self._cached_blocks:

--- a/tests/test_make_cache_key.py
+++ b/tests/test_make_cache_key.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``_make_cache_key`` (prefix-cache composite key encoding).
+
+GPU-free: ``_make_cache_key`` is a module-level pure function in
+``kvcached.integration.vllm.patches`` and needs neither the ``vmm_ops``
+extension, a GPU, nor an installed vLLM. It guards the str-hash fix: some vLLM
+versions pass a ``str`` (hex digest) where ``bytes(block_hash)`` would raise
+``TypeError``.
+"""
+import pytest
+
+from kvcached.integration.vllm.patches import _make_cache_key
+
+
+def _gid(group_id: int) -> bytes:
+    return group_id.to_bytes(4, "big", signed=False)
+
+
+def test_bytes_hash_roundtrip():
+    assert _make_cache_key(b"deadbeef", 0) == b"deadbeef" + _gid(0)
+
+
+def test_str_hash_encoded_like_bytes():
+    """A str hash must not raise and must produce the same key as bytes."""
+    assert _make_cache_key("deadbeef", 3) == b"deadbeef" + _gid(3)
+    assert _make_cache_key("deadbeef", 3) == _make_cache_key(b"deadbeef", 3)
+
+
+def test_str_does_not_raise_regression():
+    """Before the fix, bytes(str) raised TypeError; guard against regression."""
+    _make_cache_key("0a1b2c3d" * 8, 0)  # 64-char hex digest, must not raise
+
+
+def test_group_id_distinguishes_keys():
+    h = b"samehash"
+    assert _make_cache_key(h, 0) != _make_cache_key(h, 1)
+    # group_id is the 4-byte big-endian suffix.
+    assert _make_cache_key(h, 1)[-4:] == _gid(1)
+
+
+@pytest.mark.parametrize("group_id", [0, 1, 255, 256, 65535, 2 ** 31 - 1])
+def test_group_id_encoding_width(group_id):
+    key = _make_cache_key(b"h", group_id)
+    assert key == b"h" + _gid(group_id)
+    assert len(key) == len(b"h") + 4

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -279,7 +279,7 @@ class TestEvictOnDemand:
 
     def test_evict_on_alloc_pressure(self, pool_factory):
         """When kvcached is full, get_new_blocks evicts from the pool."""
-        pool, mgr = pool_factory(10)
+        pool, mgr = pool_factory(11)  # +1 for null_block
 
         # Fill all 10 blocks and cache them
         blocks = _simulate_request(pool, [f"h{i}" for i in range(10)])
@@ -298,7 +298,7 @@ class TestEvictOnDemand:
 
     def test_evict_lru_order(self, pool_factory):
         """Oldest blocks (first inserted) are evicted first."""
-        pool, mgr = pool_factory(10)
+        pool, mgr = pool_factory(11)  # +1 for null_block
 
         # Cache blocks h0..h9 in order
         blocks = _simulate_request(pool, [f"h{i}" for i in range(10)])
@@ -314,7 +314,7 @@ class TestEvictOnDemand:
 
     def test_evict_all_then_alloc(self, pool_factory):
         """Can evict entire pool and allocate fresh blocks."""
-        pool, mgr = pool_factory(5)
+        pool, mgr = pool_factory(6)  # +1 for null_block
 
         blocks = _simulate_request(pool, ["a", "b", "c", "d", "e"])
         _finish_request(pool, blocks)
@@ -328,7 +328,7 @@ class TestEvictOnDemand:
 
     def test_partial_eviction(self, pool_factory):
         """Evict only as many as needed, keep the rest."""
-        pool, mgr = pool_factory(10)
+        pool, mgr = pool_factory(11)  # +1 for null_block
 
         blocks = _simulate_request(pool, [f"h{i}" for i in range(10)])
         _finish_request(pool, blocks)
@@ -340,13 +340,13 @@ class TestEvictOnDemand:
 
     def test_no_eviction_when_kvcached_has_space(self, pool_factory):
         """Don't evict if kvcached already has enough free blocks."""
-        pool, mgr = pool_factory(20)
+        pool, mgr = pool_factory(21)  # +1 for null_block
 
         # Use 5 blocks, cache them, free them
         blocks = _simulate_request(pool, [f"h{i}" for i in range(5)])
         _finish_request(pool, blocks)
         assert len(pool._evictable_blocks) == 5
-        assert mgr.available_size() == 15  # 20 - 5 held by evictable
+        assert mgr.available_size() == 15  # 21-1(null)-5 = 15
 
         # Allocate 3 -- kvcached has 15 free, no eviction needed
         new_blocks = pool.get_new_blocks(3)
@@ -370,17 +370,17 @@ class TestResetAndExplicitEviction:
 
     def test_reset_frees_evictable_blocks(self, pool_factory):
         """reset_prefix_cache frees all evictable blocks to kvcached."""
-        pool, mgr = pool_factory(20)
+        pool, mgr = pool_factory(21)  # +1 for null_block
 
         blocks = _simulate_request(pool, ["h0", "h1", "h2"])
         _finish_request(pool, blocks)
-        assert mgr.available_size() == 17  # 20 - 3 held by pool
+        assert mgr.available_size() == 17  # 21-1(null)-3 = 17
 
         pool.reset_prefix_cache()
         assert len(pool._evictable_blocks) == 0
         assert len(pool._cached_blocks) == 0
-        assert len(pool._block_id_to_hash) == 0
-        assert mgr.available_size() == 20  # all freed
+        assert len(pool._block_id_to_key) == 0
+        assert mgr.available_size() == 20  # all freed (null_block still allocated)
 
     def test_reset_with_no_evictable(self, pool_and_manager):
         """reset_prefix_cache works even when evictable pool is empty."""
@@ -487,7 +487,7 @@ class TestEdgeCases:
 
     def test_reuse_after_eviction_and_realloc(self, pool_factory):
         """After eviction, block IDs can be reallocated and recached."""
-        pool, mgr = pool_factory(4)
+        pool, mgr = pool_factory(5)  # +1 for null_block
 
         # Fill cache
         blocks = _simulate_request(pool, ["h0", "h1", "h2", "h3"])
@@ -523,8 +523,9 @@ class TestEdgeCases:
     def test_get_usage(self, pool_factory):
         """get_usage reflects the fraction of blocks in use."""
         pool, mgr = pool_factory(100)
-        assert pool.get_usage() == 0.0
+        # null_block occupies 1/100, so usage is ~0.01
+        assert pool.get_usage() == pytest.approx(0.01, abs=0.001)
 
         pool.get_new_blocks(50)
-        # 50 allocated from kvcached, 0 evictable -> 50 free from kvcached + 0 evictable
-        assert pool.get_usage() == pytest.approx(0.5)
+        # 50+1(null) allocated, 0 evictable -> 49 free from kvcached
+        assert pool.get_usage() == pytest.approx(0.51)


### PR DESCRIPTION
## Summary

### `_make_cache_key` TypeError fix
`_make_cache_key` calls `bytes(block_hash)` which raises `TypeError` when vLLM
passes a string hash (e.g. hex digest). Added an `isinstance(block_hash, str)`
check to encode str to bytes first. Bytes input path is unchanged.

### Tests out of sync with null_block allocation
PR #319 (`c95e1c4`, *Page Allocator Migrates from Python to C++*) introduced a
null_block placeholder allocation in `ElasticBlockPool.__init__`:

```python
_null_ids = self.kv_cache_manager.alloc(1)
self.null_block = self.kv_block_pool[_null_ids[0]]
```

This consumes one block during pool initialization, but the test expectations in
`test_prefix_cache.py` were not updated to account for it. The tests were not
caught because the CI workflow does not run pytest.

Affected tests and their adjustments:
- `pool_factory(N)` → `pool_factory(N+1)` in 7 tests where the pool is fully filled
- `test_get_usage`: adjusted expected values to account for the null_block
- `test_reset_frees_evictable_blocks`: fixed `_block_id_to_hash` (renamed to `_block_id_to_key`)

## Test plan
- [x] `pytest tests/test_kvcache_manager.py` — 4 passed, 1 skipped
- [x] `pytest tests/test_shm_info_tracker.py` — 8 passed
- [x] `pytest tests/test_prefix_cache.py` — 26 passed
- [x] `pre-commit run --all-files` — all 12 hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
