### PR TITLE
fix(sglang): support SGLang 0.5.11+ (version detection + refactored leak check)

### DIFF
--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -8,7 +8,7 @@ SGLang-specific patches using unified patch infrastructure.
 import inspect
 import math
 import types
-from typing import Any, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, List, Optional, Tuple, Union, cast
 
 from kvcached.integration.patch_base import BasePatch, enable_kvcached
 from kvcached.integration.version_utils import VersionAwarePatch, version_range
@@ -1213,41 +1213,62 @@ class SchedulerMemoryLeakPatch(VersionAwarePatch, BasePatch):
 
     @version_range(SGLANG_ALL_RANGE)
     def patch_scheduler_memory_leak(self, sched_mod: types.ModuleType) -> bool:
-        """Patch scheduler to suppress memory leak check when kvcached is enabled"""
+        """Patch scheduler to suppress memory leak check when kvcached is enabled.
+
+        kvcached maps physical KV pages lazily, so SGLang's static-pool
+        invariant (total == available + in-use) does not hold and its leak
+        detector would raise spuriously.  We neutralize the leak *raisers*.
+
+        Older SGLang keeps the whole check in a single Scheduler method whose
+        source mentions ``token_to_kv_pool_allocator``.  Newer SGLang
+        (>=0.5.11) moved it into ``SchedulerRuntimeCheckerMixin`` and split it
+        across several small methods (e.g. ``_check_req_pool`` raises directly,
+        ``_report_leak`` is the choke point for pool leaks).  To stay robust
+        across both layouts we wrap every Scheduler method whose source raises
+        a ``"memory leak detected"`` error -- and only those, leaving the
+        stats/logging methods untouched.
+        """
         Scheduler = self._get_target_class(sched_mod)
         if Scheduler is None:
             return False
 
-        target_method_name: Union[str, None] = None
+        target_method_names: List[str] = []
         for name, fn in inspect.getmembers(Scheduler, predicate=inspect.isfunction):
             try:
                 src = inspect.getsource(fn)
             except Exception:
                 continue
-            if "token_to_kv_pool_allocator memory leak detected!" in src or (
-                "memory leak detected" in src and "token_to_kv_pool_allocator" in src
-            ):
-                target_method_name = name
-                break
+            if "memory leak detected" in src:
+                target_method_names.append(name)
 
-        if target_method_name is None:
+        if not target_method_names:
             self.logger.debug("No memory leak detection method found in Scheduler")
             return False
 
-        original = getattr(Scheduler, target_method_name)
-        if self._is_already_patched(original):
-            self.logger.debug("Scheduler memory leak check already patched")
-            return True
+        def _make_wrapped(original: Callable[..., Any]) -> Callable[..., Any]:
+            def _wrapped(self, *args: Any, **kwargs: Any):
+                # Disable memory leak detection when ENABLE_KVCACHED is set
+                if enable_kvcached():
+                    return
+                return original(self, *args, **kwargs)
 
-        def _wrapped(self, *args: Any, **kwargs: Any):
-            # Disable memory leak detection when ENABLE_KVCACHED is set
-            if enable_kvcached():
-                return
-            return original(self, *args, **kwargs)
+            return _wrapped
 
-        self._mark_as_patched(_wrapped)
-        setattr(Scheduler, target_method_name, _wrapped)
-        return True
+        patched_any = False
+        for target_method_name in target_method_names:
+            original = getattr(Scheduler, target_method_name)
+            if self._is_already_patched(original):
+                self.logger.debug(
+                    f"Scheduler.{target_method_name} leak check already patched")
+                patched_any = True
+                continue
+
+            wrapped = _make_wrapped(original)
+            self._mark_as_patched(wrapped)
+            setattr(Scheduler, target_method_name, wrapped)
+            patched_any = True
+
+        return patched_any
 
 
 class RadixCacheLimitPatch(VersionAwarePatch, BasePatch):

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -1223,10 +1223,16 @@ class SchedulerMemoryLeakPatch(VersionAwarePatch, BasePatch):
         source mentions ``token_to_kv_pool_allocator``.  Newer SGLang
         (>=0.5.11) moved it into ``SchedulerRuntimeCheckerMixin`` and split it
         across several small methods (e.g. ``_check_req_pool`` raises directly,
-        ``_report_leak`` is the choke point for pool leaks).  To stay robust
-        across both layouts we wrap every Scheduler method whose source raises
-        a ``"memory leak detected"`` error -- and only those, leaving the
-        stats/logging methods untouched.
+        ``_report_leak`` is the generic choke point for *token/KV* pool leaks).
+
+        We suppress only the leak checks for pools kvcached actually manages
+        (the KV / token pools).  A check that is specific to
+        ``req_to_token_pool`` is deliberately left intact -- kvcached does not
+        manage the request pool, its invariant still holds, and silencing it
+        would hide a genuine request-pool leak.  The old single-method layout
+        (which names ``token_to_kv_pool_allocator``) and the new generic
+        reporter (which names no pool, and is only ever called for the token
+        pools) are both kept; only the req-pool-specific check is skipped.
         """
         Scheduler = self._get_target_class(sched_mod)
         if Scheduler is None:
@@ -1238,8 +1244,14 @@ class SchedulerMemoryLeakPatch(VersionAwarePatch, BasePatch):
                 src = inspect.getsource(fn)
             except Exception:
                 continue
-            if "memory leak detected" in src:
-                target_method_names.append(name)
+            if "memory leak detected" not in src:
+                continue
+            # Skip a check that is specific to the request pool, which kvcached
+            # does not manage.  The generic reporter names no pool (so it is not
+            # excluded) and the legacy combined check names the KV allocator.
+            if "req_to_token_pool" in src and "token_to_kv_pool" not in src:
+                continue
+            target_method_names.append(name)
 
         if not target_method_names:
             self.logger.debug("No memory leak detection method found in Scheduler")

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -1258,11 +1258,14 @@ class SchedulerMemoryLeakPatch(VersionAwarePatch, BasePatch):
             return False
 
         def _make_wrapped(original: Callable[..., Any]) -> Callable[..., Any]:
-            def _wrapped(self, *args: Any, **kwargs: Any):
+            import functools
+
+            @functools.wraps(original)
+            def _wrapped(sched_self, *args: Any, **kwargs: Any):
                 # Disable memory leak detection when ENABLE_KVCACHED is set
                 if enable_kvcached():
                     return
-                return original(self, *args, **kwargs)
+                return original(sched_self, *args, **kwargs)
 
             return _wrapped
 

--- a/kvcached/integration/version_utils.py
+++ b/kvcached/integration/version_utils.py
@@ -154,6 +154,16 @@ class VersionManager:
         except Exception as e:
             self.logger.warning(f"Error detecting version for {library_name}: {e}")
 
+        # Fallback to installed-package metadata. Some builds (e.g. source
+        # builds of SGLang) don't expose a module-level __version__, but the
+        # distribution metadata still carries the version.
+        if detected_version is None:
+            try:
+                import importlib.metadata as _md
+                detected_version = _md.version(library_name)
+            except Exception:
+                pass
+
         self._version_cache[library_name] = detected_version
         return detected_version
 


### PR DESCRIPTION
# Summary
Two general (non-AMD) compatibility defects in the SGLang integration, found while porting kvcached to AMD. **Bug #2 affects SGLang 0.5.11+** (verified on the `0.5.12.post1` wheel); **Bug #1** affects any build that doesn't expose `sglang.__version__`. The fix was additionally checked against `0.4.9` (the oldest version kvcached supports) and `0.5.10` (the last version before the break) to confirm **no regression** on the older, still-working layouts.

## Bug #1 — version detection misses builds without a module-level `__version__`

`VersionManager.detect_version()` only reads module attributes (`__version__`, then `version`/`VERSION`/`_version`). Some SGLang builds (notably source builds) expose none of these on the `sglang` module, even though the installed-package metadata carries the version. When detection returns `None`, **every** SGLang patch bails and kvcached silently becomes a no-op:

```
[kvcached][WARNING] Could not detect version for sglang
[kvcached][WARNING] Failed to apply elastic_memory_pool / ...
[kvcached][WARNING] Failed to patch sglang: elastic_allocator, ...
```

**Fix:** fall back to `importlib.metadata.version(library_name)` when no module attribute is found.

## Bug #2 — `scheduler_memory_leak` patch doesn't match SGLang's newer leak-check layout

kvcached maps physical KV pages lazily, so SGLang's static-pool invariant (`total == available + in-use`) doesn't hold for the KV pool; the `scheduler_memory_leak` patch exists to neutralize SGLang's leak detector for **that** pool. The old patch scanned for a single `Scheduler` method containing both `"memory leak detected"` and `"token_to_kv_pool_allocator"`.

Through **0.5.10** that still worked (`check_memory` names the KV allocator). At **0.5.11+**, SGLang routes the KV-pool leak through a **generic** `_report_leak(pool_name, …)` that names no pool — so no single method has both literals, the patch matches nothing, fails to apply, and SGLang's own detector crashes the scheduler:

```
[kvcached][WARNING] Failed to apply scheduler_memory_leak
ValueError: pool memory leak detected! [full] total=..., available=..., evictable=0 ...
Received sigquit from a child process.   # exit 137
```

**Fix:** select the Scheduler leak-raisers by source (`"memory leak detected"`) but **skip any check specific to `req_to_token_pool`** — a pool kvcached does **not** manage, whose invariant still holds, and whose alarm must stay live so a genuine request-pool leak still surfaces. The KV/token-pool checks are kept (the old combined check names `token_to_kv_pool_allocator`; the new generic `_report_leak` names no pool and is only ever called for token pools). This covers the old single-method layout and the new split/generic layout without over-suppressing unrelated alarms.

## Works across versions (verified)

Bug #2 only breaks on 0.5.11+. The two older versions below are **regression checks**, not bug repros — they confirm the new matcher still neutralizes the KV-pool check exactly like the original patch did:

| SGLang | KV-cache leak check | request-pool check | result |
|---|---|---|---|
| **0.4.9** | `check_memory` (KV + request fused) | (same method) | KV check neutralized — matches original patch behavior |
| **0.5.10** | `check_memory` (KV) | separate `_check_req_pool` | KV check neutralized, request check left live |
| **0.5.12** | generic `_report_leak` (KV) | separate `_check_req_pool` | KV check neutralized, request check left live — **fixes the crash the old patch couldn't** |

No regression on older versions (behavior matches the original patch where it worked); fixes 0.5.11+; and the request-pool alarm is preserved wherever the version's structure keeps it separate.

## Manifestation

|                | exists in code? | manifests on 0.5.12 wheel? | manifests on no-`__version__` build? |
|----------------|:---------------:|:--------------------------:|:------------------------------------:|
| **Bug #1**     | ✅ yes          | ❌ no (`__version__` present) | ✅ yes                              |
| **Bug #2**     | ✅ yes          | ✅ yes (leak crash, exit 137) | ✅ yes                              |

## Changes

- `kvcached/integration/version_utils.py` — `importlib.metadata` fallback in `detect_version()`.
- `kvcached/integration/sglang/patches.py` — generalize the `scheduler_memory_leak` patch across SGLang's leak-check layouts, skipping the `req_to_token_pool`-specific check.

Commits:
- `support SGLang 0.5.11-0.5.12 (version detection + refactored leak check)`
- `leave req_to_token_pool leak check intact`