### PR TITLE
Clarify KVCACHED_MAX_CACHED_TOKENS semantics

### DIFF
--- a/examples/09_prefix_caching/README.md
+++ b/examples/09_prefix_caching/README.md
@@ -19,7 +19,13 @@ GPU Memory (per model)
 └─────────────────────────────────────┘
 ```
 
-The **memory bound** (`KVCACHED_MAX_CACHED_TOKENS`, default `16000`; `0` means unlimited) caps how many tokens of cached prefixes a model may keep. When the cache exceeds this bound, older prefixes are evicted. This prevents prefix caching from consuming all free memory, which would undermine the elastic sharing between co-located models that kvcached is designed for.
+The **memory bound** (`KVCACHED_MAX_CACHED_TOKENS`, default `16000`) caps how many tokens of cached prefixes a model may keep. When the cache exceeds this bound, older prefixes are evicted. This prevents prefix caching from consuming all free memory, which would undermine the elastic sharing between co-located models that kvcached is designed for.
+
+Sentinel values:
+
+- `KVCACHED_MAX_CACHED_TOKENS=-1` — **unlimited**: closest to vanilla vLLM/SGLang prefix-cache behavior, at the cost of memory elasticity.
+- `KVCACHED_MAX_CACHED_TOKENS=0` — **disabled at the kvcached layer**: the framework's prefix-cache module still runs, but every cached prefix is evicted as soon as it becomes evictable, so there is no cross-request reuse. To fully turn off prefix caching (skip the caching path entirely), use the framework flags below instead.
+- `KVCACHED_MAX_CACHED_TOKENS=N` (`N>0`) — cap cached prefixes at `N` tokens.
 
 ## Usage
 
@@ -28,7 +34,7 @@ Prefix caching is enabled by default when kvcached is active. No additional flag
 To control the cached token budget:
 
 ```bash
-export KVCACHED_MAX_CACHED_TOKENS=16000   # default; set to 0 for unlimited
+export KVCACHED_MAX_CACHED_TOKENS=16000   # default; -1 = unlimited, 0 = disabled
 ```
 
 To disable prefix caching:

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -1258,8 +1258,10 @@ class RadixCacheLimitPatch(VersionAwarePatch, BasePatch):
     down to that limit.  This prevents the cache from consuming all KV pool
     capacity and leaves headroom for running requests.
 
-    Set KVCACHED_MAX_CACHED_TOKENS to a positive integer to enable.
-    0 (default) means unlimited — this patch is a no-op in that case.
+    KVCACHED_MAX_CACHED_TOKENS semantics:
+      < 0  → unlimited; this patch is a no-op.
+      == 0 → disabled; every cached entry is evicted immediately on insert.
+      > 0  → cap evictable size at this many tokens.
     """
 
     library = "sglang"
@@ -1268,9 +1270,10 @@ class RadixCacheLimitPatch(VersionAwarePatch, BasePatch):
     patch_name = "radix_cache_limit"
 
     def apply(self, radix_cache_mod: types.ModuleType) -> bool:
-        if MAX_CACHED_TOKENS <= 0:
+        if MAX_CACHED_TOKENS < 0:
             logger.debug(
-                "KVCACHED_MAX_CACHED_TOKENS not set — RadixCacheLimitPatch skipped"
+                "KVCACHED_MAX_CACHED_TOKENS < 0 (unlimited) — "
+                "RadixCacheLimitPatch skipped"
             )
             return True  # Not an error; just not needed.
 

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -246,11 +246,13 @@ def _is_mla_kv_cache_spec(kv_cache_spec: Any) -> bool:
 def _get_max_cached_blocks(block_size: int) -> int:
     """Derive max cached blocks from the unified MAX_CACHED_TOKENS config.
 
-    Returns 0 (unlimited) when MAX_CACHED_TOKENS is 0.
+    Returns -1 (unlimited) when MAX_CACHED_TOKENS < 0.
+    Returns 0  (disabled — evict on free) when MAX_CACHED_TOKENS == 0.
+    Otherwise returns MAX_CACHED_TOKENS // block_size.
     """
     from kvcached.utils import MAX_CACHED_TOKENS
-    if MAX_CACHED_TOKENS <= 0:
-        return 0
+    if MAX_CACHED_TOKENS < 0:
+        return -1
     return MAX_CACHED_TOKENS // block_size
 
 class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
@@ -300,7 +302,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
             ) -> None:
                 assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
                 self.enable_prefix_cache = enable_caching
-                # 0 means unlimited
+                # -1 = unlimited, 0 = disabled (evict on free), >0 = cap
                 self.max_cached_blocks = max_cached_blocks
                 if enable_caching:
                     logger.info("Prefix caching enabled for ElasticBlockPool")
@@ -537,7 +539,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 if uncached_to_free:
                     self.kv_cache_manager.free(uncached_to_free)
 
-                if (self.max_cached_blocks > 0
+                if (self.max_cached_blocks >= 0
                         and len(self._evictable_blocks) > self.max_cached_blocks):
                     excess = len(self._evictable_blocks) - self.max_cached_blocks
                     self._evict_blocks_from_pool(excess)

--- a/kvcached/utils.py
+++ b/kvcached/utils.py
@@ -129,8 +129,13 @@ MAX_RESERVED_PAGES = int(os.getenv("KVCACHED_MAX_RESERVED_PAGES", "10"))
 MAX_CACHED_BLOCKS = int(os.getenv("KVCACHED_MAX_CACHED_BLOCKS", "1000"))
 SANITY_CHECK = os.getenv("KVCACHED_SANITY_CHECK", "false").lower() == "true"
 # Maximum number of tokens the cache may hold as evictable (cached) entries.
-# 0 means unlimited. When set, the cache is proactively evicted after each
-# finished request to stay within the limit.
+# Semantics:
+#   < 0  → unlimited (closest to vanilla vLLM/SGLang prefix-cache behavior;
+#          gives up memory elasticity)
+#   == 0 → disabled (cached prefixes are evicted as soon as they become
+#          evictable, effectively turning off prefix-cache reuse)
+#   > 0  → proactively evict after each finished request to stay within
+#          this many cached tokens
 # Used by both SGLang (RadixCacheLimitPatch) and vLLM (ElasticBlockPool),
 # which converts to blocks internally via MAX_CACHED_TOKENS // block_size.
 MAX_CACHED_TOKENS = int(os.getenv("KVCACHED_MAX_CACHED_TOKENS", "16000"))


### PR DESCRIPTION
Fix issue #338 

Previously `0` meant "unlimited", which was easily misread as "disable prefix caching". Switch to explicit sentinels: `-1` = unlimited, `0` = disabled (cached blocks evicted on free), `>0` = cap. Verified end-to-end on vLLM & SGLang with Llama-3.2-1B: hit_rate(-1)=0.954, hit_rate(0)=0.000