### PR TITLE
fix: make FTensor cleanup tolerate stale VMM mappings

### DIFF
--- a/csrc/ftensor.cpp
+++ b/csrc/ftensor.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fcntl.h>
+#include <iostream>
 #include <sys/mman.h>
 
 #include "constants.hpp"
@@ -62,12 +63,26 @@ FTensor::FTensor(const std::string &name, size_t size, torch::Dtype dtype,
 }
 
 FTensor::~FTensor() {
-  mapping_.clear(); // Free all physical pages directly.
-  zero_page_.reset();
   if (vaddr_) {
-    CHECK_DRV(cuMemUnmap(reinterpret_cast<CUdeviceptr>(vaddr_), size_));
-    CHECK_DRV(cuMemAddressFree(reinterpret_cast<CUdeviceptr>(vaddr_), size_));
+    CUresult res = cuMemUnmap(reinterpret_cast<CUdeviceptr>(vaddr_), size_);
+    if (res != CUDA_SUCCESS) {
+      const char *err = nullptr;
+      (void)cuGetErrorString(res, &err);
+      std::cerr << __FILE__ << ':' << __LINE__
+                << " cuMemUnmap during FTensor cleanup failed: "
+                << (err ? err : "unknown") << std::endl;
+    }
+    res = cuMemAddressFree(reinterpret_cast<CUdeviceptr>(vaddr_), size_);
+    if (res != CUDA_SUCCESS) {
+      const char *err = nullptr;
+      (void)cuGetErrorString(res, &err);
+      std::cerr << __FILE__ << ':' << __LINE__
+                << " cuMemAddressFree during FTensor cleanup failed: "
+                << (err ? err : "unknown") << std::endl;
+    }
   }
+  mapping_.clear(); // Free physical page handles after their mappings are gone.
+  zero_page_.reset();
 }
 
 bool FTensor::map(offset_t offset) {

--- a/csrc/ftensor.cpp
+++ b/csrc/ftensor.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fcntl.h>
-#include <iostream>
 #include <sys/mman.h>
 
 #include "constants.hpp"
@@ -68,17 +67,15 @@ FTensor::~FTensor() {
     if (res != CUDA_SUCCESS) {
       const char *err = nullptr;
       (void)cuGetErrorString(res, &err);
-      std::cerr << __FILE__ << ':' << __LINE__
-                << " cuMemUnmap during FTensor cleanup failed: "
-                << (err ? err : "unknown") << std::endl;
+      LOGGER(ERROR, "cuMemUnmap during FTensor cleanup failed: %s",
+             err ? err : "unknown");
     }
     res = cuMemAddressFree(reinterpret_cast<CUdeviceptr>(vaddr_), size_);
     if (res != CUDA_SUCCESS) {
       const char *err = nullptr;
       (void)cuGetErrorString(res, &err);
-      std::cerr << __FILE__ << ':' << __LINE__
-                << " cuMemAddressFree during FTensor cleanup failed: "
-                << (err ? err : "unknown") << std::endl;
+      LOGGER(ERROR, "cuMemAddressFree during FTensor cleanup failed: %s",
+             err ? err : "unknown");
     }
   }
   mapping_.clear(); // Free physical page handles after their mappings are gone.


### PR DESCRIPTION
## Summary

  This PR makes `FTensor` cleanup more robust for CUDA VMM teardown.

  The destructor now unmaps and frees the reserved virtual address range before releasing the physical page handles held by `mapping_`. Cleanup-time CUDA driver errors are logged instead of aborting the process, so teardown failures do not mask the original initialization or mapping error.

  ## Motivation

  During vLLM/kvcached startup failure paths, `FTensor` teardown can encounter stale or partially unmapped VMM state. Previously, cleanup used `CHECK_DRV`, which could abort the process while unwinding and obscure the root cause.

  ## Changes

  - Add explicit `<iostream>` include for cleanup logging.
  - Reorder `FTensor::~FTensor()` cleanup:
    - unmap reserved virtual address range
    - free reserved virtual address range
    - release physical page handles
    - reset zero page
  - Replace cleanup-path `CHECK_DRV` calls with best-effort error logging.