### PR TITLE
fix: reuse recorded tp world size in coordinator

### DIFF
--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -29,6 +29,16 @@ _is_worker: bool = False
 def should_use_worker_ipc() -> bool:
     return _kvcached_initialized and not _is_worker
 
+
+def get_world_size() -> int:
+    """Return the TP world size recorded by the latest initialization."""
+    if not _kvcached_initialized:
+        raise RuntimeError(
+            "kvcached is not initialized. Please call init_kvcached() first."
+        )
+    return _world_size
+
+
 def init_kvcached(
     tp_rank: int = 0,
     world_size: int = 1,

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -765,10 +765,13 @@ class KVCacheCoordinatorPatch(VersionAwarePatch, BasePatch):
 
             try:
                 self._setup_kvcached_coordinator()
-            except KVCachedConfigError:
+            except (KVCachedConfigError, RuntimeError):
                 # User-fixable misconfiguration (e.g. KV block larger than the
-                # page size). Abort loudly instead of silently disabling
-                # kvcached and falling back to vanilla allocation.
+                # page size), or a broken kvcached invariant such as
+                # get_world_size() finding kvcached uninitialized. Abort loudly
+                # instead of silently disabling kvcached and falling back to
+                # vanilla allocation: a half-applied coordinator patch changes
+                # KV behaviour while leaving only a warning in the log.
                 raise
             except Exception as e:
                 logger.warning("Failed to patch kv_cache_coordinator: %s", e)

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -801,14 +801,12 @@ class KVCacheCoordinatorPatch(VersionAwarePatch, BasePatch):
             cell_size, num_kv_buffers = _get_kv_cache_params(
                 kv_cache_spec, block_size, attention_type=attention_type)
 
-            try:
-                from vllm.distributed.parallel_state import get_tensor_model_parallel_world_size
-
-                tp_size = int(get_tensor_model_parallel_world_size())
-            except Exception:
-                tp_size = 1
-
             from kvcached.integration.vllm import interfaces as kvi
+
+            # EngineCore records tensor_parallel_size before constructing this
+            # coordinator. parallel_state is not authoritative here: depending
+            # on startup timing it can either raise or still report world size 1.
+            tp_size = int(kvi.get_world_size())
 
             # Use tp_size (not TP*PP global world size) for the KVCacheManager world_size.
             # Each PP stage manages its own KV tensors independently. The IPC sockets

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -707,22 +707,19 @@ class EngineCorePatch(VersionAwarePatch, BasePatch):
 
         def _patched_engine_init(self, vllm_config, *args: Any, **kwargs: Any):
             if enable_kvcached():
-                try:
-                    from kvcached.integration.vllm.interfaces import init_kvcached
+                from kvcached.integration.vllm.interfaces import init_kvcached
 
-                    # IMPORTANT: use tp_size only, NOT tp_size * pp_size.
-                    # The kvcached IPC mechanism coordinates KV tensor readiness
-                    # within a single PP stage's TP group (w0.sock … w(tp-1).sock).
-                    # Each PP stage manages its own KV memory independently, so
-                    # cross-stage IPC is neither needed nor correct.
-                    init_kvcached(
-                        tp_rank=0,
-                        world_size=vllm_config.parallel_config.tensor_parallel_size,
-                        is_worker=False,
-                        async_sched=_should_enable_async_sched(vllm_config),
-                    )
-                except Exception:
-                    pass
+                # IMPORTANT: use tp_size only, NOT tp_size * pp_size.
+                # The kvcached IPC mechanism coordinates KV tensor readiness
+                # within a single PP stage's TP group (w0.sock … w(tp-1).sock).
+                # Each PP stage manages its own KV memory independently, so
+                # cross-stage IPC is neither needed nor correct.
+                init_kvcached(
+                    tp_rank=0,
+                    world_size=vllm_config.parallel_config.tensor_parallel_size,
+                    is_worker=False,
+                    async_sched=_should_enable_async_sched(vllm_config),
+                )
             return original_init(self, vllm_config, *args, **kwargs)
 
         self._mark_as_patched(_patched_engine_init, "init")

--- a/tests/test_vllm_tp_world_size.py
+++ b/tests/test_vllm_tp_world_size.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import sys
+import types
+from typing import Any
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture
+def vllm_modules(monkeypatch):
+    torch = mock.MagicMock()
+    torch.__version__ = "2.6.0"
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "torch.cuda", torch.cuda)
+    monkeypatch.setitem(sys.modules, "torch.utils", torch.utils)
+    monkeypatch.setitem(
+        sys.modules, "torch.utils.cpp_extension", torch.utils.cpp_extension
+    )
+    monkeypatch.setitem(sys.modules, "posix_ipc", mock.MagicMock())
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", mock.MagicMock())
+    monkeypatch.delitem(
+        sys.modules, "kvcached.integration.vllm.interfaces", raising=False
+    )
+    monkeypatch.delitem(
+        sys.modules, "kvcached.integration.vllm.patches", raising=False
+    )
+
+    interfaces: Any = importlib.import_module(
+        "kvcached.integration.vllm.interfaces"
+    )
+    patches: Any = importlib.import_module("kvcached.integration.vllm.patches")
+    return interfaces, patches
+
+
+def test_get_world_size_returns_engine_core_recorded_value(
+    monkeypatch, vllm_modules
+):
+    interfaces, _ = vllm_modules
+    monkeypatch.setattr(interfaces, "_kvcached_initialized", True)
+    monkeypatch.setattr(interfaces, "_world_size", 4)
+
+    assert interfaces.get_world_size() == 4
+
+
+def test_get_world_size_rejects_uninitialized_state(monkeypatch, vllm_modules):
+    interfaces, _ = vllm_modules
+    monkeypatch.setattr(interfaces, "_kvcached_initialized", False)
+
+    with pytest.raises(RuntimeError, match="kvcached is not initialized"):
+        interfaces.get_world_size()
+
+
+class FakeElasticBlockPool:
+    def __init__(self, *args, **kwargs):
+        self.null_block = object()
+
+
+def test_coordinator_uses_recorded_world_size(monkeypatch, vllm_modules):
+    interfaces, patches = vllm_modules
+    monkeypatch.setattr(patches, "enable_kvcached", lambda: True)
+    monkeypatch.setattr(patches, "_validate_kv_cache_groups", lambda cfg: None)
+    monkeypatch.setattr(
+        patches,
+        "_get_first_attention_group",
+        lambda cfg: types.SimpleNamespace(
+            kv_cache_spec=types.SimpleNamespace(block_size=16)
+        ),
+    )
+    monkeypatch.setattr(patches, "_infer_attention_type", lambda cfg: "MHA")
+    monkeypatch.setattr(
+        patches, "_get_kv_cache_params", lambda *args, **kwargs: (1024, 2)
+    )
+    monkeypatch.setattr(patches, "_get_group_size", lambda cfg: 1)
+    monkeypatch.setattr(patches, "_get_max_cached_blocks", lambda block_size: 0)
+    monkeypatch.setattr(patches, "_should_enable_async_sched", lambda cfg: False)
+    monkeypatch.setattr(interfaces, "_kvcached_initialized", True)
+    monkeypatch.setattr(interfaces, "get_world_size", lambda: 4)
+    init_kvcached = mock.Mock()
+    monkeypatch.setattr(interfaces, "init_kvcached", init_kvcached)
+
+    fake_block_pool_mod = types.ModuleType("vllm.v1.core.block_pool")
+    setattr(fake_block_pool_mod, "ElasticBlockPool", FakeElasticBlockPool)
+    monkeypatch.setitem(
+        sys.modules, "vllm.v1.core.block_pool", fake_block_pool_mod
+    )
+
+    kvcoord_mod = types.ModuleType("mock_kvcoord_mod")
+
+    class FakeKVCacheCoordinator:
+        def __init__(self, *args, **kwargs):
+            self.enable_caching = False
+            self.kv_cache_config = types.SimpleNamespace(num_blocks=8)
+            self.single_type_managers = [types.SimpleNamespace()]
+
+    setattr(kvcoord_mod, "KVCacheCoordinator", FakeKVCacheCoordinator)
+
+    assert patches.KVCacheCoordinatorPatch().patch_coordinator(kvcoord_mod)
+    coordinator = kvcoord_mod.KVCacheCoordinator()
+
+    assert init_kvcached.call_args.kwargs["world_size"] == 4
+    assert isinstance(getattr(coordinator, "block_pool"), FakeElasticBlockPool)

--- a/tests/test_vllm_tp_world_size.py
+++ b/tests/test_vllm_tp_world_size.py
@@ -167,3 +167,54 @@ def test_coordinator_uses_recorded_world_size(monkeypatch, vllm_modules):
 
     assert init_kvcached.call_args.kwargs["world_size"] == 4
     assert isinstance(getattr(coordinator, "block_pool"), FakeElasticBlockPool)
+
+
+def test_coordinator_propagates_uninitialized_world_size(
+    monkeypatch, vllm_modules
+):
+    """An uninitialized kvcached must abort startup, not warn and continue.
+
+    ``get_world_size()`` raises when ``init_kvcached()`` never ran, and the
+    coordinator patch used to swallow that into a warning — leaving the engine
+    running with a half-applied patch and no signal beyond one log line.
+    """
+    interfaces, patches = vllm_modules
+    monkeypatch.setattr(patches, "enable_kvcached", lambda: True)
+    monkeypatch.setattr(patches, "_validate_kv_cache_groups", lambda cfg: None)
+    monkeypatch.setattr(
+        patches,
+        "_get_first_attention_group",
+        lambda cfg: types.SimpleNamespace(
+            kv_cache_spec=types.SimpleNamespace(block_size=16)
+        ),
+    )
+    monkeypatch.setattr(patches, "_infer_attention_type", lambda cfg: "MHA")
+    monkeypatch.setattr(
+        patches, "_get_kv_cache_params", lambda *args, **kwargs: (1024, 2)
+    )
+    monkeypatch.setattr(patches, "_get_group_size", lambda cfg: 1)
+    monkeypatch.setattr(patches, "_get_max_cached_blocks", lambda block_size: 0)
+    monkeypatch.setattr(patches, "_should_enable_async_sched", lambda cfg: False)
+    # EngineCore never recorded a world size, so get_world_size() raises.
+    monkeypatch.setattr(interfaces, "_kvcached_initialized", False)
+
+    fake_block_pool_mod = types.ModuleType("vllm.v1.core.block_pool")
+    setattr(fake_block_pool_mod, "ElasticBlockPool", FakeElasticBlockPool)
+    monkeypatch.setitem(
+        sys.modules, "vllm.v1.core.block_pool", fake_block_pool_mod
+    )
+
+    kvcoord_mod = types.ModuleType("mock_kvcoord_mod")
+
+    class FakeKVCacheCoordinator:
+        def __init__(self, *args, **kwargs):
+            self.enable_caching = False
+            self.kv_cache_config = types.SimpleNamespace(num_blocks=8)
+            self.single_type_managers = [types.SimpleNamespace()]
+
+    setattr(kvcoord_mod, "KVCacheCoordinator", FakeKVCacheCoordinator)
+
+    assert patches.KVCacheCoordinatorPatch().patch_coordinator(kvcoord_mod)
+
+    with pytest.raises(RuntimeError, match="not initialized"):
+        kvcoord_mod.KVCacheCoordinator()

--- a/tests/test_vllm_tp_world_size.py
+++ b/tests/test_vllm_tp_world_size.py
@@ -54,6 +54,70 @@ def test_get_world_size_rejects_uninitialized_state(monkeypatch, vllm_modules):
         interfaces.get_world_size()
 
 
+def test_engine_core_records_tp_world_size_before_original_init(
+    monkeypatch, vllm_modules
+):
+    interfaces, patches = vllm_modules
+    monkeypatch.setattr(patches, "enable_kvcached", lambda: True)
+    monkeypatch.setattr(patches, "_should_enable_async_sched", lambda cfg: True)
+    init_kvcached = mock.Mock()
+    monkeypatch.setattr(interfaces, "init_kvcached", init_kvcached)
+
+    def assert_kvcached_initialized_first(*args, **kwargs):
+        init_kvcached.assert_called_once()
+
+    original_init = mock.Mock(side_effect=assert_kvcached_initialized_first)
+    engine_mod = types.ModuleType("mock_engine_mod")
+
+    class FakeEngineCore:
+        __init__ = original_init
+
+    setattr(engine_mod, "EngineCore", FakeEngineCore)
+    assert patches.EngineCorePatch().patch_engine_init(engine_mod)
+
+    config = types.SimpleNamespace(
+        parallel_config=types.SimpleNamespace(tensor_parallel_size=4)
+    )
+    engine_mod.EngineCore(config)
+
+    init_kvcached.assert_called_once_with(
+        tp_rank=0,
+        world_size=4,
+        is_worker=False,
+        async_sched=True,
+    )
+    original_init.assert_called_once()
+
+
+def test_engine_core_propagates_kvcached_initialization_failure(
+    monkeypatch, vllm_modules
+):
+    interfaces, patches = vllm_modules
+    monkeypatch.setattr(patches, "enable_kvcached", lambda: True)
+    monkeypatch.setattr(patches, "_should_enable_async_sched", lambda cfg: False)
+    init_error = RuntimeError("failed to record TP state")
+    monkeypatch.setattr(
+        interfaces, "init_kvcached", mock.Mock(side_effect=init_error)
+    )
+
+    original_init = mock.Mock(return_value=None)
+    engine_mod = types.ModuleType("mock_engine_mod")
+
+    class FakeEngineCore:
+        __init__ = original_init
+
+    setattr(engine_mod, "EngineCore", FakeEngineCore)
+    assert patches.EngineCorePatch().patch_engine_init(engine_mod)
+
+    config = types.SimpleNamespace(
+        parallel_config=types.SimpleNamespace(tensor_parallel_size=4)
+    )
+    with pytest.raises(RuntimeError, match="failed to record TP state"):
+        engine_mod.EngineCore(config)
+
+    original_init.assert_not_called()
+
+
 class FakeElasticBlockPool:
     def __init__(self, *args, **kwargs):
         self.null_block = object()


### PR DESCRIPTION
## Summary

Fix the coordinator startup path by reusing the TP world size already recorded during EngineCore initialization instead of querying vLLM parallel state again.

Related issue: #339

## Root cause

EngineCore already knows `tensor_parallel_size` and records it through `init_kvcached()`. The coordinator runs in a process where vLLM parallel state may be unavailable or may still report world size 1. Falling back to 1 overwrites the authoritative value and makes later worker IPC and allocator broadcasts use the wrong TP topology.

## Changes

- expose the world size recorded by the vLLM integration through a small public helper
- make `KVCacheCoordinatorPatch` consume that recorded value
- add regression coverage for a recorded TP world size greater than 1

## Why this approach

The coordinator should not rediscover TP topology from startup-time parallel state. Reusing the value supplied by `vllm_config.parallel_config.tensor_parallel_size` earlier in the same startup sequence is narrower and deterministic.

## Validation

- `python -m pytest tests/test_vllm_tp_world_size.py -q` -> 2 passed
- reproduced the repository's complete `pre-commit run --all-files` job under Python 3.11 -> all hooks passed
- reproduced the manual mypy matrix under Python 3.9, 3.10, 3.11, 3.12, and 3.13 -> all passed
- CI containers used the standard `runc` runtime with GPU devices explicitly hidden

This remains independent from preallocation timing and hybrid KV-layout changes.