### PR TITLE
fix: cache worker IPC state for prealloc thread

### DIFF
--- a/csrc/inc/page_allocator.hpp
+++ b/csrc/inc/page_allocator.hpp
@@ -171,6 +171,7 @@ private:
   BroadcastMapCallback broadcast_map_callback_;
   BroadcastUnmapCallback broadcast_unmap_callback_;
   ShouldUseWorkerIpcCallback should_use_worker_ipc_callback_;
+  mutable std::atomic<bool> should_use_worker_ipc_cached_{false};
 };
 
 } // namespace kvcached

--- a/csrc/page_allocator.cpp
+++ b/csrc/page_allocator.cpp
@@ -516,8 +516,11 @@ void PageAllocator::set_broadcast_unmap_callback(
 
 void PageAllocator::set_should_use_worker_ipc_callback(
     ShouldUseWorkerIpcCallback callback) {
+  bool use_worker_ipc = callback ? callback() : false;
   std::lock_guard<std::mutex> lock(lock_);
-  should_use_worker_ipc_callback_ = callback;
+  should_use_worker_ipc_callback_ = std::move(callback);
+  should_use_worker_ipc_cached_.store(use_worker_ipc,
+                                      std::memory_order_release);
   LOGGER(INFO, "Should-use-worker-ipc callback set for PageAllocator");
 }
 
@@ -755,10 +758,26 @@ void PageAllocator::stop_prealloc_thread_internal() {
 }
 
 bool PageAllocator::should_use_worker_ipc() const {
-  if (should_use_worker_ipc_callback_) {
-    return should_use_worker_ipc_callback_();
+  ShouldUseWorkerIpcCallback callback;
+  {
+    std::lock_guard<std::mutex> lock(lock_);
+    if (prealloc_thread_ &&
+        prealloc_thread_->get_id() == std::this_thread::get_id()) {
+      // The background prealloc thread must not re-enter Python here. It only
+      // consumes the cached decision, which non-prealloc callers refresh.
+      return should_use_worker_ipc_cached_.load(std::memory_order_acquire);
+    }
+    callback = should_use_worker_ipc_callback_;
   }
-  return false;
+
+  if (callback) {
+    bool use_worker_ipc = callback();
+    should_use_worker_ipc_cached_.store(use_worker_ipc,
+                                        std::memory_order_release);
+    return use_worker_ipc;
+  }
+
+  return should_use_worker_ipc_cached_.load(std::memory_order_acquire);
 }
 
 void PageAllocator::resize_watcher() {


### PR DESCRIPTION
## Summary

Fix single-GPU startup hangs by caching the worker-IPC decision for the C++ background prealloc thread instead of calling back into Python from that thread.

Related issue: [#334](https://github.com/ovg-project/kvcached/issues/334)

## Root cause

On world_size=1, the background prealloc thread enters PageAllocator::map_pages() during startup and evaluates should_use_worker_ipc().

That check was implemented as a Python callback. The prealloc thread therefore tried to re-enter Python while the main Python thread was still inside extension code and holding the GIL during startup. The background thread stalled before the first KV page mapping call, preallocation never completed, and the server never became ready.

An earlier revision of this PR avoided the hang by skipping the background prealloc thread for world_size=1, but it did not fix the underlying cause and was not part of upstream.

## Changes

- Cache the should_use_worker_ipc() result when the callback is installed from the Python-owned thread.
- Make the C++ prealloc thread read that cached value instead of calling back into Python.
- Keep the existing callback path for non-prealloc-thread callers.
- Keep world_size=1 on the normal background-preallocation flow; the merged implementation does not add or remove any upstream Python-side skip workaround.

## Why this approach

This keeps the behavior change narrowly scoped to the background prealloc thread, which is the only place that needs to avoid Python callback re-entry during startup. It restores the intended preallocation behavior on single-GPU startup instead of bypassing it.

## Validation

Validated against the single-GPU reproduction described in issue #334:

- vLLM 0.18.1
- world_size=1
- kvcached enabled
- async scheduling enabled
- eager mode enabled

Observed after the fix:

- Background prealloc runs on single-GPU startup
- Log shows `Mapped 3 pages to KV tensors`
- Log shows `Preallocated 3 pages, reserved=3`
- `GET /health` returns 200
- `GET /v1/models` returns 200
- Real `POST /v1/chat/completions` returns 200

## Notes

Earlier revisions of this PR skipped background preallocation for world_size=1. The merged implementation does not use that workaround; it fixes the verified #334 deadlock mechanism directly by caching the worker-IPC decision. Its scope is limited to that decision check: in worker-IPC mode, map broadcasts can still re-enter Python, and the general #371 fix requires releasing the GIL in blocking bindings.