### PR TITLE
feat: Triattention support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,11 @@ benchmarks/bench_latency_benefit/plot*
 benchmarks/gsm8k/*.jsonl
 benchmarks/gsm8k/*.txt
 
+# local experiment outputs and generated change records
+results/
+results_*.csv
+change_records_*/
+
 # tools
 tools/addlicense
 tools/.addlicense.lock

--- a/csrc/ftensor.cpp
+++ b/csrc/ftensor.cpp
@@ -57,7 +57,6 @@ FTensor::FTensor(const std::string &name, size_t size, torch::Dtype dtype,
   auto num_elems = static_cast<int64_t>(size / torch::elementSize(dtype_));
   auto options =
       torch::TensorOptions().dtype(dtype_).device(dev_).requires_grad(false);
-  torch::NoGradGuard no_grad;
   tensor_ =
       torch::from_blob(reinterpret_cast<void *>(vaddr_), {num_elems}, options);
 }

--- a/csrc/ftensor.cpp
+++ b/csrc/ftensor.cpp
@@ -57,6 +57,7 @@ FTensor::FTensor(const std::string &name, size_t size, torch::Dtype dtype,
   auto num_elems = static_cast<int64_t>(size / torch::elementSize(dtype_));
   auto options =
       torch::TensorOptions().dtype(dtype_).device(dev_).requires_grad(false);
+  torch::NoGradGuard no_grad;
   tensor_ =
       torch::from_blob(reinterpret_cast<void *>(vaddr_), {num_elems}, options);
 }

--- a/engine_integration/patches/README-triattention.md
+++ b/engine_integration/patches/README-triattention.md
@@ -22,3 +22,65 @@ The patch keeps only the changes needed by kvcached's vLLM integration:
   applied/skipped compression actions without depending on log formatting.
 
 SGLang uses the upstream TriAttention integration directly.
+
+## Benchmark scripts
+
+Run the comparison scripts from the kvcached repository root after installing
+kvcached, the target serving engine, and the external TriAttention package in
+the same Python environment. The scripts start and stop the serving process by
+themselves, so make sure the selected port is free before running them.
+
+### vLLM
+
+Use `tools/compare_vllm_triattention.py` to compare kvcached-only serving with
+kvcached plus TriAttention. The script disables vLLM automatic prefix caching,
+samples GPU memory with `nvidia-smi`, sends concurrent long-context OpenAI
+chat requests, and writes one CSV row per run.
+
+```bash
+python tools/compare_vllm_triattention.py \
+  --concurrencies 4 \
+  --budgets 1024 \
+  --triattention-root /root/triattention-main \
+  --stats-path /root/triattention-main/triattention/calibration/for_aime25_experiment/qwen3_8b.pt \
+  --model /root/data/models/Qwen/Qwen3-8B \
+  --served-model-name qwen3-8b \
+  --max-model-len 32768 \
+  --max-tokens 2048 \
+  --trust-remote-code
+```
+
+Use `--skip-baseline` to run only the TriAttention row, or
+`--skip-triattention` to run only the kvcached baseline. Results are written to
+`results/results_vllm_tri_compare.csv` by default, and server logs are written
+under `/tmp/triattn-compare`.
+
+### SGLang
+
+Use `tools/compare_sglang_triattention.py` to run the same style of comparison
+on SGLang. The script starts SGLang with `--disable-radix-cache` and
+`--disable-overlap-schedule`, which are required for TriAttention's SGLang
+compression path.
+
+SGLang TriAttention compression is decode-time driven, so a long prompt alone
+is not enough to trigger it. Use `--min-tokens` with a value larger than the KV
+budget and `--ignore-eos` when validating compression/reclaim events.
+
+```bash
+python tools/compare_sglang_triattention.py \
+  --concurrencies 4 \
+  --budgets 1024 \
+  --triattention-root /root/triattention-main \
+  --stats-path /root/triattention-main/triattention/calibration/for_aime25_experiment/qwen3_8b.pt \
+  --model /root/data/models/Qwen/Qwen3-8B \
+  --max-model-len 32768 \
+  --max-tokens 2048 \
+  --min-tokens 1536 \
+  --ignore-eos \
+  --trust-remote-code
+```
+
+Results are written to `results/results_sglang_tri_compare.csv` by default, and
+server logs are written under `/tmp/triattn-sglang-compare`. The SGLang parser
+counts log lines such as `TriAttention compression complete ... (freed N slots)`
+as compression and reclaim events.

--- a/engine_integration/patches/README-triattention.md
+++ b/engine_integration/patches/README-triattention.md
@@ -53,7 +53,10 @@ python tools/compare_vllm_triattention.py \
 Use `--skip-baseline` to run only the TriAttention row, or
 `--skip-triattention` to run only the kvcached baseline. Results are written to
 `results/results_vllm_tri_compare.csv` by default, and server logs are written
-under `/tmp/triattn-compare`.
+under `/tmp/triattn-compare`. The CSV includes `saved_kv_tokens`,
+`freed_blocks`, and `freed_blocks_by_gid`; for hybrid-attention models such as
+gpt-oss, TriAttention should reclaim only the plain full-attention gid and leave
+sliding-window groups untouched.
 
 ### SGLang
 

--- a/engine_integration/patches/README-triattention.md
+++ b/engine_integration/patches/README-triattention.md
@@ -62,20 +62,23 @@ on SGLang. The script starts SGLang with `--disable-radix-cache` and
 `--disable-overlap-schedule`, which are required for TriAttention's SGLang
 compression path.
 
-SGLang TriAttention compression is decode-time driven, so a long prompt alone
-is not enough to trigger it. Use `--min-tokens` with a value larger than the KV
-budget and `--ignore-eos` when validating compression/reclaim events.
+SGLang TriAttention compression is decode-time driven, so the recommended
+benchmark uses a short prompt and a long forced decode. This lets compression
+and reclaim happen while decode memory is still growing, making the effect more
+visible in GPU peak memory.
 
 ```bash
 python tools/compare_sglang_triattention.py \
+  --workload-profile decode-stress \
   --concurrencies 4 \
   --budgets 1024 \
   --triattention-root /root/triattention-main \
   --stats-path /root/triattention-main/triattention/calibration/for_aime25_experiment/qwen3_8b.pt \
   --model /root/data/models/Qwen/Qwen3-8B \
   --max-model-len 32768 \
-  --max-tokens 2048 \
-  --min-tokens 1536 \
+  --prompt-repeat 64 \
+  --max-tokens 8192 \
+  --min-tokens 8192 \
   --ignore-eos \
   --trust-remote-code
 ```

--- a/engine_integration/patches/README-triattention.md
+++ b/engine_integration/patches/README-triattention.md
@@ -1,0 +1,24 @@
+# TriAttention external integration
+
+kvcached does not vendor TriAttention source.  To enable TriAttention, install
+the upstream repository separately and apply the kvcached compatibility patch:
+
+```bash
+git clone https://github.com/WeianMao/triattention.git
+cd triattention
+git apply /path/to/kvcached/engine_integration/patches/kvcached-triattention-main.patch
+pip install -e .
+pip install flash-attn --no-build-isolation
+```
+
+The patch keeps only the changes needed by kvcached's vLLM integration:
+
+- reject vLLM automatic prefix caching when TriAttention reclaim is active;
+- keep effective KV length anchored after compression;
+- handle vLLM V1 tensor/numpy input-buffer variants;
+- make KV group/tensor resolution more tolerant across vLLM layouts.
+- emit optional JSONL compression events when
+  `TRIATTN_RUNTIME_EVENT_SINK_PATH` is set, so benchmark scripts can count
+  applied/skipped compression actions without depending on log formatting.
+
+SGLang uses the upstream TriAttention integration directly.

--- a/engine_integration/patches/kvcached-triattention-main.patch
+++ b/engine_integration/patches/kvcached-triattention-main.patch
@@ -1,3 +1,73 @@
+diff --git a/triattention/vllm/runtime/config.py b/triattention/vllm/runtime/config.py
+index 63e4089..d43e644 100644
+--- a/triattention/vllm/runtime/config.py
++++ b/triattention/vllm/runtime/config.py
+@@ -50,6 +50,22 @@ class TriAttentionRuntimeConfig:
+     sparse_score_aggregation: str = "mean"
+     sparse_normalize_scores: bool = True
+     window_size: int = 128
++    # Always keep the first K tokens (attention-sink / format-anchor preservation,
++    # StreamingLLM-style). For structured/reasoning models (e.g. gpt-oss harmony),
++    # the channel/format scaffolding lives at the start of the prompt; protecting it
++    # lets the bulk prompt be compressed without corrupting generation. 0 = disabled.
++    protect_prefix_tokens: int = 0
++    # Token-aware ("content") protection: force-keep KV slots whose decoded token id
++    # is structurally critical, regardless of score/position. For gpt-oss harmony,
++    # the generated control tokens (<|start|>=200006, <|channel|>, <|message|>,
++    # <|end|>, <|return|>, all >= 200000) must survive compression or the model's
++    # channel structure breaks. protect_token_ids = explicit id set;
++    # protect_token_ids_min = keep all ids >= this (0 = off, e.g. 200000 for harmony);
++    # protect_token_ids_lookahead = also keep N slots after each protected slot
++    # (captures the channel-name run after <|channel|>). All default off (no-op).
++    protect_token_ids: tuple[int, ...] = ()
++    protect_token_ids_min: int = 0
++    protect_token_ids_lookahead: int = 0
+     include_prefill_in_budget: bool = True
+     per_head_selection_semantics: str = "hf_aligned_global_per_head"
+     layer_perhead_aggregation: str = "max"
+@@ -85,6 +101,12 @@ class TriAttentionRuntimeConfig:
+             raw = raw.strip()
+             return raw if raw else default
+
++        def maybe_int_tuple(name: str, default: tuple[int, ...]) -> tuple[int, ...]:
++            raw = _get_raw(name)
++            if raw is None:
++                return default
++            return tuple(int(p.strip()) for p in raw.split(",") if p.strip())
++
+         sparse_stats_path_raw = maybe_str("SPARSE_STATS_PATH", None)
+         model_path_raw = maybe_str("MODEL_PATH", None)
+
+@@ -144,6 +166,18 @@ class TriAttentionRuntimeConfig:
+                 "SPARSE_NORMALIZE_SCORES", cls.sparse_normalize_scores
+             ),
+             window_size=maybe_int("WINDOW_SIZE", cls.window_size),
++            protect_prefix_tokens=maybe_int(
++                "PROTECT_PREFIX_TOKENS", cls.protect_prefix_tokens
++            ),
++            protect_token_ids=maybe_int_tuple(
++                "PROTECT_TOKEN_IDS", cls.protect_token_ids
++            ),
++            protect_token_ids_min=maybe_int(
++                "PROTECT_TOKEN_IDS_MIN", cls.protect_token_ids_min
++            ),
++            protect_token_ids_lookahead=maybe_int(
++                "PROTECT_TOKEN_IDS_LOOKAHEAD", cls.protect_token_ids_lookahead
++            ),
+             include_prefill_in_budget=maybe_bool(
+                 "INCLUDE_PREFILL_IN_BUDGET", cls.include_prefill_in_budget
+             ),
+@@ -239,6 +273,10 @@ class TriAttentionRuntimeConfig:
+             )
+         if self.window_size < 0:
+             raise ValueError(f"window_size must be >= 0, got {self.window_size}")
++        if self.protect_prefix_tokens < 0:
++            raise ValueError(
++                f"protect_prefix_tokens must be >= 0, got {self.protect_prefix_tokens}"
++            )
+         if self.disable_top_n_high_freq < 0:
+             raise ValueError(
+                 "disable_top_n_high_freq must be >= 0, "
 diff --git a/triattention/vllm/runtime/hook_runtime_context.py b/triattention/vllm/runtime/hook_runtime_context.py
 index 301dfe1..f1fcb72 100644
 --- a/triattention/vllm/runtime/hook_runtime_context.py
@@ -53,7 +123,7 @@ index 301dfe1..f1fcb72 100644
      _post_forward = getattr(signal, '_post_forward', False)
      if _post_forward:
 diff --git a/triattention/vllm/runtime/input_patch_vllm_v1_backend.py b/triattention/vllm/runtime/input_patch_vllm_v1_backend.py
-index 6871474..7bc4651 100644
+index 6871474..b061894 100644
 --- a/triattention/vllm/runtime/input_patch_vllm_v1_backend.py
 +++ b/triattention/vllm/runtime/input_patch_vllm_v1_backend.py
 @@ -11,6 +11,7 @@ import os
@@ -64,10 +134,19 @@ index 6871474..7bc4651 100644
 
  from . import input_patch_state as _patch_state
 
-@@ -27,6 +28,106 @@ def _debug_preserve_rope_positions() -> bool:
+@@ -27,6 +28,115 @@ def _debug_preserve_rope_positions() -> bool:
      return os.environ.get("TRIATTN_DEBUG_V1_PRESERVE_ROPE_POSITIONS", "0") == "1"
 
 
++def _debug_enable_slot_shift() -> bool:
++    return os.environ.get("TRIATTN_DEBUG_ENABLE_SLOT_SHIFT", "0").strip().lower() in {
++        "1",
++        "true",
++        "yes",
++        "on",
++    }
++
++
 +def _to_numpy(value: Any, *, dtype: np.dtype | type | None = None) -> np.ndarray | None:
 +    if isinstance(value, np.ndarray):
 +        return value.astype(dtype, copy=False) if dtype is not None else value
@@ -171,7 +250,140 @@ index 6871474..7bc4651 100644
  def _build_effective_slot_positions(
      *,
      positions_np: np.ndarray,
-@@ -106,26 +210,48 @@ def make_patched_v1_prepare_inputs(
+@@ -60,34 +170,118 @@ def _build_effective_slot_positions(
+     return out
+
+
+-def _apply_sparse_seq_len_overrides_in_place(
++def _planned_seq_len_overrides(
+     *,
+-    seq_lens_np: np.ndarray,
+-    num_computed_tokens_cpu: np.ndarray,
+     num_scheduled_tokens: np.ndarray,
+     num_reqs: int,
+-) -> bool:
++) -> dict[int, int] | None:
+     if _debug_drop_seq_base():
+-        return False
++        return None
+     if num_reqs <= 0:
+-        return False
++        return None
+
+-    applied = False
+     if num_reqs == 1 and _patch_state.ACTIVE_SINGLE_EFFECTIVE_SEQ_BASE is not None:
+-        seq_lens_np[0] = int(_patch_state.ACTIVE_SINGLE_EFFECTIVE_SEQ_BASE) + int(num_scheduled_tokens[0])
+-        return True
++        return {
++            0: int(_patch_state.ACTIVE_SINGLE_EFFECTIVE_SEQ_BASE)
++            + int(num_scheduled_tokens[0])
++        }
+
+     sparse_bases = _patch_state.ACTIVE_EFFECTIVE_BASE_BY_REQ_IDX
+     if not sparse_bases:
+-        return False
++        return None
+
+-    seq_lens_np[:num_reqs] = num_computed_tokens_cpu[:num_reqs] + num_scheduled_tokens[:num_reqs]
++    overrides: dict[int, int] = {}
+     for req_idx, effective_base in sparse_bases.items():
+         idx = int(req_idx)
+         if 0 <= idx < num_reqs:
+-            seq_lens_np[idx] = int(effective_base) + int(num_scheduled_tokens[idx])
+-            applied = True
+-    return applied
++            overrides[idx] = int(effective_base) + int(num_scheduled_tokens[idx])
++    return overrides or None
++
++
++def _apply_seq_len_overrides_to_buffer(
++    seq_lens: Any,
++    *,
++    overrides: dict[int, int],
++    num_reqs: int,
++) -> bool:
++    if not overrides:
++        return False
++    if hasattr(seq_lens, "np"):
++        seq_lens_np = seq_lens.np
++        for idx, value in overrides.items():
++            seq_lens_np[int(idx)] = int(value)
++        seq_lens_np[num_reqs:].fill(0)
++        copy_to_gpu = getattr(seq_lens, "copy_to_gpu", None)
++        if callable(copy_to_gpu):
++            copy_to_gpu()
++        return True
++
++    if isinstance(seq_lens, np.ndarray):
++        for idx, value in overrides.items():
++            seq_lens[int(idx)] = int(value)
++        seq_lens[num_reqs:].fill(0)
++        return True
++
++    if isinstance(seq_lens, torch.Tensor):
++        indices = torch.as_tensor(
++            list(overrides.keys()),
++            device=seq_lens.device,
++            dtype=torch.long,
++        )
++        values = torch.as_tensor(
++            list(overrides.values()),
++            device=seq_lens.device,
++            dtype=seq_lens.dtype,
++        )
++        seq_lens.index_copy_(0, indices, values)
++        seq_lens[num_reqs:].fill_(0)
++        return True
++
++    return False
++
++
++def _positions_numpy_view(positions: Any, total_num_scheduled_tokens: int) -> np.ndarray | None:
++    if hasattr(positions, "np"):
++        return positions.np[:total_num_scheduled_tokens]
++    if isinstance(positions, torch.Tensor):
++        return positions[:total_num_scheduled_tokens].detach().to("cpu").numpy()
++    return None
++
++
++def _recompute_slot_mapping(
++    *,
++    runner: Any,
++    num_reqs: int,
++    total_num_scheduled_tokens: int,
++    slot_positions_np: np.ndarray,
++    req_indices: np.ndarray,
++) -> None:
++    block_table = getattr(getattr(runner, "input_batch", None), "block_table", None)
++    compute_slot_mapping = getattr(block_table, "compute_slot_mapping", None)
++    if not callable(compute_slot_mapping):
++        return
++
++    positions = getattr(runner, "positions", None)
++    query_start_loc = getattr(runner, "query_start_loc", None)
++    query_start_loc_gpu = getattr(query_start_loc, "gpu", None)
++    if isinstance(positions, torch.Tensor) and isinstance(query_start_loc_gpu, torch.Tensor):
++        slot_positions = torch.as_tensor(
++            slot_positions_np,
++            device=positions.device,
++            dtype=positions.dtype,
++        )
++        try:
++            compute_slot_mapping(
++                num_reqs,
++                query_start_loc_gpu[: num_reqs + 1],
++                slot_positions[:total_num_scheduled_tokens],
++            )
++            return
++        except TypeError:
++            pass
++
++    if _compute_slot_mapping(block_table, req_indices, slot_positions_np):
++        _commit_slot_mapping(block_table, total_num_scheduled_tokens)
+
+
+ def make_patched_v1_prepare_inputs(
+@@ -106,26 +300,51 @@ def make_patched_v1_prepare_inputs(
          if total_num_scheduled_tokens <= 0 or num_reqs <= 0:
              return out
 
@@ -182,59 +394,146 @@ index 6871474..7bc4651 100644
 +        if num_scheduled_tokens_np is None:
 +            return out
 +        req_indices = np.repeat(self.arange_np[:num_reqs], num_scheduled_tokens_np)
-+        positions_full_np = _buffer_numpy(getattr(self, "positions", None))
-+        if positions_full_np is None:
-+            return out
-+        positions_np = positions_full_np[:total_num_scheduled_tokens]
 
-         slot_positions_np = _build_effective_slot_positions(
-             positions_np=positions_np,
-             req_indices=req_indices,
-         )
-         if slot_positions_np is not None:
+-        slot_positions_np = _build_effective_slot_positions(
+-            positions_np=positions_np,
+-            req_indices=req_indices,
+-        )
+-        if slot_positions_np is not None:
 -            self.input_batch.block_table.compute_slot_mapping(req_indices, slot_positions_np)
 -            self.input_batch.block_table.commit_slot_mapping(total_num_scheduled_tokens)
-+            if not _compute_slot_mapping(
-+                self.input_batch.block_table,
-+                req_indices,
-+                slot_positions_np,
-+            ):
-+                return out
-+            if not _commit_slot_mapping(
-+                self.input_batch.block_table,
-+                total_num_scheduled_tokens,
-+            ):
-+                return out
-+        seq_lens_obj = getattr(self, "seq_lens", None)
-+        seq_lens_np = _buffer_numpy(seq_lens_obj)
-+        num_computed_tokens_cpu = _to_numpy(
-+            getattr(self.input_batch, "num_computed_tokens_cpu", None),
-+            dtype=np.int64,
-+        )
-+        if seq_lens_np is None or num_computed_tokens_cpu is None:
-+            return out
-         seq_applied = _apply_sparse_seq_len_overrides_in_place(
+-        seq_applied = _apply_sparse_seq_len_overrides_in_place(
 -            seq_lens_np=self.seq_lens.np,
 -            num_computed_tokens_cpu=self.input_batch.num_computed_tokens_cpu,
 -            num_scheduled_tokens=num_scheduled_tokens,
-+            seq_lens_np=seq_lens_np,
-+            num_computed_tokens_cpu=num_computed_tokens_cpu,
++        # Slot-position shifting is unsafe for current vLLM V1 gpt-oss decode:
++        # RoPE/logical positions must stay in original sequence space, while
++        # the scheduler block table has already been reclaimed separately.
++        # Keep the old path debug-gated for targeted layout experiments.
++        if _debug_enable_slot_shift():
++            positions_np = _positions_numpy_view(
++                getattr(self, "positions", None),
++                total_num_scheduled_tokens,
++            )
++            if positions_np is not None:
++                slot_positions_np = _build_effective_slot_positions(
++                    positions_np=positions_np,
++                    req_indices=req_indices,
++                )
++                if slot_positions_np is not None:
++                    _recompute_slot_mapping(
++                        runner=self,
++                        num_reqs=num_reqs,
++                        total_num_scheduled_tokens=total_num_scheduled_tokens,
++                        slot_positions_np=slot_positions_np,
++                        req_indices=req_indices,
++                    )
++
++        seq_overrides = _planned_seq_len_overrides(
 +            num_scheduled_tokens=num_scheduled_tokens_np,
              num_reqs=num_reqs,
          )
-         if seq_applied:
+-        if seq_applied:
 -            self.seq_lens.np[num_reqs:].fill(0)
 -            self.seq_lens.copy_to_gpu()
-+            seq_lens_np[num_reqs:].fill(0)
-+            _copy_numpy_back(seq_lens_obj, seq_lens_np)
++        if seq_overrides:
++            optimistic_seq_lens_cpu = getattr(self, "optimistic_seq_lens_cpu", None)
++            if optimistic_seq_lens_cpu is not None:
++                _apply_seq_len_overrides_to_buffer(
++                    optimistic_seq_lens_cpu,
++                    overrides=seq_overrides,
++                    num_reqs=num_reqs,
++                )
++            _apply_seq_len_overrides_to_buffer(
++                getattr(self, "seq_lens", None),
++                overrides=seq_overrides,
++                num_reqs=num_reqs,
++            )
 
          return out
 
 diff --git a/triattention/vllm/runtime/integration_monkeypatch.py b/triattention/vllm/runtime/integration_monkeypatch.py
-index 6fb2df8..9ecefa1 100644
+index 6fb2df8..1bcc6cf 100644
 --- a/triattention/vllm/runtime/integration_monkeypatch.py
 +++ b/triattention/vllm/runtime/integration_monkeypatch.py
-@@ -87,9 +87,24 @@ def _refresh_scheduler_stats_kv_usage(outputs: Any, kv_usage: float) -> None:
+@@ -7,6 +7,7 @@ injecting the minimum TriAttention hooks needed for current runtime behavior.
+ from __future__ import annotations
+
+ import os
++import sys
+ from concurrent.futures import Future
+ from typing import Any, Callable, cast
+
+@@ -37,6 +38,68 @@ _ORIG_WORKER_INIT_DEVICE: Callable[..., Any] | None = None
+ _ORIG_WORKER_EXECUTE_MODEL: Callable[..., Any] | None = None
+ _ORIG_KVCACHE_ALLOCATE_SLOTS: Callable[..., Any] | None = None
+ _ORIG_ENGINE_CORE_STEP_WITH_BATCH_QUEUE: Callable[..., Any] | None = None
++_ORIG_GET_KV_CACHE_GROUPS: Callable[..., Any] | None = None
++
++
++def _debug_stderr(message: str) -> None:
++    if os.environ.get("TRIATTN_DEBUG_STDERR", "0") == "1":
++        print(message, file=sys.stderr, flush=True)
++
++
++def _triattention_should_split_full_attention_window_specs(
++    kv_cache_spec: dict[str, Any],
++) -> bool:
++    """Detect gpt-oss-style FullAttentionSpec groups with local-window layers."""
++    if not kv_cache_spec:
++        return False
++    try:
++        from vllm.v1.kv_cache_interface import FullAttentionSpec
++    except Exception:
++        return False
++
++    values = list(kv_cache_spec.values())
++    if not all(isinstance(spec, FullAttentionSpec) for spec in values):
++        return False
++    profiles = {
++        (
++            getattr(spec, "sliding_window", None),
++            getattr(spec, "attention_chunk_size", None),
++        )
++        for spec in values
++    }
++    return (None, None) in profiles and len(profiles) > 1
++
++
++def _patched_get_kv_cache_groups(vllm_config, kv_cache_spec, *args, **kwargs):
++    """Split plain full attention away from full-storage local-window layers."""
++    assert _ORIG_GET_KV_CACHE_GROUPS is not None
++    if not _triattention_should_split_full_attention_window_specs(kv_cache_spec):
++        return _ORIG_GET_KV_CACHE_GROUPS(vllm_config, kv_cache_spec, *args, **kwargs)
++
++    try:
++        import vllm.v1.core.kv_cache_utils as _kv_utils
++
++        grouped_specs = _kv_utils.unify_kv_cache_spec_page_size(kv_cache_spec)
++        groups = _kv_utils._get_kv_cache_groups_uniform_page_size(grouped_specs)
++        logger.info(
++            "[TriAttention] Split mixed FullAttentionSpec KV cache into %d "
++            "groups for full-attention-only reclaim",
++            len(groups),
++        )
++        _debug_stderr(
++            "[TriAttentionDebug] split mixed FullAttentionSpec groups="
++            f"{len(groups)} sizes={[len(g.layer_names) for g in groups]} "
++            "local_flags="
++            f"{[(getattr(g.kv_cache_spec, 'sliding_window', None), getattr(g.kv_cache_spec, 'attention_chunk_size', None)) for g in groups]}"
++        )
++        return groups
++    except Exception:
++        logger.warning(
++            "[TriAttention] Failed to split mixed FullAttentionSpec KV cache; "
++            "falling back to vLLM grouping",
++            exc_info=True,
++        )
++        return _ORIG_GET_KV_CACHE_GROUPS(vllm_config, kv_cache_spec, *args, **kwargs)
+
+
+ def _maybe_rewrite_v2_output_req_map(scheduler_output: Any, model_runner_output: Any) -> None:
+@@ -87,9 +150,24 @@ def _refresh_scheduler_stats_kv_usage(outputs: Any, kv_usage: float) -> None:
              scheduler_stats.kv_cache_usage = usage
 
 
@@ -259,11 +558,62 @@ index 6fb2df8..9ecefa1 100644
      cfg = TriAttentionRuntimeConfig.from_env()
      # Always attach config/state once patched to keep behavior deterministic.
      self.triattention_config = cfg
+@@ -407,6 +485,7 @@ def install_vllm_integration_monkeypatches(
+     global _PATCHED, _ORIG_SCHED_INIT, _ORIG_SCHED_SCHEDULE, _ORIG_SCHED_UPDATE_FROM_OUTPUT
+     global _ORIG_WORKER_INIT_DEVICE, _ORIG_WORKER_EXECUTE_MODEL
+     global _ORIG_KVCACHE_ALLOCATE_SLOTS, _ORIG_ENGINE_CORE_STEP_WITH_BATCH_QUEUE
++    global _ORIG_GET_KV_CACHE_GROUPS
+     global _PATCHED_SCHEDULER_ACTIVE, _PATCHED_WORKER_ACTIVE
+     if _PATCHED:
+         _PATCHED_SCHEDULER_ACTIVE = _PATCHED_SCHEDULER_ACTIVE or bool(patch_scheduler)
+@@ -415,6 +494,7 @@ def install_vllm_integration_monkeypatches(
+
+     import vllm.v1.core.sched.scheduler as sched_mod
+     import vllm.v1.core.kv_cache_manager as kv_cache_manager_mod
++    import vllm.v1.core.kv_cache_utils as kv_cache_utils_mod
+     import vllm.v1.engine.core as engine_core_mod
+     import vllm.v1.worker.gpu_worker as worker_mod
+
+@@ -423,6 +503,9 @@ def install_vllm_integration_monkeypatches(
+     KVCacheManager = kv_cache_manager_mod.KVCacheManager
+     Worker = worker_mod.Worker
+
++    _ORIG_GET_KV_CACHE_GROUPS = kv_cache_utils_mod.get_kv_cache_groups
++    kv_cache_utils_mod.get_kv_cache_groups = _patched_get_kv_cache_groups
++
+     if patch_scheduler:
+         _ORIG_SCHED_INIT = Scheduler.__init__
+         _ORIG_SCHED_SCHEDULE = Scheduler.schedule
 diff --git a/triattention/vllm/runtime/kv_group_resolver.py b/triattention/vllm/runtime/kv_group_resolver.py
-index de07981..706e34a 100644
+index de07981..5e517e1 100644
 --- a/triattention/vllm/runtime/kv_group_resolver.py
 +++ b/triattention/vllm/runtime/kv_group_resolver.py
-@@ -28,6 +28,8 @@ def _infer_kv_axis_from_group_backend(base_runner: Any, gid: int) -> int | None:
+@@ -2,7 +2,9 @@
+
+ from __future__ import annotations
+
++import os
+ import re
++import sys
+ from typing import Any
+
+ import torch
+@@ -10,6 +12,14 @@ import torch
+ from .kv_compaction import register_kv_layout_axis_hint
+
+
++_DEBUG_REPORTED_RUNNERS: set[int] = set()
++
++
++def _debug_stderr(message: str) -> None:
++    if os.environ.get("TRIATTN_DEBUG_STDERR", "0") == "1":
++        print(message, file=sys.stderr, flush=True)
++
++
+ def infer_layer_idx(layer_name: str, layer_obj: Any, fallback_idx: int) -> int:
+     for attr in ("layer_idx", "layer_id", "idx"):
+         value = getattr(layer_obj, attr, None)
+@@ -28,6 +38,8 @@ def _infer_kv_axis_from_group_backend(base_runner: Any, gid: int) -> int | None:
      if gid < 0 or gid >= len(attn_groups):
          return None
      group = attn_groups[gid]
@@ -272,19 +622,29 @@ index de07981..706e34a 100644
      backend = getattr(group, "backend", None)
      if backend is None:
          return None
-@@ -65,6 +67,57 @@ def _infer_kv_axis_from_group_backend(base_runner: Any, gid: int) -> int | None:
+@@ -65,6 +77,110 @@ def _infer_kv_axis_from_group_backend(base_runner: Any, gid: int) -> int | None:
      return None
 
 
++def _is_attention_kv_cache_tensor(tensor: torch.Tensor) -> bool:
++    if tensor.ndim != 5:
++        return False
++    return int(tensor.shape[0]) == 2 or int(tensor.shape[1]) == 2
++
++
 +def _first_tensor(value: Any) -> torch.Tensor | None:
 +    if isinstance(value, torch.Tensor):
-+        return value
++        return value if _is_attention_kv_cache_tensor(value) else None
 +    if isinstance(value, (list, tuple)):
 +        for item in value:
 +            tensor = _first_tensor(item)
 +            if tensor is not None:
 +                return tensor
 +    return None
++
++
++def _extract_attention_kv_cache_tensor(kv_cache: Any) -> torch.Tensor | None:
++    return _first_tensor(kv_cache)
 +
 +
 +def _resolve_tensor_from_kv_caches(
@@ -327,10 +687,53 @@ index de07981..706e34a 100644
 +            pass
 +
 +
++def _is_plain_full_attention_spec(spec: Any) -> bool:
++    try:
++        from vllm.v1.kv_cache_interface import FullAttentionSpec
++    except Exception:
++        return True
++    if not isinstance(spec, FullAttentionSpec):
++        return False
++    if getattr(spec, "sliding_window", None) is not None:
++        return False
++    if getattr(spec, "attention_chunk_size", None) is not None:
++        return False
++    return True
++
++
++def _is_reclaimable_full_attention_group(group: Any) -> bool:
++    """True only for plain full-attention KV-cache groups whose scheduler block
++    table is a 1:1 tail-truncatable mirror of the worker block_ids.
++
++    Sliding-window / chunked-local / mamba / cross-attention groups null-pad or
++    window their scheduler-side block table (out-of-window slots overwritten with
++    the null block id 0) while the worker keeps real append-only ids, so they are
++    NOT tail-truncatable and must be excluded from TriAttention compaction/reclaim.
++    Permissive (True) when spec info is unavailable so single-group full-attention
++    models and fake-spec tests are unaffected.
++    """
++    spec = getattr(group, "kv_cache_spec", None)
++    if spec is None:
++        return True
++    try:
++        from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
++    except Exception:
++        return True
++    if isinstance(spec, UniformTypeKVCacheSpecs):
++        layer_specs = getattr(spec, "kv_cache_specs", None)
++        if not isinstance(layer_specs, dict) or not layer_specs:
++            return False
++        # A mixed uniform group shares one block table across plain full and
++        # SWA-as-full-storage layers. Reclaiming it after moving only the plain
++        # full tensors would free blocks that SWA layers still reference.
++        return all(_is_plain_full_attention_spec(s) for s in layer_specs.values())
++    return _is_plain_full_attention_spec(spec)
++
++
  def resolve_group_tensors(base_runner: Any) -> dict[int, list[tuple[int, torch.Tensor]]]:
      """Resolve kv cache tensors for each kv cache group.
 
-@@ -81,8 +140,9 @@ def resolve_group_tensors(base_runner: Any) -> dict[int, list[tuple[int, torch.T
+@@ -81,8 +197,9 @@ def resolve_group_tensors(base_runner: Any) -> dict[int, list[tuple[int, torch.T
          else None
      )
 
@@ -341,7 +744,7 @@ index de07981..706e34a 100644
          if isinstance(fallback, list):
              tensors = [
                  (idx, t)
-@@ -91,6 +151,16 @@ def resolve_group_tensors(base_runner: Any) -> dict[int, list[tuple[int, torch.T
+@@ -91,13 +208,61 @@ def resolve_group_tensors(base_runner: Any) -> dict[int, list[tuple[int, torch.T
              ]
              if tensors:
                  group_tensors[0] = tensors
@@ -358,7 +761,52 @@ index de07981..706e34a 100644
          return group_tensors
 
      kv_cache_groups = getattr(kv_cache_config, "kv_cache_groups", None)
-@@ -105,13 +175,19 @@ def resolve_group_tensors(base_runner: Any) -> dict[int, list[tuple[int, torch.T
+     if not isinstance(kv_cache_groups, (list, tuple)):
+         return group_tensors
+
++    debug_runner_id = id(base_runner)
++    debug_report = (
++        os.environ.get("TRIATTN_DEBUG_STDERR", "0") == "1"
++        and debug_runner_id not in _DEBUG_REPORTED_RUNNERS
++    )
++    if debug_report:
++        _DEBUG_REPORTED_RUNNERS.add(debug_runner_id)
++
+     for gid, group in enumerate(kv_cache_groups):
++        if debug_report:
++            spec = getattr(group, "kv_cache_spec", None)
++            layer_names_dbg = getattr(group, "layer_names", None)
++            inner = getattr(spec, "kv_cache_specs", None)
++            if isinstance(inner, dict):
++                profiles: dict[str, int] = {}
++                for inner_spec in inner.values():
++                    key = (
++                        f"{type(inner_spec).__name__}:"
++                        f"sw={getattr(inner_spec, 'sliding_window', None)}:"
++                        f"chunk={getattr(inner_spec, 'attention_chunk_size', None)}"
++                    )
++                    profiles[key] = profiles.get(key, 0) + 1
++                inner_desc = profiles
++            else:
++                inner_desc = None
++            _debug_stderr(
++                "[TriAttentionDebug] resolver group "
++                f"gid={gid} spec={type(spec).__name__ if spec is not None else None} "
++                f"layers={len(layer_names_dbg) if isinstance(layer_names_dbg, (list, tuple)) else None} "
++                f"sw={getattr(spec, 'sliding_window', None)} "
++                f"chunk={getattr(spec, 'attention_chunk_size', None)} "
++                f"reclaimable={_is_reclaimable_full_attention_group(group)} "
++                f"inner={inner_desc}"
++            )
++        if not _is_reclaimable_full_attention_group(group):
++            # Sliding-window / chunked-local / mamba groups are not
++            # tail-truncatable; skip so the pipeline never compacts or emits a
++            # ReclaimGroup for them (hook_group_pipeline skips empty group_tensors).
++            continue
+         layer_names = getattr(group, "layer_names", None)
+         if not isinstance(layer_names, (list, tuple)):
+             continue
+@@ -105,13 +270,19 @@ def resolve_group_tensors(base_runner: Any) -> dict[int, list[tuple[int, torch.T
          seen_ptrs: set[int] = set()
          for local_idx, layer_name in enumerate(layer_names):
              layer = static_forward_context.get(layer_name)
@@ -370,7 +818,7 @@ index de07981..706e34a 100644
 -            tensor = kv_cache_list[0]
 -            if not isinstance(tensor, torch.Tensor):
 +            tensor = (
-+                _first_tensor(getattr(layer, "kv_cache", None))
++                _extract_attention_kv_cache_tensor(getattr(layer, "kv_cache", None))
 +                if layer is not None
 +                else None
 +            )
@@ -385,7 +833,7 @@ index de07981..706e34a 100644
                  continue
              ptr = tensor.data_ptr()
              if ptr in seen_ptrs:
-@@ -128,14 +204,6 @@ def resolve_group_tensors(base_runner: Any) -> dict[int, list[tuple[int, torch.T
+@@ -128,14 +299,17 @@ def resolve_group_tensors(base_runner: Any) -> dict[int, list[tuple[int, torch.T
                  )
              )
          if tensors:
@@ -400,9 +848,20 @@ index de07981..706e34a 100644
 -                        pass
 +            _register_group_axis_hints(base_runner, gid, tensors)
              group_tensors[gid] = tensors
++            if debug_report:
++                sample_shape = tuple(int(x) for x in tensors[0][1].shape)
++                _debug_stderr(
++                    "[TriAttentionDebug] resolver resolved "
++                    f"gid={gid} tensors={len(tensors)} sample_shape={sample_shape}"
++                )
++        elif debug_report:
++            _debug_stderr(
++                "[TriAttentionDebug] resolver resolved "
++                f"gid={gid} tensors=0"
++            )
      return group_tensors
 diff --git a/triattention/vllm/runtime/runner.py b/triattention/vllm/runtime/runner.py
-index b315dce..51da10d 100644
+index 72ecfca..7038c3b 100644
 --- a/triattention/vllm/runtime/runner.py
 +++ b/triattention/vllm/runtime/runner.py
 @@ -9,6 +9,7 @@ from typing import Any
@@ -413,7 +872,7 @@ index b315dce..51da10d 100644
  from .input_patch_backend import install_runtime_input_patch
  from .request_key_compat import get_scheduled_token_items
  from .runner_compression_actions import execute_runner_compression_actions
-@@ -123,6 +124,27 @@ class TriAttentionModelRunner:
+@@ -124,6 +125,27 @@ class TriAttentionModelRunner:
              return None
          return int(num_blocks_per_row[req_index]) * blk_size
 
@@ -441,7 +900,7 @@ index b315dce..51da10d 100644
      def _supplement_worker_self_triggers(
          self,
          scheduler_output: Any,
-@@ -152,12 +174,23 @@ class TriAttentionModelRunner:
+@@ -153,12 +175,23 @@ class TriAttentionModelRunner:
              if state is None:
                  continue
              prefill_len = state.prefill_len
@@ -466,7 +925,7 @@ index b315dce..51da10d 100644
                  actual_kv = state.current_cache_len
              else:
                  # First-time compression: use block table for ground truth.
-@@ -192,9 +225,9 @@ class TriAttentionModelRunner:
+@@ -193,9 +226,9 @@ class TriAttentionModelRunner:
              self._logger.info(
                  "TriAttention worker self-trigger: req=%s actual_kv=%d "
                  "effective_kv=%d scheduled=%d threshold=%d "
@@ -479,7 +938,7 @@ index b315dce..51da10d 100644
              signals[req_id] = CompressionSignal(
                  req_id=req_id,
 diff --git a/triattention/vllm/runtime/runner_compression_actions.py b/triattention/vllm/runtime/runner_compression_actions.py
-index 0631b30..8572771 100644
+index 0631b30..7b929b8 100644
 --- a/triattention/vllm/runtime/runner_compression_actions.py
 +++ b/triattention/vllm/runtime/runner_compression_actions.py
 @@ -1,13 +1,34 @@
@@ -566,7 +1025,7 @@ index 0631b30..8572771 100644
              _sched_nct = None
              _cached_reqs = getattr(scheduler_output, "scheduled_cached_reqs", None)
              if _cached_reqs is not None:
-@@ -152,6 +189,8 @@ def execute_runner_compression_actions(
+@@ -152,6 +177,8 @@ def execute_runner_compression_actions(
                          _sched_nct = int(_cr_nct[_idx])
                      except (ValueError, IndexError):
                          pass
@@ -575,7 +1034,7 @@ index 0631b30..8572771 100644
              state_store.mark_compressed(
                  req_id=req_id,
                  step=signal.step,
-@@ -182,7 +221,8 @@ def execute_runner_compression_actions(
+@@ -182,7 +209,8 @@ def execute_runner_compression_actions(
                      int(getattr(signal, "estimated_cache_len", 0)),
                      result.reason,
                  )
@@ -585,7 +1044,7 @@ index 0631b30..8572771 100644
                  {
                      "req_id": req_id,
                      "step": signal.step,
-@@ -198,7 +238,7 @@ def execute_runner_compression_actions(
+@@ -198,7 +226,7 @@ def execute_runner_compression_actions(
                          if isinstance(result.details, dict)
                          else None
                      ),
@@ -594,7 +1053,7 @@ index 0631b30..8572771 100644
              )
              continue
 
-@@ -216,7 +256,8 @@ def execute_runner_compression_actions(
+@@ -216,7 +244,8 @@ def execute_runner_compression_actions(
              result.cache_len_after,
              result.details,
          )
@@ -604,7 +1063,7 @@ index 0631b30..8572771 100644
              {
                  "req_id": req_id,
                  "step": signal.step,
-@@ -232,6 +273,6 @@ def execute_runner_compression_actions(
+@@ -232,6 +261,6 @@ def execute_runner_compression_actions(
                      if isinstance(result.details, dict)
                      else None
                  ),
@@ -613,10 +1072,59 @@ index 0631b30..8572771 100644
          )
      return events
 diff --git a/triattention/vllm/runtime/scheduler.py b/triattention/vllm/runtime/scheduler.py
-index dd4151a..06ad4fc 100644
+index dd4151a..58a20b8 100644
 --- a/triattention/vllm/runtime/scheduler.py
 +++ b/triattention/vllm/runtime/scheduler.py
-@@ -103,6 +103,15 @@ class TriAttentionScheduler(Scheduler):
+@@ -2,6 +2,8 @@
+
+ from __future__ import annotations
+
++import os
++import sys
+ from typing import Any
+
+ from vllm.config import VllmConfig
+@@ -13,6 +15,13 @@ from vllm.v1.kv_cache_interface import KVCacheConfig
+ from vllm.v1.outputs import ModelRunnerOutput
+ from vllm.v1.structured_output import StructuredOutputManager
+
++try:
++    # Only full-attention groups have a 1:1 tail-truncatable block table.
++    # Sliding-window / chunked-local / mamba managers null-pad in place.
++    from vllm.v1.core.single_type_kv_cache_manager import FullAttentionManager
++except Exception:  # pragma: no cover - version/layout fallback
++    FullAttentionManager = None  # type: ignore[assignment]
++
+ from .config import TriAttentionRuntimeConfig
+ from .effective_len_tracker import EffectiveCacheLenTracker
+ from .kv_allocation_sync import (
+@@ -26,6 +35,12 @@ from .signals import CompressionSignal
+
+ logger = init_logger(__name__)
+
++
++def _debug_stderr(message: str) -> None:
++    if os.environ.get("TRIATTN_DEBUG_STDERR", "0") == "1":
++        print(message, file=sys.stderr, flush=True)
++
++
+ def _evict_reclaimed_block_metadata(block_pool: Any, block: Any) -> None:
+     """Best-effort clear of prefix-cache metadata before reusing a block."""
+     if block_pool is None or block is None:
+@@ -90,6 +105,7 @@ class TriAttentionScheduler(Scheduler):
+         kv_cache_config: KVCacheConfig,
+         structured_output_manager: StructuredOutputManager,
+         block_size: int,
++        hash_block_size: int | None = None,
+         mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
+         include_finished_set: bool = False,
+         log_stats: bool = False,
+@@ -99,10 +115,20 @@ class TriAttentionScheduler(Scheduler):
+             kv_cache_config=kv_cache_config,
+             structured_output_manager=structured_output_manager,
+             block_size=block_size,
++            hash_block_size=hash_block_size,
+             mm_registry=mm_registry,
              include_finished_set=include_finished_set,
              log_stats=log_stats,
          )
@@ -632,3 +1140,334 @@ index dd4151a..06ad4fc 100644
          self.triattention_config = TriAttentionRuntimeConfig.from_env()
          self._planner = CompressionPlanner(self.triattention_config)
          self._effective_len_tracker = EffectiveCacheLenTracker()
+@@ -119,6 +145,12 @@ class TriAttentionScheduler(Scheduler):
+             self.triattention_config.enable_kv_usage_trigger,
+             self.triattention_config.enable_experimental_block_reclaim,
+         )
++        _debug_stderr(
++            "[TriAttentionDebug] scheduler init "
++            f"budget={self.triattention_config.kv_budget} "
++            f"divide={self.triattention_config.divide_length} "
++            f"reclaim={self.triattention_config.enable_experimental_block_reclaim}"
++        )
+
+     def _resolve_prefill_len(self, req_id: str) -> int:
+         if req_id in self._prefill_lens:
+@@ -260,6 +292,11 @@ class TriAttentionScheduler(Scheduler):
+                         req_id, self._triattention_step,
+                         estimated_cache_len, signal.reason,
+                     )
++                    _debug_stderr(
++                        "[TriAttentionDebug] signal "
++                        f"req={req_id} step={self._triattention_step} "
++                        f"estimated={estimated_cache_len} reason={signal.reason}"
++                    )
+                 signals[req_id] = signal
+         return signals
+
+@@ -385,12 +422,64 @@ class TriAttentionScheduler(Scheduler):
+             req_groups_seen = 0
+             if isinstance(managers, (list, tuple)):
+                 for gid, manager in enumerate(managers):
++                    if FullAttentionManager is not None and not isinstance(
++                        manager, FullAttentionManager
++                    ):
++                        # sliding-window/chunked/mamba: null-padded block table,
++                        # not tail-truncatable -> never synthesize a reclaim for it.
++                        continue
+                     req_blocks = manager.req_to_blocks.get(req_id)
+                     if req_blocks and required_blocks < len(req_blocks):
+                         expected_shrink_gids.add(gid)
+                     if req_blocks:
+                         req_groups_seen += 1
+
++            def _can_synthesize_reclaim(gids: set[int]) -> bool:
++                if not gids or not isinstance(managers, (list, tuple)):
++                    return False
++                if len(managers) == 1:
++                    return True
++                if FullAttentionManager is None:
++                    return False
++                return all(
++                    0 <= gid < len(managers)
++                    and isinstance(managers[gid], FullAttentionManager)
++                    for gid in gids
++                )
++
++            def _synthesize_reclaim(gids: set[int], reason: str) -> bool:
++                applied = False
++                if not isinstance(managers, (list, tuple)):
++                    return False
++                for gid in sorted(gids):
++                    if gid < 0 or gid >= len(managers):
++                        continue
++                    manager = managers[gid]
++                    req_blocks = manager.req_to_blocks.get(req_id)
++                    if not req_blocks or required_blocks >= len(req_blocks):
++                        continue
++                    kept_blocks = req_blocks[:required_blocks]
++                    removed_blocks = req_blocks[required_blocks:]
++                    manager.req_to_blocks[req_id] = kept_blocks
++                    if req_id in manager.num_cached_block:
++                        manager.num_cached_block[req_id] = min(
++                            manager.num_cached_block[req_id],
++                            len(kept_blocks),
++                        )
++                    logger.info(
++                        "TriAttention scheduler FREE_BLOCKS synthesized: "
++                        "req=%s gid=%d freed=%d kept=%d reason=%s",
++                        req_id, gid, len(removed_blocks), len(kept_blocks), reason,
++                    )
++                    _debug_stderr(
++                        "[TriAttentionDebug] FREE_BLOCKS "
++                        f"req={req_id} gid={gid} freed={len(removed_blocks)} "
++                        f"kept={len(kept_blocks)} synthesized={reason}"
++                    )
++                    if _free_reclaimed_blocks(manager, removed_blocks):
++                        applied = True
++                return applied
++
+             block_reclaim = event.get("block_reclaim")
+             groups = (
+                 block_reclaim.get("groups")
+@@ -423,22 +512,23 @@ class TriAttentionScheduler(Scheduler):
+                         "scheduled_tokens=%d) req=%s",
+                         _evt_scheduled, req_id,
+                     )
+-                elif expected_shrink_gids and isinstance(managers, (list, tuple)):
+-                    for gid in sorted(expected_shrink_gids):
+-                        manager = managers[gid]
+-                        req_blocks = manager.req_to_blocks.get(req_id)
+-                        if not req_blocks or required_blocks >= len(req_blocks):
+-                            continue
+-                        kept_blocks = req_blocks[:required_blocks]
+-                        removed_blocks = req_blocks[required_blocks:]
+-                        manager.req_to_blocks[req_id] = kept_blocks
+-                        if req_id in manager.num_cached_block:
+-                            manager.num_cached_block[req_id] = min(
+-                                manager.num_cached_block[req_id],
+-                                len(kept_blocks),
+-                            )
+-                        if _free_reclaimed_blocks(manager, removed_blocks):
+-                            reclaim_applied_any = True
++                elif expected_shrink_gids and _can_synthesize_reclaim(expected_shrink_gids):
++                    if _synthesize_reclaim(expected_shrink_gids, "no_groups_payload"):
++                        reclaim_applied_any = True
++                elif (
++                    expected_shrink_gids
++                    and isinstance(managers, (list, tuple))
++                    and len(managers) > 1
++                ):
++                    # Hybrid model where we cannot prove all missing gids are
++                    # plain full-attention managers. Skip rather than risking
++                    # SWA/chunked-local block-table corruption.
++                    logger.warning(
++                        "TriAttention block reclaim: skipping synthesized "
++                        "reclaim on hybrid model (no groups payload, "
++                        "unverified group layout) expected_shrink_gids=%s req=%s",
++                        sorted(expected_shrink_gids), req_id,
++                    )
+                 if reclaim_applied_any:
+                     update_request_effective_kv_offset(
+                         request=req,
+@@ -470,23 +560,31 @@ class TriAttentionScheduler(Scheduler):
+                 curr_ids = [block.block_id for block in req_blocks]
+                 kept_len = len(block_ids_after)
+                 if kept_len > len(curr_ids):
+-                    raise RuntimeError(
+-                        "TriAttention block reclaim invalid length: "
+-                        f"req={req_id} gid={gid} kept_len={kept_len} "
+-                        f"curr_len={len(curr_ids)}"
++                    logger.warning(
++                        "TriAttention block reclaim: skipping group "
++                        "(invalid length kept_len > curr_len) "
++                        "req=%s gid=%s kept_len=%s curr_len=%s",
++                        req_id, gid, kept_len, len(curr_ids),
+                     )
++                    continue
+                 if len(set(block_ids_after)) != kept_len:
+-                    raise RuntimeError(
+-                        "TriAttention block reclaim contains duplicate block ids: "
+-                        f"req={req_id} gid={gid} block_ids_after={block_ids_after}"
++                    logger.warning(
++                        "TriAttention block reclaim: skipping group "
++                        "(duplicate block ids / group-identity mismatch) "
++                        "req=%s gid=%s block_ids_after=%s",
++                        req_id, gid, block_ids_after,
+                     )
++                    continue
+                 expected_prefix = curr_ids[:kept_len]
+                 if expected_prefix != block_ids_after:
+-                    raise RuntimeError(
+-                        "TriAttention block reclaim prefix mismatch: "
+-                        f"req={req_id} gid={gid} expected_prefix={expected_prefix} "
+-                        f"actual_after={block_ids_after}"
++                    logger.warning(
++                        "TriAttention block reclaim: skipping group "
++                        "(prefix mismatch / sliding-window null padding or "
++                        "group-identity mismatch) req=%s gid=%s "
++                        "expected_prefix=%s actual_after=%s",
++                        req_id, gid, expected_prefix, block_ids_after,
+                     )
++                    continue
+                 if (
+                     getattr(self.triattention_config, "require_physical_reclaim", False)
+                     and gid in expected_shrink_gids
+@@ -524,6 +622,11 @@ class TriAttentionScheduler(Scheduler):
+                         req_id, gid, len(removed_old_blocks),
+                         len(kept_old_blocks), len(new_blocks_this_step),
+                     )
++                    _debug_stderr(
++                        "[TriAttentionDebug] FREE_BLOCKS "
++                        f"req={req_id} gid={gid} freed={len(removed_old_blocks)} "
++                        f"kept={len(kept_old_blocks)} new={len(new_blocks_this_step)}"
++                    )
+                     if _free_reclaimed_blocks(manager, removed_old_blocks):
+                         reclaim_applied_any = True
+
+@@ -533,22 +636,13 @@ class TriAttentionScheduler(Scheduler):
+             # Same safety as above: skip during chunked prefill without
+             # block_ids_before to avoid freeing new blocks.
+             missing_gids = expected_shrink_gids - seen_gids
+-            if missing_gids and _evt_scheduled <= 1:
+-                for gid in sorted(missing_gids):
+-                    manager = managers[gid]
+-                    req_blocks = manager.req_to_blocks.get(req_id)
+-                    if not req_blocks or required_blocks >= len(req_blocks):
+-                        continue
+-                    kept_blocks = req_blocks[:required_blocks]
+-                    removed_blocks = req_blocks[required_blocks:]
+-                    manager.req_to_blocks[req_id] = kept_blocks
+-                    if req_id in manager.num_cached_block:
+-                        manager.num_cached_block[req_id] = min(
+-                            manager.num_cached_block[req_id],
+-                            len(kept_blocks),
+-                        )
+-                    if _free_reclaimed_blocks(manager, removed_blocks):
+-                        reclaim_applied_any = True
++            if (
++                missing_gids
++                and _evt_scheduled <= 1
++                and _can_synthesize_reclaim(missing_gids)
++            ):
++                if _synthesize_reclaim(missing_gids, "missing_groups_payload"):
++                    reclaim_applied_any = True
+             elif missing_gids and _evt_scheduled > 1:
+                 logger.info(
+                     "TriAttention block reclaim: skipping synthesized "
+@@ -556,6 +650,13 @@ class TriAttentionScheduler(Scheduler):
+                     "(scheduled_tokens=%d) req=%s",
+                     sorted(missing_gids), _evt_scheduled, req_id,
+                 )
++            elif missing_gids and isinstance(managers, (list, tuple)) and len(managers) > 1:
++                logger.warning(
++                    "TriAttention block reclaim: skipping synthesized "
++                    "reclaim on hybrid model (unverified group layout) "
++                    "missing_gids=%s req=%s",
++                    sorted(missing_gids), req_id,
++                )
+
+             if reclaim_applied_any:
+                 update_request_effective_kv_offset(
+diff --git a/triattention/vllm/runtime/selector_hf.py b/triattention/vllm/runtime/selector_hf.py
+index 82abd43..24879d3 100644
+--- a/triattention/vllm/runtime/selector_hf.py
++++ b/triattention/vllm/runtime/selector_hf.py
+@@ -339,9 +339,13 @@ def build_triattention_selector(
+
+         if config.sparse_normalize_scores:
+             scores = normalize_scores(scores)
++        prefix_protect = min(
++            max(0, int(config.protect_prefix_tokens)), int(scores.shape[-1])
++        )
+         mutate_scores = (
+             config.window_size > 0
+             or (protect_prefill and prefill_len > 0)
++            or prefix_protect > 0
+         )
+         if mutate_scores:
+             scores = scores.clone()
+@@ -352,6 +356,11 @@ def build_triattention_selector(
+                 scores[..., total_tokens - recent_count :] = float("inf")
+         if protect_prefill and prefill_len > 0:
+             scores[..., :prefill_len] = float("inf")
++        if prefix_protect > 0:
++            # Attention-sink / format-anchor preservation: always keep the first K
++            # tokens (e.g. gpt-oss harmony channel scaffolding) so compressing the
++            # bulk prompt does not corrupt structured generation.
++            scores[..., :prefix_protect] = float("inf")
+         if use_hf_group_max:
+             scores = _reduce_grouped_head_scores(
+                 scores=scores,
+@@ -423,7 +432,12 @@ def build_triattention_selector(
+         protect_prefill: bool,
+         device: torch.device,
+     ) -> torch.Tensor | None:
+-        if config.window_size <= 0 and not (protect_prefill and prefill_len > 0):
++        prefix_protect = max(0, int(config.protect_prefix_tokens))
++        if (
++            config.window_size <= 0
++            and not (protect_prefill and prefill_len > 0)
++            and prefix_protect <= 0
++        ):
+             return None
+         token_positions = torch.arange(
+             start_token,
+@@ -438,6 +452,9 @@ def build_triattention_selector(
+             guard_mask |= token_positions >= window_start
+         if protect_prefill and prefill_len > 0:
+             guard_mask |= token_positions < prefill_len
++        if prefix_protect > 0:
++            # Attention-sink / format-anchor preservation (first K tokens).
++            guard_mask |= token_positions < prefix_protect
+         return guard_mask
+
+     def _apply_token_guards(
+diff --git a/triattention/vllm/runtime/worker_reclaim_sync.py b/triattention/vllm/runtime/worker_reclaim_sync.py
+index f9964cf..da8109d 100644
+--- a/triattention/vllm/runtime/worker_reclaim_sync.py
++++ b/triattention/vllm/runtime/worker_reclaim_sync.py
+@@ -85,6 +85,22 @@ def apply_worker_block_reclaim_events(
+     if block_size <= 0:
+         block_size = 16
+
++    # Only full-attention groups have tail-truncatable block tables. Sliding-window /
++    # chunked-local / mamba groups null-pad or window their tables, so shrinking them
++    # by the (full-attention-derived) required_blocks would corrupt their live KV.
++    full_attn_gids: set[int] | None = None
++    _kv_cache_config = getattr(base_runner, "kv_cache_config", None)
++    _groups = getattr(_kv_cache_config, "kv_cache_groups", None) if _kv_cache_config else None
++    if isinstance(_groups, (list, tuple)):
++        try:
++            from .kv_group_resolver import _is_reclaimable_full_attention_group
++            full_attn_gids = {
++                gid for gid, g in enumerate(_groups)
++                if _is_reclaimable_full_attention_group(g)
++            }
++        except Exception:
++            full_attn_gids = None
++
+     for event in events:
+         if not isinstance(event, dict) or event.get("status") != "applied":
+             continue
+@@ -100,7 +116,9 @@ def apply_worker_block_reclaim_events(
+
+         required_blocks = (cache_len_after + block_size - 1) // block_size
+
+-        for table in tables:
++        for gid, table in enumerate(tables):
++            if full_attn_gids is not None and gid not in full_attn_gids:
++                continue
+             num_blocks_per_row = getattr(table, "num_blocks_per_row", None)
+             if num_blocks_per_row is None:
+                 continue
+@@ -123,6 +141,8 @@ def apply_worker_block_reclaim_events(
+             if req_state is not None:
+                 block_ids_attr = getattr(req_state, "block_ids", None)
+                 if isinstance(block_ids_attr, (list, tuple)):
+-                    for group_blocks in block_ids_attr:
++                    for gid, group_blocks in enumerate(block_ids_attr):
++                        if full_attn_gids is not None and gid not in full_attn_gids:
++                            continue
+                         if isinstance(group_blocks, list) and len(group_blocks) > required_blocks:
+                             del group_blocks[required_blocks:]

--- a/engine_integration/patches/kvcached-triattention-main.patch
+++ b/engine_integration/patches/kvcached-triattention-main.patch
@@ -1,0 +1,667 @@
+diff --git a/triattention/vllm/runtime/hook_runtime_context.py b/triattention/vllm/runtime/hook_runtime_context.py
+index 301dfe1..f1fcb72 100644
+--- a/triattention/vllm/runtime/hook_runtime_context.py
++++ b/triattention/vllm/runtime/hook_runtime_context.py
+@@ -40,6 +40,30 @@ def _resolve_estimated_effective_tokens(
+     return max(0, int(getattr(signal, "estimated_cache_len", 0)))
+
+
++def compression_anchored_effective_len(
++    req_runtime_state: Any,
++    *,
++    logical_num_computed_tokens: int,
++) -> int | None:
++    if req_runtime_state is None:
++        return None
++    compression_count = getattr(req_runtime_state, "compression_count", None)
++    nct_at_compression = getattr(req_runtime_state, "nct_at_last_compression", None)
++    cache_len_after = getattr(req_runtime_state, "cache_len_after_last_compression", None)
++    if not (
++        isinstance(compression_count, int)
++        and compression_count > 0
++        and isinstance(nct_at_compression, int)
++        and isinstance(cache_len_after, int)
++    ):
++        return None
++    decoded_since_compression = max(
++        0,
++        int(logical_num_computed_tokens) - int(nct_at_compression),
++    )
++    return max(0, int(cache_len_after) + decoded_since_compression)
++
++
+ def effective_len_guard_upper(
+     config: TriAttentionRuntimeConfig,
+     signal: CompressionSignal,
+@@ -130,6 +154,18 @@ def build_hook_runtime_context(
+         signal=signal,
+         req_runtime_state=req_runtime_state,
+     )
++    anchored_effective_pre_step = compression_anchored_effective_len(
++        req_runtime_state,
++        logical_num_computed_tokens=num_computed_tokens,
++    )
++    if anchored_effective_pre_step is not None:
++        estimated_upper = anchored_effective_pre_step
++        if not getattr(signal, "_post_forward", False):
++            estimated_upper += max(0, scheduled_tokens)
++        estimated_effective_tokens = min(
++            estimated_effective_tokens,
++            max(0, int(estimated_upper)),
++        )
+
+     _post_forward = getattr(signal, '_post_forward', False)
+     if _post_forward:
+diff --git a/triattention/vllm/runtime/input_patch_vllm_v1_backend.py b/triattention/vllm/runtime/input_patch_vllm_v1_backend.py
+index 6871474..7bc4651 100644
+--- a/triattention/vllm/runtime/input_patch_vllm_v1_backend.py
++++ b/triattention/vllm/runtime/input_patch_vllm_v1_backend.py
+@@ -11,6 +11,7 @@ import os
+ from typing import Any, Callable
+
+ import numpy as np
++import torch
+
+ from . import input_patch_state as _patch_state
+
+@@ -27,6 +28,109 @@ def _debug_preserve_rope_positions() -> bool:
+     return os.environ.get("TRIATTN_DEBUG_V1_PRESERVE_ROPE_POSITIONS", "0") == "1"
+
+
++def _to_numpy(value: Any, *, dtype: np.dtype | type | None = None) -> np.ndarray | None:
++    if isinstance(value, np.ndarray):
++        return value.astype(dtype, copy=False) if dtype is not None else value
++    if isinstance(value, torch.Tensor):
++        arr = value.detach().to("cpu").numpy()
++        return arr.astype(dtype, copy=False) if dtype is not None else arr
++    return None
++
++
++def _buffer_numpy(value: Any) -> np.ndarray | None:
++    if hasattr(value, "np"):
++        arr = getattr(value, "np")
++        return arr if isinstance(arr, np.ndarray) else None
++    return _to_numpy(value)
++
++
++def _copy_numpy_back(value: Any, arr: np.ndarray, *, length: int | None = None) -> None:
++    if hasattr(value, "np"):
++        copy_to_gpu = getattr(value, "copy_to_gpu", None)
++        if callable(copy_to_gpu):
++            copy_to_gpu()
++        return
++    if isinstance(value, torch.Tensor):
++        target = value if length is None else value[:length]
++        src_arr = arr if length is None else arr[:length]
++        src = torch.as_tensor(src_arr, device=value.device, dtype=value.dtype)
++        target.copy_(src)
++
++
++def _get_buffer_np(obj: Any, attr: str) -> np.ndarray | None:
++    value = getattr(obj, attr, None)
++    if isinstance(value, np.ndarray):
++        return value
++    if hasattr(value, "np"):
++        arr = getattr(value, "np")
++        return arr if isinstance(arr, np.ndarray) else None
++    legacy = getattr(obj, f"{attr}_np", None)
++    return legacy if isinstance(legacy, np.ndarray) else None
++
++
++def _manual_compute_slot_mapping(block_table_obj: Any, req_indices: np.ndarray, positions: np.ndarray) -> bool:
++    block_tables = getattr(block_table_obj, "block_tables", None)
++    if isinstance(block_tables, (list, tuple)) and block_tables:
++        ok = False
++        for table in block_tables:
++            ok = _manual_compute_slot_mapping(table, req_indices, positions) or ok
++        return ok
++
++    block_table_np = _get_buffer_np(block_table_obj, "block_table")
++    slot_mapping_np = _get_buffer_np(block_table_obj, "slot_mapping")
++    block_size = int(getattr(block_table_obj, "block_size", 0) or 0)
++    max_blocks = int(getattr(block_table_obj, "max_num_blocks_per_req", 0) or 0)
++    if block_table_np is None or slot_mapping_np is None or block_size <= 0 or max_blocks <= 0:
++        return False
++
++    block_table_indices = req_indices * max_blocks + positions // block_size
++    block_numbers = block_table_np.ravel()[block_table_indices]
++    block_offsets = positions % block_size
++    np.add(
++        block_numbers * block_size,
++        block_offsets,
++        out=slot_mapping_np[: req_indices.shape[0]],
++    )
++    return True
++
++
++def _compute_slot_mapping(block_table_obj: Any, req_indices: np.ndarray, positions: np.ndarray) -> bool:
++    method = getattr(block_table_obj, "compute_slot_mapping", None)
++    if callable(method):
++        try:
++            method(req_indices, positions)
++            return True
++        except TypeError:
++            try:
++                # Some vLLM builds expose the function without binding it as an
++                # instance method; pass the table explicitly in that case.
++                method(block_table_obj, req_indices, positions)
++                return True
++            except TypeError:
++                pass
++
++    return _manual_compute_slot_mapping(block_table_obj, req_indices, positions)
++
++
++def _commit_slot_mapping(block_table_obj: Any, total_num_scheduled_tokens: int) -> bool:
++    method = getattr(block_table_obj, "commit_slot_mapping", None)
++    if callable(method):
++        method(total_num_scheduled_tokens)
++        return True
++
++    block_tables = getattr(block_table_obj, "block_tables", None)
++    if isinstance(block_tables, (list, tuple)) and block_tables:
++        committed = False
++        for table in block_tables:
++            committed = _commit_slot_mapping(table, total_num_scheduled_tokens) or committed
++        if committed:
++            return True
++
++    # Some vLLM variants write directly into the active slot-mapping buffer
++    # during compute_slot_mapping and expose no explicit commit hook.
++    return _get_buffer_np(block_table_obj, "slot_mapping") is not None
++
++
+ def _build_effective_slot_positions(
+     *,
+     positions_np: np.ndarray,
+@@ -106,26 +210,48 @@ def make_patched_v1_prepare_inputs(
+         if total_num_scheduled_tokens <= 0 or num_reqs <= 0:
+             return out
+
+-        req_indices = np.repeat(self.arange_np[:num_reqs], num_scheduled_tokens)
+-        positions_np = self.positions.np[:total_num_scheduled_tokens]
+-        original_positions_np = positions_np.copy()
++        num_scheduled_tokens_np = _to_numpy(num_scheduled_tokens, dtype=np.int64)
++        if num_scheduled_tokens_np is None:
++            return out
++        req_indices = np.repeat(self.arange_np[:num_reqs], num_scheduled_tokens_np)
++        positions_full_np = _buffer_numpy(getattr(self, "positions", None))
++        if positions_full_np is None:
++            return out
++        positions_np = positions_full_np[:total_num_scheduled_tokens]
+
+         slot_positions_np = _build_effective_slot_positions(
+             positions_np=positions_np,
+             req_indices=req_indices,
+         )
+         if slot_positions_np is not None:
+-            self.input_batch.block_table.compute_slot_mapping(req_indices, slot_positions_np)
+-            self.input_batch.block_table.commit_slot_mapping(total_num_scheduled_tokens)
++            if not _compute_slot_mapping(
++                self.input_batch.block_table,
++                req_indices,
++                slot_positions_np,
++            ):
++                return out
++            if not _commit_slot_mapping(
++                self.input_batch.block_table,
++                total_num_scheduled_tokens,
++            ):
++                return out
++        seq_lens_obj = getattr(self, "seq_lens", None)
++        seq_lens_np = _buffer_numpy(seq_lens_obj)
++        num_computed_tokens_cpu = _to_numpy(
++            getattr(self.input_batch, "num_computed_tokens_cpu", None),
++            dtype=np.int64,
++        )
++        if seq_lens_np is None or num_computed_tokens_cpu is None:
++            return out
+         seq_applied = _apply_sparse_seq_len_overrides_in_place(
+-            seq_lens_np=self.seq_lens.np,
+-            num_computed_tokens_cpu=self.input_batch.num_computed_tokens_cpu,
+-            num_scheduled_tokens=num_scheduled_tokens,
++            seq_lens_np=seq_lens_np,
++            num_computed_tokens_cpu=num_computed_tokens_cpu,
++            num_scheduled_tokens=num_scheduled_tokens_np,
+             num_reqs=num_reqs,
+         )
+         if seq_applied:
+-            self.seq_lens.np[num_reqs:].fill(0)
+-            self.seq_lens.copy_to_gpu()
++            seq_lens_np[num_reqs:].fill(0)
++            _copy_numpy_back(seq_lens_obj, seq_lens_np)
+
+         return out
+
+diff --git a/triattention/vllm/runtime/integration_monkeypatch.py b/triattention/vllm/runtime/integration_monkeypatch.py
+index 6fb2df8..9ecefa1 100644
+--- a/triattention/vllm/runtime/integration_monkeypatch.py
++++ b/triattention/vllm/runtime/integration_monkeypatch.py
+@@ -87,9 +87,33 @@ def _refresh_scheduler_stats_kv_usage(outputs: Any, kv_usage: float) -> None:
+             scheduler_stats.kv_cache_usage = usage
+
+
++def _assert_apc_disabled(scheduler_self: Any) -> None:
++    """Hard-fail when vLLM automatic prefix caching is enabled.
++
++    TriAttention's block reclaim path calls ``block_pool.free_blocks(...)``.
++    Under kvcached that resolves to ``ElasticBlockPool.free_blocks``, which —
++    when prefix caching is enabled — decrements ref counts and stashes the
++    blocks in ``_evictable_blocks`` instead of returning them to the kvcached
++    allocator. Because TriAttention has already truncated the request's
++    block list, those stashed blocks become orphans and the freed KV slots
++    are never reused. To avoid silent corruption we refuse to start.
++    """
++    vllm_cfg = getattr(scheduler_self, "vllm_config", None)
++    cache_cfg = getattr(vllm_cfg, "cache_config", None)
++    if cache_cfg is None:
++        return
++    if bool(getattr(cache_cfg, "enable_prefix_caching", False)):
++        raise RuntimeError(
++            "TriAttention is incompatible with vLLM automatic prefix caching. "
++            "Relaunch with --no-enable-prefix-caching (or "
++            "--enable-prefix-caching false), or unset ENABLE_TRIATTENTION."
++        )
++
++
+ def _patched_scheduler_init(self, *args, **kwargs):
+     assert _ORIG_SCHED_INIT is not None
+     _ORIG_SCHED_INIT(self, *args, **kwargs)
++    _assert_apc_disabled(self)
+     cfg = TriAttentionRuntimeConfig.from_env()
+     # Always attach config/state once patched to keep behavior deterministic.
+     self.triattention_config = cfg
+diff --git a/triattention/vllm/runtime/kv_group_resolver.py b/triattention/vllm/runtime/kv_group_resolver.py
+index de07981..706e34a 100644
+--- a/triattention/vllm/runtime/kv_group_resolver.py
++++ b/triattention/vllm/runtime/kv_group_resolver.py
+@@ -28,6 +28,8 @@ def _infer_kv_axis_from_group_backend(base_runner: Any, gid: int) -> int | None:
+     if gid < 0 or gid >= len(attn_groups):
+         return None
+     group = attn_groups[gid]
++    if isinstance(group, (list, tuple)) and group:
++        group = group[0]
+     backend = getattr(group, "backend", None)
+     if backend is None:
+         return None
+@@ -65,6 +67,63 @@ def _infer_kv_axis_from_group_backend(base_runner: Any, gid: int) -> int | None:
+     return None
+
+
++def _first_tensor(value: Any) -> torch.Tensor | None:
++    if isinstance(value, torch.Tensor):
++        return value
++    if isinstance(value, (list, tuple)):
++        for item in value:
++            tensor = _first_tensor(item)
++            if tensor is not None:
++                return tensor
++    return None
++
++
++def _resolve_tensor_from_kv_caches(
++    kv_caches: Any,
++    *,
++    layer_name: str,
++    gid: int,
++    local_idx: int,
++) -> torch.Tensor | None:
++    if isinstance(kv_caches, dict):
++        return _first_tensor(kv_caches.get(layer_name))
++    if isinstance(kv_caches, (list, tuple)):
++        # vLLM variants differ here:
++        # - some expose a flat list of layer tensors;
++        # - some expose per-group containers;
++        # - some expose dict-like layer mappings inside the list.
++        if gid < len(kv_caches):
++            group_entry = kv_caches[gid]
++            if isinstance(group_entry, dict):
++                tensor = _first_tensor(group_entry.get(layer_name))
++                if tensor is not None:
++                    return tensor
++            elif isinstance(group_entry, (list, tuple)) and local_idx < len(group_entry):
++                tensor = _first_tensor(group_entry[local_idx])
++                if tensor is not None:
++                    return tensor
++        if local_idx < len(kv_caches):
++            return _first_tensor(kv_caches[local_idx])
++    return None
++
++
++def _register_group_axis_hints(
++    base_runner: Any,
++    gid: int,
++    tensors: list[tuple[int, torch.Tensor]],
++) -> None:
++    kv_axis_hint = _infer_kv_axis_from_group_backend(base_runner=base_runner, gid=gid)
++    if kv_axis_hint is None:
++        return
++    for _layer_idx, tensor in tensors:
++        try:
++            register_kv_layout_axis_hint(tensor, kv_axis_hint)
++        except ValueError:
++            # Best effort registration only; compaction path will fail-fast if
++            # an ambiguous layout cannot be safely disambiguated.
++            pass
++
++
+ def resolve_group_tensors(base_runner: Any) -> dict[int, list[tuple[int, torch.Tensor]]]:
+     """Resolve kv cache tensors for each kv cache group.
+
+@@ -81,8 +140,9 @@ def resolve_group_tensors(base_runner: Any) -> dict[int, list[tuple[int, torch.T
+         else None
+     )
+
++    fallback = getattr(base_runner, "kv_caches", None)
++
+     if kv_cache_config is None or not isinstance(static_forward_context, dict):
+-        fallback = getattr(base_runner, "kv_caches", None)
+         if isinstance(fallback, list):
+             tensors = [
+                 (idx, t)
+@@ -91,6 +151,16 @@ def resolve_group_tensors(base_runner: Any) -> dict[int, list[tuple[int, torch.T
+             ]
+             if tensors:
+                 group_tensors[0] = tensors
++                _register_group_axis_hints(base_runner, 0, tensors)
++        elif isinstance(fallback, dict):
++            tensors = [
++                (idx, t)
++                for idx, t in enumerate(fallback.values())
++                if isinstance(t, torch.Tensor)
++            ]
++            if tensors:
++                group_tensors[0] = tensors
++                _register_group_axis_hints(base_runner, 0, tensors)
+         return group_tensors
+
+     kv_cache_groups = getattr(kv_cache_config, "kv_cache_groups", None)
+@@ -105,13 +175,19 @@ def resolve_group_tensors(base_runner: Any) -> dict[int, list[tuple[int, torch.T
+         seen_ptrs: set[int] = set()
+         for local_idx, layer_name in enumerate(layer_names):
+             layer = static_forward_context.get(layer_name)
+-            if layer is None:
+-                continue
+-            kv_cache_list = getattr(layer, "kv_cache", None)
+-            if not isinstance(kv_cache_list, list) or not kv_cache_list:
+-                continue
+-            tensor = kv_cache_list[0]
+-            if not isinstance(tensor, torch.Tensor):
++            tensor = (
++                _first_tensor(getattr(layer, "kv_cache", None))
++                if layer is not None
++                else None
++            )
++            if tensor is None:
++                tensor = _resolve_tensor_from_kv_caches(
++                    fallback,
++                    layer_name=str(layer_name),
++                    gid=gid,
++                    local_idx=local_idx,
++                )
++            if tensor is None:
+                 continue
+             ptr = tensor.data_ptr()
+             if ptr in seen_ptrs:
+@@ -128,14 +204,6 @@ def resolve_group_tensors(base_runner: Any) -> dict[int, list[tuple[int, torch.T
+                 )
+             )
+         if tensors:
+-            kv_axis_hint = _infer_kv_axis_from_group_backend(base_runner=base_runner, gid=gid)
+-            if kv_axis_hint is not None:
+-                for _layer_idx, tensor in tensors:
+-                    try:
+-                        register_kv_layout_axis_hint(tensor, kv_axis_hint)
+-                    except ValueError:
+-                        # Best effort registration only; compaction path will fail-fast if
+-                        # an ambiguous layout cannot be safely disambiguated.
+-                        pass
++            _register_group_axis_hints(base_runner, gid, tensors)
+             group_tensors[gid] = tensors
+     return group_tensors
+diff --git a/triattention/vllm/runtime/runner.py b/triattention/vllm/runtime/runner.py
+index b315dce..51da10d 100644
+--- a/triattention/vllm/runtime/runner.py
++++ b/triattention/vllm/runtime/runner.py
+@@ -9,6 +9,7 @@ from typing import Any
+
+ from .config import TriAttentionRuntimeConfig
+ from .executor import CompressionExecutor, RunnerHookCompressionExecutor
++from .hook_runtime_context import compression_anchored_effective_len
+ from .input_patch_backend import install_runtime_input_patch
+ from .request_key_compat import get_scheduled_token_items
+ from .runner_compression_actions import execute_runner_compression_actions
+@@ -123,6 +124,27 @@ class TriAttentionModelRunner:
+             return None
+         return int(num_blocks_per_row[req_index]) * blk_size
+
++    def _get_scheduler_num_computed(self, scheduler_output: Any, req_id: str) -> int | None:
++        cached = getattr(scheduler_output, "scheduled_cached_reqs", None)
++        if cached is not None:
++            req_ids = getattr(cached, "req_ids", None)
++            num_computed = getattr(cached, "num_computed_tokens", None)
++            if isinstance(req_ids, list) and isinstance(num_computed, list):
++                try:
++                    idx = req_ids.index(req_id)
++                    return int(num_computed[idx])
++                except (ValueError, IndexError, TypeError):
++                    pass
++        requests = getattr(self._base_runner, "requests", None)
++        if isinstance(requests, dict):
++            req_state = requests.get(req_id)
++            if req_state is not None:
++                try:
++                    return int(getattr(req_state, "num_computed_tokens", 0))
++                except (TypeError, ValueError):
++                    return None
++        return None
++
+     def _supplement_worker_self_triggers(
+         self,
+         scheduler_output: Any,
+@@ -152,12 +174,23 @@ class TriAttentionModelRunner:
+             if state is None:
+                 continue
+             prefill_len = state.prefill_len
++            scheduler_nct = self._get_scheduler_num_computed(scheduler_output, req_id)
++            anchored_kv = (
++                compression_anchored_effective_len(
++                    state,
++                    logical_num_computed_tokens=scheduler_nct,
++                )
++                if scheduler_nct is not None
++                else None
++            )
+             # Compute actual KV length on the Worker side.
+             # kv_from_blocks: block table already includes current step's
+             # allocated blocks (update_states runs before execute_model),
+             # so scheduled_tokens must NOT be added again.
+             kv_from_blocks = False
+-            if state.compression_count > 0 and state.current_cache_len > 0:
++            if anchored_kv is not None:
++                actual_kv = anchored_kv
++            elif state.compression_count > 0 and state.current_cache_len > 0:
+                 actual_kv = state.current_cache_len
+             else:
+                 # First-time compression: use block table for ground truth.
+@@ -192,9 +225,9 @@ class TriAttentionModelRunner:
+             self._logger.info(
+                 "TriAttention worker self-trigger: req=%s actual_kv=%d "
+                 "effective_kv=%d scheduled=%d threshold=%d "
+-                "from_blocks=%s (scheduler had no signal)",
++                "from_blocks=%s anchored=%s (scheduler had no signal)",
+                 req_id, actual_kv, effective_kv, scheduled_tokens,
+-                threshold, kv_from_blocks,
++                threshold, kv_from_blocks, anchored_kv is not None,
+             )
+             signals[req_id] = CompressionSignal(
+                 req_id=req_id,
+diff --git a/triattention/vllm/runtime/runner_compression_actions.py b/triattention/vllm/runtime/runner_compression_actions.py
+index 0631b30..8572771 100644
+--- a/triattention/vllm/runtime/runner_compression_actions.py
++++ b/triattention/vllm/runtime/runner_compression_actions.py
+@@ -1,13 +1,34 @@
+ """Compression action execution for TriAttentionModelRunner."""
+ from __future__ import annotations
+
++import json
+ import logging
++import os
++import time
+ from typing import Any
+
+ from .constants import TRITON_SCORING_REQUIRED_MARKER
+ from .signals import CompressionSignal
+
+
++def _write_event_sink(event: dict[str, Any]) -> None:
++    sink_path = os.environ.get("TRIATTN_RUNTIME_EVENT_SINK_PATH")
++    if not sink_path:
++        return
++    payload = dict(event)
++    payload.setdefault("ts", time.time())
++    try:
++        with open(sink_path, "a", encoding="utf-8") as fp:
++            fp.write(json.dumps(payload, sort_keys=True, default=str) + "\n")
++    except Exception:
++        pass
++
++
++def _append_event(events: list[dict[str, Any]], event: dict[str, Any]) -> None:
++    events.append(event)
++    _write_event_sink(event)
++
++
+ def execute_runner_compression_actions(
+     *,
+     executor: Any,
+@@ -48,7 +69,8 @@ def execute_runner_compression_actions(
+                         reason="batch_queue_dedup",
+                         step=signal.step,
+                     )
+-                events.append(
++                _append_event(
++                    events,
+                     {
+                         "req_id": req_id,
+                         "step": signal.step,
+@@ -58,7 +80,7 @@ def execute_runner_compression_actions(
+                         "scheduled_tokens": int(getattr(signal, "scheduled_tokens", 1)),
+                         "estimated_cache_len": int(getattr(signal, "estimated_cache_len", 0)),
+                         "prefill_len": int(getattr(signal, "prefill_len", 0)),
+-                    }
++                    },
+                 )
+                 continue
+         try:
+@@ -97,7 +119,8 @@ def execute_runner_compression_actions(
+                 req_id,
+                 signal.step,
+             )
+-            events.append(
++            _append_event(
++                events,
+                 {
+                     "req_id": req_id,
+                     "step": signal.step,
+@@ -107,7 +130,7 @@ def execute_runner_compression_actions(
+                     "scheduled_tokens": int(getattr(signal, "scheduled_tokens", 1)),
+                     "estimated_cache_len": int(getattr(signal, "estimated_cache_len", 0)),
+                     "prefill_len": int(getattr(signal, "prefill_len", 0)),
+-                }
++                },
+             )
+             continue
+
+@@ -140,7 +163,21 @@ def execute_runner_compression_actions(
+             )
+             # Resolve scheduler_nct for this request so state can record
+             # the num_computed_tokens at compression time (used by
+-            # build_effective_sparse_overrides for stable delta).
++            # compression_anchored_effective_len for stable post-compression
++            # decode tracking — without this the regression guard fires on
++            # the next step because anchored fallback can't compute a delta).
++            #
++            # Order matters:
++            # 1. ``scheduled_cached_reqs`` — authoritative for subsequent
++            #    compressions on requests that are mid-decode.
++            # 2. ``before_len`` (effective_tokens_before) — for the FIRST
++            #    compression. The request still lives in
++            #    ``scheduled_new_reqs`` whose ``num_computed_tokens`` reflects
++            #    the pre-prefill state (0 or a small chunk offset), NOT the
++            #    post-prefill KV position where compression actually happens.
++            #    ``before_len`` is the worker-side measured KV length at the
++            #    moment of compression, which is exactly what anchored decode
++            #    tracking needs.
+             _sched_nct = None
+             _cached_reqs = getattr(scheduler_output, "scheduled_cached_reqs", None)
+             if _cached_reqs is not None:
+@@ -152,6 +189,8 @@ def execute_runner_compression_actions(
+                         _sched_nct = int(_cr_nct[_idx])
+                     except (ValueError, IndexError):
+                         pass
++            if _sched_nct is None and isinstance(before_len, int) and before_len > 0:
++                _sched_nct = int(before_len)
+             state_store.mark_compressed(
+                 req_id=req_id,
+                 step=signal.step,
+@@ -182,7 +221,8 @@ def execute_runner_compression_actions(
+                     int(getattr(signal, "estimated_cache_len", 0)),
+                     result.reason,
+                 )
+-            events.append(
++            _append_event(
++                events,
+                 {
+                     "req_id": req_id,
+                     "step": signal.step,
+@@ -198,7 +238,7 @@ def execute_runner_compression_actions(
+                         if isinstance(result.details, dict)
+                         else None
+                     ),
+-                }
++                },
+             )
+             continue
+
+@@ -216,7 +256,8 @@ def execute_runner_compression_actions(
+             result.cache_len_after,
+             result.details,
+         )
+-        events.append(
++        _append_event(
++            events,
+             {
+                 "req_id": req_id,
+                 "step": signal.step,
+@@ -232,6 +273,6 @@ def execute_runner_compression_actions(
+                     if isinstance(result.details, dict)
+                     else None
+                 ),
+-            }
++            },
+         )
+     return events
+diff --git a/triattention/vllm/runtime/scheduler.py b/triattention/vllm/runtime/scheduler.py
+index dd4151a..06ad4fc 100644
+--- a/triattention/vllm/runtime/scheduler.py
++++ b/triattention/vllm/runtime/scheduler.py
+@@ -103,6 +103,18 @@ class TriAttentionScheduler(Scheduler):
+             include_finished_set=include_finished_set,
+             log_stats=log_stats,
+         )
++        # Refuse to run when vLLM automatic prefix caching is enabled.
++        # See _assert_apc_disabled in integration_monkeypatch.py for why
++        # ElasticBlockPool.free_blocks under APC silently orphans freed
++        # blocks after TriAttention reclaim.
++        cache_cfg = getattr(vllm_config, "cache_config", None)
++        if cache_cfg is not None and bool(
++            getattr(cache_cfg, "enable_prefix_caching", False)
++        ):
++            raise RuntimeError(
++                "TriAttention is incompatible with vLLM automatic prefix "
++                "caching. Relaunch with --no-enable-prefix-caching."
++            )
+         self.triattention_config = TriAttentionRuntimeConfig.from_env()
+         self._planner = CompressionPlanner(self.triattention_config)
+         self._effective_len_tracker = EffectiveCacheLenTracker()

--- a/engine_integration/patches/kvcached-triattention-main.patch
+++ b/engine_integration/patches/kvcached-triattention-main.patch
@@ -64,7 +64,7 @@ index 6871474..7bc4651 100644
 
  from . import input_patch_state as _patch_state
 
-@@ -27,6 +28,109 @@ def _debug_preserve_rope_positions() -> bool:
+@@ -27,6 +28,106 @@ def _debug_preserve_rope_positions() -> bool:
      return os.environ.get("TRIATTN_DEBUG_V1_PRESERVE_ROPE_POSITIONS", "0") == "1"
 
 
@@ -142,8 +142,7 @@ index 6871474..7bc4651 100644
 +            return True
 +        except TypeError:
 +            try:
-+                # Some vLLM builds expose the function without binding it as an
-+                # instance method; pass the table explicitly in that case.
++                # Handle unbound compatibility shims.
 +                method(block_table_obj, req_indices, positions)
 +                return True
 +            except TypeError:
@@ -166,8 +165,6 @@ index 6871474..7bc4651 100644
 +        if committed:
 +            return True
 +
-+    # Some vLLM variants write directly into the active slot-mapping buffer
-+    # during compute_slot_mapping and expose no explicit commit hook.
 +    return _get_buffer_np(block_table_obj, "slot_mapping") is not None
 +
 +
@@ -237,21 +234,12 @@ diff --git a/triattention/vllm/runtime/integration_monkeypatch.py b/triattention
 index 6fb2df8..9ecefa1 100644
 --- a/triattention/vllm/runtime/integration_monkeypatch.py
 +++ b/triattention/vllm/runtime/integration_monkeypatch.py
-@@ -87,9 +87,33 @@ def _refresh_scheduler_stats_kv_usage(outputs: Any, kv_usage: float) -> None:
+@@ -87,9 +87,24 @@ def _refresh_scheduler_stats_kv_usage(outputs: Any, kv_usage: float) -> None:
              scheduler_stats.kv_cache_usage = usage
 
 
 +def _assert_apc_disabled(scheduler_self: Any) -> None:
-+    """Hard-fail when vLLM automatic prefix caching is enabled.
-+
-+    TriAttention's block reclaim path calls ``block_pool.free_blocks(...)``.
-+    Under kvcached that resolves to ``ElasticBlockPool.free_blocks``, which —
-+    when prefix caching is enabled — decrements ref counts and stashes the
-+    blocks in ``_evictable_blocks`` instead of returning them to the kvcached
-+    allocator. Because TriAttention has already truncated the request's
-+    block list, those stashed blocks become orphans and the freed KV slots
-+    are never reused. To avoid silent corruption we refuse to start.
-+    """
++    """Fail fast because APC can orphan TriAttention-reclaimed blocks."""
 +    vllm_cfg = getattr(scheduler_self, "vllm_config", None)
 +    cache_cfg = getattr(vllm_cfg, "cache_config", None)
 +    if cache_cfg is None:
@@ -284,7 +272,7 @@ index de07981..706e34a 100644
      backend = getattr(group, "backend", None)
      if backend is None:
          return None
-@@ -65,6 +67,63 @@ def _infer_kv_axis_from_group_backend(base_runner: Any, gid: int) -> int | None:
+@@ -65,6 +67,57 @@ def _infer_kv_axis_from_group_backend(base_runner: Any, gid: int) -> int | None:
      return None
 
 
@@ -309,10 +297,6 @@ index de07981..706e34a 100644
 +    if isinstance(kv_caches, dict):
 +        return _first_tensor(kv_caches.get(layer_name))
 +    if isinstance(kv_caches, (list, tuple)):
-+        # vLLM variants differ here:
-+        # - some expose a flat list of layer tensors;
-+        # - some expose per-group containers;
-+        # - some expose dict-like layer mappings inside the list.
 +        if gid < len(kv_caches):
 +            group_entry = kv_caches[gid]
 +            if isinstance(group_entry, dict):
@@ -340,8 +324,6 @@ index de07981..706e34a 100644
 +        try:
 +            register_kv_layout_axis_hint(tensor, kv_axis_hint)
 +        except ValueError:
-+            # Best effort registration only; compaction path will fail-fast if
-+            # an ambiguous layout cannot be safely disambiguated.
 +            pass
 +
 +
@@ -573,26 +555,14 @@ index 0631b30..8572771 100644
              )
              continue
 
-@@ -140,7 +163,21 @@ def execute_runner_compression_actions(
+@@ -140,7 +163,9 @@ def execute_runner_compression_actions(
              )
              # Resolve scheduler_nct for this request so state can record
              # the num_computed_tokens at compression time (used by
 -            # build_effective_sparse_overrides for stable delta).
 +            # compression_anchored_effective_len for stable post-compression
-+            # decode tracking — without this the regression guard fires on
-+            # the next step because anchored fallback can't compute a delta).
-+            #
-+            # Order matters:
-+            # 1. ``scheduled_cached_reqs`` — authoritative for subsequent
-+            #    compressions on requests that are mid-decode.
-+            # 2. ``before_len`` (effective_tokens_before) — for the FIRST
-+            #    compression. The request still lives in
-+            #    ``scheduled_new_reqs`` whose ``num_computed_tokens`` reflects
-+            #    the pre-prefill state (0 or a small chunk offset), NOT the
-+            #    post-prefill KV position where compression actually happens.
-+            #    ``before_len`` is the worker-side measured KV length at the
-+            #    moment of compression, which is exactly what anchored decode
-+            #    tracking needs.
++            # decode tracking. For the first compression, scheduled_new_reqs
++            # can still carry the pre-prefill count, so fall back to before_len.
              _sched_nct = None
              _cached_reqs = getattr(scheduler_output, "scheduled_cached_reqs", None)
              if _cached_reqs is not None:
@@ -646,14 +616,11 @@ diff --git a/triattention/vllm/runtime/scheduler.py b/triattention/vllm/runtime/
 index dd4151a..06ad4fc 100644
 --- a/triattention/vllm/runtime/scheduler.py
 +++ b/triattention/vllm/runtime/scheduler.py
-@@ -103,6 +103,18 @@ class TriAttentionScheduler(Scheduler):
+@@ -103,6 +103,15 @@ class TriAttentionScheduler(Scheduler):
              include_finished_set=include_finished_set,
              log_stats=log_stats,
          )
-+        # Refuse to run when vLLM automatic prefix caching is enabled.
-+        # See _assert_apc_disabled in integration_monkeypatch.py for why
-+        # ElasticBlockPool.free_blocks under APC silently orphans freed
-+        # blocks after TriAttention reclaim.
++        # Keep subclass and monkeypatch paths equally fail-fast.
 +        cache_cfg = getattr(vllm_config, "cache_config", None)
 +        if cache_cfg is not None and bool(
 +            getattr(cache_cfg, "enable_prefix_caching", False)

--- a/kvcached/integration/sglang/autopatch.py
+++ b/kvcached/integration/sglang/autopatch.py
@@ -53,9 +53,8 @@ def _patch_sglang(_sglang: types.ModuleType) -> None:
     # Log results
     log_patch_results("sglang", results)
 
-    # Optional: layer TriAttention KV compression on top of kvcached's SGLang
-    # patches. Gated by ENABLE_TRIATTENTION=1. Must run AFTER kvcached patches
-    # so TriAttention's scheduler/worker hooks see the kvcached-aware runtime.
+    # Optional TriAttention layer. Install after kvcached patches so
+    # TriAttention sees kvcached-backed SGLang runtime state.
     if os.getenv("ENABLE_TRIATTENTION", "0").lower() in ("true", "1"):
         try:
             from kvcached.integration.triattention_external import (
@@ -73,3 +72,8 @@ def _patch_sglang(_sglang: types.ModuleType) -> None:
                 "[TriAttention] SGLang activation failed: %s: %s",
                 type(exc).__name__, exc,
             )
+            raise RuntimeError(
+                "ENABLE_TRIATTENTION=1 was requested, but TriAttention "
+                "SGLang activation failed. Check the external triattention "
+                "package and PYTHONPATH."
+            ) from exc

--- a/kvcached/integration/sglang/autopatch.py
+++ b/kvcached/integration/sglang/autopatch.py
@@ -52,3 +52,24 @@ def _patch_sglang(_sglang: types.ModuleType) -> None:
 
     # Log results
     log_patch_results("sglang", results)
+
+    # Optional: layer TriAttention KV compression on top of kvcached's SGLang
+    # patches. Gated by ENABLE_TRIATTENTION=1. Must run AFTER kvcached patches
+    # so TriAttention's scheduler/worker hooks see the kvcached-aware runtime.
+    if os.getenv("ENABLE_TRIATTENTION", "0").lower() in ("true", "1"):
+        try:
+            from kvcached.integration.triattention_external import (
+                get_external_sglang_installer,
+            )
+
+            install_sglang_integration = get_external_sglang_installer()
+            install_sglang_integration()
+            logger.info(
+                "[TriAttention] SGLang integration activated on top of "
+                "kvcached (ENABLE_TRIATTENTION=1)."
+            )
+        except Exception as exc:
+            logger.error(
+                "[TriAttention] SGLang activation failed: %s: %s",
+                type(exc).__name__, exc,
+            )

--- a/kvcached/integration/triattention_external.py
+++ b/kvcached/integration/triattention_external.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for loading an externally installed TriAttention package.
+
+kvcached intentionally does not vendor TriAttention source.  Users should
+install TriAttention separately and apply the small kvcached compatibility
+patch shipped in ``engine_integration/patches/kvcached-triattention-main.patch``.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+from typing import Callable
+
+PATCH_HINT = (
+    "Install TriAttention from https://github.com/WeianMao/triattention and "
+    "apply engine_integration/patches/kvcached-triattention-main.patch from "
+    "the TriAttention repository root."
+)
+
+
+def _import_external_module(name: str) -> ModuleType:
+    try:
+        return importlib.import_module(name)
+    except ImportError as exc:
+        raise RuntimeError(
+            "ENABLE_TRIATTENTION=1 requires the external 'triattention' "
+            f"package. {PATCH_HINT}"
+        ) from exc
+
+
+def _require_attr(module: ModuleType, attr: str) -> None:
+    if not hasattr(module, attr):
+        raise RuntimeError(
+            "The installed TriAttention package is missing kvcached "
+            f"compatibility marker {module.__name__}.{attr}. {PATCH_HINT}"
+        )
+
+
+def install_external_vllm_triattention() -> None:
+    """Install external TriAttention's vLLM hooks after patch validation."""
+
+    integration = _import_external_module(
+        "triattention.vllm.runtime.integration_monkeypatch"
+    )
+    hook_context = _import_external_module(
+        "triattention.vllm.runtime.hook_runtime_context"
+    )
+    v1_backend = _import_external_module(
+        "triattention.vllm.runtime.input_patch_vllm_v1_backend"
+    )
+
+    _require_attr(hook_context, "compression_anchored_effective_len")
+    _require_attr(v1_backend, "_to_numpy")
+    _require_attr(integration, "_assert_apc_disabled")
+
+    install = getattr(integration, "install_vllm_integration_monkeypatches", None)
+    if not callable(install):
+        raise RuntimeError(
+            "The installed TriAttention package does not expose "
+            "install_vllm_integration_monkeypatches. "
+            f"{PATCH_HINT}"
+        )
+
+    install(patch_scheduler=True, patch_worker=True)
+
+
+def get_external_sglang_installer() -> Callable[[], None]:
+    """Return external TriAttention's SGLang installer."""
+
+    sglang = _import_external_module("triattention.sglang")
+    install = getattr(sglang, "install_sglang_integration", None)
+    if not callable(install):
+        raise RuntimeError(
+            "The installed TriAttention package does not expose "
+            f"install_sglang_integration. {PATCH_HINT}"
+        )
+    return install

--- a/kvcached/integration/triattention_external.py
+++ b/kvcached/integration/triattention_external.py
@@ -14,11 +14,58 @@ import importlib
 from types import ModuleType
 from typing import Callable
 
+from kvcached.integration.version_utils import VersionRange
+from kvcached.utils import get_kvcached_logger
+
+logger = get_kvcached_logger()
+
 PATCH_HINT = (
     "Install TriAttention from https://github.com/WeianMao/triattention and "
     "apply engine_integration/patches/kvcached-triattention-main.patch from "
     "the TriAttention repository root."
 )
+
+# TriAttention's vLLM integration unconditionally replaces
+# ``GPUModelRunner._prepare_inputs`` with a wrapper that expects vLLM to pass
+# ``num_scheduled_tokens`` as a positional argument. That calling convention
+# only exists in vLLM >= 0.13.0. On vLLM 0.11.x and earlier the engine instead
+# calls ``_prepare_inputs(scheduler_output)`` and TriAttention crashes on the
+# first decode step with a cryptic
+# ``TypeError: ... missing 1 required positional argument: 'num_scheduled_tokens'``.
+# We gate activation on the version so users get a clear startup error instead.
+_TRIATTENTION_MIN_VLLM = "0.13.0"
+_TRIATTENTION_TESTED_VLLM = "0.21.0"
+
+
+def _check_vllm_version_supported() -> None:
+    """Fail fast (with a clear message) on a vLLM that TriAttention cannot patch."""
+
+    try:
+        import vllm
+
+        detected = str(getattr(vllm, "__version__", "") or "")
+    except Exception:
+        # vLLM not importable here; the activation imports below will surface it.
+        return
+    if not detected:
+        return
+
+    if not VersionRange(f">={_TRIATTENTION_MIN_VLLM}").contains(detected):
+        raise RuntimeError(
+            f"TriAttention requires vLLM >= {_TRIATTENTION_MIN_VLLM}, but vLLM "
+            f"{detected} is installed. vLLM 0.11.x and earlier call "
+            "GPUModelRunner._prepare_inputs(scheduler_output) without "
+            "'num_scheduled_tokens', so TriAttention's input patch crashes on "
+            "the first decode step. Upgrade vLLM (validated through "
+            f"{_TRIATTENTION_TESTED_VLLM}) or unset ENABLE_TRIATTENTION."
+        )
+    if not VersionRange(f"<={_TRIATTENTION_TESTED_VLLM}").contains(detected):
+        logger.warning(
+            "[TriAttention] vLLM %s is newer than the last validated version "
+            "(%s); the TriAttention integration is untested here and may break.",
+            detected,
+            _TRIATTENTION_TESTED_VLLM,
+        )
 
 
 def _import_external_module(name: str) -> ModuleType:
@@ -41,6 +88,8 @@ def _require_attr(module: ModuleType, attr: str) -> None:
 
 def install_external_vllm_triattention() -> None:
     """Install external TriAttention's vLLM hooks after patch validation."""
+
+    _check_vllm_version_supported()
 
     integration = _import_external_module(
         "triattention.vllm.runtime.integration_monkeypatch"

--- a/kvcached/integration/vllm/autopatch.py
+++ b/kvcached/integration/vllm/autopatch.py
@@ -55,18 +55,8 @@ def _patch_vllm(_vllm: types.ModuleType) -> None:
     # Log results
     log_patch_results("vllm", results)
 
-    # Optional: layer TriAttention KV compression on top of kvcached's vLLM
-    # patches. Gated by ENABLE_TRIATTENTION=1 so existing kvcached users are
-    # unaffected. Must run AFTER kvcached patches so TriAttention's scheduler/
-    # worker monkeypatches wrap the kvcached-aware scheduler & runner.
-    #
-    # Block reclaim routing: TriAttention's reclaim path ultimately calls
-    # ``block_pool.free_blocks(...)``. After ElasticBlockPoolPatch above,
-    # ``block_pool`` is kvcached's ElasticBlockPool, which routes free_blocks
-    # to ``self.kv_cache_manager.free(...)`` — i.e. through kvcached's
-    # allocator. No extra glue is needed. The only hard requirement is that
-    # vLLM automatic prefix caching be disabled; TriAttention's scheduler
-    # hook asserts this at startup.
+    # Optional TriAttention layer. Install after kvcached patches so
+    # TriAttention sees kvcached-backed vLLM scheduler and block pool state.
     if os.getenv("ENABLE_TRIATTENTION", "0").lower() in ("true", "1"):
         try:
             from kvcached.integration.triattention_external import (
@@ -85,7 +75,7 @@ def _patch_vllm(_vllm: types.ModuleType) -> None:
             )
             raise RuntimeError(
                 "ENABLE_TRIATTENTION=1 was requested, but TriAttention "
-                "activation failed. Check the external triattention package, "
-                "PYTHONPATH/--triattention-root, and the kvcached compatibility "
-                "patch."
+                "vLLM activation failed. Check the external triattention "
+                "package, PYTHONPATH/--triattention-root, and the kvcached "
+                "compatibility patch."
             ) from exc

--- a/kvcached/integration/vllm/autopatch.py
+++ b/kvcached/integration/vllm/autopatch.py
@@ -54,3 +54,38 @@ def _patch_vllm(_vllm: types.ModuleType) -> None:
 
     # Log results
     log_patch_results("vllm", results)
+
+    # Optional: layer TriAttention KV compression on top of kvcached's vLLM
+    # patches. Gated by ENABLE_TRIATTENTION=1 so existing kvcached users are
+    # unaffected. Must run AFTER kvcached patches so TriAttention's scheduler/
+    # worker monkeypatches wrap the kvcached-aware scheduler & runner.
+    #
+    # Block reclaim routing: TriAttention's reclaim path ultimately calls
+    # ``block_pool.free_blocks(...)``. After ElasticBlockPoolPatch above,
+    # ``block_pool`` is kvcached's ElasticBlockPool, which routes free_blocks
+    # to ``self.kv_cache_manager.free(...)`` — i.e. through kvcached's
+    # allocator. No extra glue is needed. The only hard requirement is that
+    # vLLM automatic prefix caching be disabled; TriAttention's scheduler
+    # hook asserts this at startup.
+    if os.getenv("ENABLE_TRIATTENTION", "0").lower() in ("true", "1"):
+        try:
+            from kvcached.integration.triattention_external import (
+                install_external_vllm_triattention,
+            )
+
+            install_external_vllm_triattention()
+            logger.info(
+                "[TriAttention] Runtime plugin activated on top of kvcached "
+                "(ENABLE_TRIATTENTION=1)."
+            )
+        except Exception as exc:
+            logger.error(
+                "[TriAttention] Activation failed: %s: %s",
+                type(exc).__name__, exc,
+            )
+            raise RuntimeError(
+                "ENABLE_TRIATTENTION=1 was requested, but TriAttention "
+                "activation failed. Check the external triattention package, "
+                "PYTHONPATH/--triattention-root, and the kvcached compatibility "
+                "patch."
+            ) from exc

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -1320,12 +1320,24 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
         if self._is_already_patched(original_method, "reshape_kv_cache_tensors"):
             return True
 
-        def _patched_reshape_kv(self, kv_cache_config, kv_cache_raw_tensors, *args: Any, **kwargs: Any):
+        def _patched_reshape_kv(self, *args: Any, **kwargs: Any):
             if enable_kvcached():
+                # vLLM <=0.19: _reshape_kv_cache_tensors(kv_cache_config, kv_cache_raw_tensors)
+                # vLLM >=0.20: _reshape_kv_cache_tensors(kv_cache_raw_tensors, kernel_block_sizes)
+                #              and kv_cache_config now lives on self.kv_cache_config.
+                first = args[0] if args else kwargs.get("kv_cache_config")
+                if first is not None and hasattr(first, "kv_cache_groups"):
+                    kv_cache_config = first
+                    kv_cache_raw_tensors = (
+                        args[1] if len(args) > 1 else kwargs.get("kv_cache_raw_tensors")
+                    )
+                else:
+                    kv_cache_config = getattr(self, "kv_cache_config", None)
+                    kv_cache_raw_tensors = first
                 return self._reshape_kv_cache_tensors_from_kvcached(
-                    kv_cache_config, kv_cache_raw_tensors, *args, **kwargs
+                    kv_cache_config, kv_cache_raw_tensors
                 )
-            return original_method(self, kv_cache_config, kv_cache_raw_tensors, *args, **kwargs)
+            return original_method(self, *args, **kwargs)
 
         self._mark_as_patched(_patched_reshape_kv, "reshape_kv_cache_tensors")
         setattr(GPUModelRunner, "_reshape_kv_cache_tensors", _patched_reshape_kv)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,11 @@ dev = [
     "setuptools>=64",
     "wheel",
 ]
+triattention = [
+    "einops",
+    "scipy",
+    "transformers>=4.48.1",
+]
 
 [tool.setuptools]
 include-package-data = true

--- a/tools/compare_sglang_triattention.py
+++ b/tools/compare_sglang_triattention.py
@@ -34,6 +34,8 @@ CSV_FIELDS = [
     "kv_budget",
     "divide_length",
     "max_tokens",
+    "min_tokens",
+    "ignore_eos",
     "concurrency",
     "requests",
     "successes",
@@ -75,6 +77,21 @@ PROMPT_UNIT = (
 DEFAULT_STATS_RELATIVE_PATH = (
     "triattention/calibration/for_aime25_experiment/qwen3_8b.pt"
 )
+
+WORKLOAD_PROFILES: dict[str, dict[str, Any]] = {
+    "long-prompt": {
+        "prompt_repeat": 1200,
+        "max_tokens": 2048,
+        "min_tokens": 0,
+        "ignore_eos": False,
+    },
+    "decode-stress": {
+        "prompt_repeat": 64,
+        "max_tokens": 8192,
+        "min_tokens": 8192,
+        "ignore_eos": True,
+    },
+}
 
 
 def default_triattention_root() -> str:
@@ -679,12 +696,14 @@ def build_row(
     )
     return {
         "label": label,
-        "workload": "concurrency",
+        "workload": args.workload_profile,
         "model": args.model,
         "prompt_repeat": actual_prompt_repeat,
         "kv_budget": "" if budget is None else budget,
         "divide_length": "" if budget is None else args.divide_length,
         "max_tokens": args.max_tokens,
+        "min_tokens": args.min_tokens,
+        "ignore_eos": str(args.ignore_eos).lower(),
         "concurrency": concurrency,
         "requests": len(request_metrics),
         "successes": len(successes),
@@ -728,12 +747,38 @@ def parse_int_list(raw: str) -> list[int]:
     return values
 
 
+def apply_workload_profile(args: argparse.Namespace) -> None:
+    profile = WORKLOAD_PROFILES[args.workload_profile]
+    if args.prompt_repeat is None:
+        args.prompt_repeat = int(profile["prompt_repeat"])
+    if args.max_tokens is None:
+        args.max_tokens = int(profile["max_tokens"])
+    if args.min_tokens is None:
+        args.min_tokens = (
+            args.max_tokens
+            if args.workload_profile == "decode-stress"
+            else int(profile["min_tokens"])
+        )
+    if profile["ignore_eos"]:
+        args.ignore_eos = True
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Compare kvcached-only and kvcached+TriAttention on a "
             "long-context SGLang workload."
         )
+    )
+    parser.add_argument(
+        "--workload-profile",
+        choices=sorted(WORKLOAD_PROFILES),
+        default="decode-stress",
+        help=(
+            "decode-stress uses a short prompt and long forced decode so "
+            "SGLang TriAttention reclaim can affect GPU peak memory. "
+            "long-prompt keeps the original prompt-heavy workload."
+        ),
     )
     parser.add_argument("--model", default="/root/data/models/Qwen/Qwen3-8B")
     parser.add_argument(
@@ -768,7 +813,7 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=Path(tempfile.gettempdir()) / "triattn-sglang-compare",
     )
-    parser.add_argument("--prompt-repeat", type=int, default=1200)
+    parser.add_argument("--prompt-repeat", type=int, default=None)
     parser.add_argument(
         "--prompt-token-margin",
         type=int,
@@ -778,11 +823,11 @@ def parse_args() -> argparse.Namespace:
             "the long prompt."
         ),
     )
-    parser.add_argument("--max-tokens", type=int, default=2048)
+    parser.add_argument("--max-tokens", type=int, default=None)
     parser.add_argument(
         "--min-tokens",
         type=int,
-        default=0,
+        default=None,
         help=(
             "Forward min_tokens to SGLang's OpenAI-compatible endpoint. "
             "Use a value larger than the KV budget to exercise decode-time "
@@ -827,7 +872,9 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Run only kvcached baseline rows.",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    apply_workload_profile(args)
+    return args
 
 
 def resolve_triattention_paths(args: argparse.Namespace) -> None:
@@ -887,7 +934,8 @@ def main() -> int:
     print(f"TriAttention root: {args.triattention_root}")
     print(f"TriAttention stats: {args.stats_path}")
     print(
-        f"Workload: prompt_repeat={args.prompt_repeat}, max_tokens={args.max_tokens}, "
+        f"Workload: profile={args.workload_profile}, "
+        f"prompt_repeat={args.prompt_repeat}, max_tokens={args.max_tokens}, "
         f"min_tokens={args.min_tokens}, ignore_eos={args.ignore_eos}, "
         f"concurrencies={args.concurrencies}, budgets={args.budgets}"
     )
@@ -895,7 +943,7 @@ def main() -> int:
     for idx, (label, budget, pair_budget, concurrency) in enumerate(plan, start=1):
         budget_tag = f"budget{pair_budget}"
         log_name = (
-            f"concurrency-{label}-{budget_tag}-tok{args.max_tokens}-"
+            f"concurrency-{args.workload_profile}-{label}-{budget_tag}-tok{args.max_tokens}-"
             f"conc{concurrency}-{int(time.time())}.log"
         )
         log_path = args.log_dir / log_name

--- a/tools/compare_sglang_triattention.py
+++ b/tools/compare_sglang_triattention.py
@@ -1,0 +1,993 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compare long-context SGLang serving with and without TriAttention.
+
+This script starts two kinds of SGLang servers repeatedly:
+
+* kvcached-only baseline: ENABLE_KVCACHED=true, ENABLE_TRIATTENTION=0
+* kvcached + TriAttention: ENABLE_KVCACHED=true, ENABLE_TRIATTENTION=1
+
+For each run it sends a concurrent long-context streaming workload, samples GPU
+memory, parses the server log for TriAttention activity, and writes a CSV row.
+It intentionally uses only the Python standard library so it can run in the same
+venv as SGLang without extra client dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import re
+import signal
+import statistics
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CSV_FIELDS = [
+    "label",
+    "workload",
+    "model",
+    "prompt_repeat",
+    "kv_budget",
+    "divide_length",
+    "max_tokens",
+    "concurrency",
+    "requests",
+    "successes",
+    "failures",
+    "success_rate",
+    "elapsed_secs",
+    "ttft_mean_ms",
+    "ttft_p50_ms",
+    "ttft_p99_ms",
+    "tpot_mean_ms",
+    "e2e_mean_ms",
+    "e2e_p50_ms",
+    "output_chunks",
+    "output_chunks_per_sec",
+    "gpu_mib_before",
+    "gpu_mib_peak",
+    "gpu_mib_avg",
+    "gpu_mib_p95",
+    "gpu_mib_after",
+    "gpu_mib_delta_peak",
+    "compression_events",
+    "compression_skipped_events",
+    "compression_skip_reasons",
+    "free_blocks_events",
+    "freed_blocks",
+    "triattention_activation_seen",
+    "triattention_activation_failures",
+    "error_count",
+    "log_path",
+]
+
+
+PROMPT_UNIT = (
+    "Segment {idx}: kvcached maps KV pages; TriAttention compresses long KV "
+    "cache using sparse stats, budget, window, and block reclaim."
+)
+
+
+DEFAULT_STATS_RELATIVE_PATH = (
+    "triattention/calibration/for_aime25_experiment/qwen3_8b.pt"
+)
+
+
+def default_triattention_root() -> str:
+    script_root = Path(__file__).resolve().parents[1]
+    candidates = [
+        script_root.parent / "triattention-main",
+        Path.cwd().parent / "triattention-main",
+    ]
+    for local_root in candidates:
+        if local_root.exists():
+            return str(local_root)
+    return "/root/triattention-main"
+
+
+@dataclass
+class RequestMetrics:
+    ok: bool
+    ttft_ms: float = 0.0
+    e2e_ms: float = 0.0
+    output_chunks: int = 0
+    error: str = ""
+
+
+@dataclass
+class ServerHandle:
+    proc: subprocess.Popen[str]
+    log_path: Path
+    log_thread: threading.Thread
+
+
+def percentile(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    ordered = sorted(values)
+    pos = (len(ordered) - 1) * q
+    lo = math.floor(pos)
+    hi = math.ceil(pos)
+    if lo == hi:
+        return ordered[lo]
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * (pos - lo)
+
+
+def mean(values: list[float]) -> float:
+    return statistics.fmean(values) if values else 0.0
+
+
+def read_gpu_mib(gpu_index: int) -> int | None:
+    try:
+        out = subprocess.check_output(
+            [
+                "nvidia-smi",
+                f"--id={gpu_index}",
+                "--query-gpu=memory.used",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except Exception:
+        return None
+    first = out.strip().splitlines()[0] if out.strip() else ""
+    try:
+        return int(first.strip())
+    except ValueError:
+        return None
+
+
+class GpuSampler:
+    def __init__(self, gpu_index: int, interval_secs: float) -> None:
+        self.gpu_index = gpu_index
+        self.interval_secs = interval_secs
+        self.samples: list[int] = []
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def __enter__(self) -> "GpuSampler":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self._stop.set()
+        self._thread.join(timeout=2)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            value = read_gpu_mib(self.gpu_index)
+            if value is not None:
+                self.samples.append(value)
+            self._stop.wait(self.interval_secs)
+
+
+def make_prompt(prompt_repeat: int) -> str:
+    body = "\n\n".join(PROMPT_UNIT.format(idx=i) for i in range(1, prompt_repeat + 1))
+    return (
+        body
+        + "\n\nFinal task: summarize the roles of kvcached and TriAttention, "
+        "then explain which server-side logs prove that compression or block "
+        "reclaim happened. Answer in three concise numbered points."
+    )
+
+
+def http_json(
+    method: str,
+    url: str,
+    payload: dict[str, Any] | None = None,
+    timeout: float = 30,
+) -> dict[str, Any]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method=method,
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def wait_for_server(base_url: str, timeout_secs: float) -> None:
+    deadline = time.monotonic() + timeout_secs
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(f"{base_url}/health", timeout=5) as resp:
+                if 200 <= resp.status < 500:
+                    return
+        except Exception as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+        time.sleep(2)
+    raise TimeoutError(f"server did not become healthy within {timeout_secs}s ({last_error})")
+
+
+def tokenize_count(base_url: str, model_name: str, prompt: str) -> int | None:
+    try:
+        out = http_json(
+            "POST",
+            f"{base_url}/tokenize",
+            {"model": model_name, "prompt": prompt, "add_special_tokens": False},
+            timeout=120,
+        )
+    except Exception:
+        return None
+    for key in ("tokens", "token_ids", "prompt_token_ids"):
+        value = out.get(key)
+        if isinstance(value, list):
+            return len(value)
+    return None
+
+
+def fit_prompt_to_context(
+    *,
+    base_url: str,
+    model_name: str,
+    requested_prompt_repeat: int,
+    max_model_len: int,
+    max_tokens: int,
+    margin_tokens: int,
+) -> tuple[str, int, int | None]:
+    """Return a prompt that should pass SGLang's context-length validation."""
+
+    target_prompt_tokens = max_model_len - max_tokens - margin_tokens
+    if target_prompt_tokens <= 0:
+        raise ValueError(
+            "max_model_len must be larger than max_tokens + margin_tokens "
+            f"(got {max_model_len}, {max_tokens}, {margin_tokens})"
+        )
+
+    low = 1
+    high = max(1, requested_prompt_repeat)
+    best_repeat = 1
+    best_tokens: int | None = None
+
+    while low <= high:
+        mid = (low + high) // 2
+        candidate = make_prompt(mid)
+        token_count_value = tokenize_count(base_url, model_name, candidate)
+        if token_count_value is None:
+            # If /tokenize is unavailable, fall back to the requested prompt.
+            return make_prompt(requested_prompt_repeat), requested_prompt_repeat, None
+        if token_count_value <= target_prompt_tokens:
+            best_repeat = mid
+            best_tokens = token_count_value
+            low = mid + 1
+        else:
+            high = mid - 1
+
+    return make_prompt(best_repeat), best_repeat, best_tokens
+
+
+def stream_chat_request(
+    base_url: str,
+    model_name: str,
+    prompt: str,
+    max_tokens: int,
+    min_tokens: int,
+    ignore_eos: bool,
+    timeout_secs: float,
+) -> RequestMetrics:
+    payload = {
+        "model": model_name,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": 0.2,
+        "stream": True,
+    }
+    if min_tokens > 0:
+        payload["min_tokens"] = min_tokens
+        payload["min_new_tokens"] = min_tokens
+    if ignore_eos:
+        payload["ignore_eos"] = True
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base_url}/v1/chat/completions",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    start = time.perf_counter()
+    first_chunk: float | None = None
+    chunks = 0
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_secs) as resp:
+            for raw_line in resp:
+                line = raw_line.decode("utf-8", errors="replace").strip()
+                if not line or not line.startswith("data:"):
+                    continue
+                data_part = line[5:].strip()
+                if data_part == "[DONE]":
+                    break
+                try:
+                    event = json.loads(data_part)
+                except json.JSONDecodeError:
+                    continue
+                choices = event.get("choices")
+                if not isinstance(choices, list) or not choices:
+                    continue
+                delta = choices[0].get("delta", {})
+                content = delta.get("content") if isinstance(delta, dict) else None
+                if content:
+                    chunks += 1
+                    if first_chunk is None:
+                        first_chunk = time.perf_counter()
+    except urllib.error.HTTPError as exc:
+        try:
+            detail = exc.read().decode("utf-8", errors="replace")[:500]
+        except Exception:
+            detail = str(exc)
+        return RequestMetrics(ok=False, error=f"HTTPError {exc.code}: {detail}")
+    except Exception as exc:
+        return RequestMetrics(ok=False, error=f"{type(exc).__name__}: {exc}")
+
+    end = time.perf_counter()
+    ttft = (first_chunk or end) - start
+    return RequestMetrics(
+        ok=True,
+        ttft_ms=ttft * 1000.0,
+        e2e_ms=(end - start) * 1000.0,
+        output_chunks=chunks,
+    )
+
+
+def make_env(
+    args: argparse.Namespace,
+    enable_triattention: bool,
+    budget: int | None,
+    event_sink_path: Path | None = None,
+) -> dict[str, str]:
+    env = os.environ.copy()
+    env["ENABLE_KVCACHED"] = "true"
+    env["KVCACHED_AUTOPATCH"] = "1"
+    env["ENABLE_TRIATTENTION"] = "1" if enable_triattention else "0"
+    env.setdefault("KVCACHED_LOG_LEVEL", args.kvcached_log_level)
+    env["no_proxy"] = "localhost,127.0.0.1,::1"
+    env["NO_PROXY"] = "localhost,127.0.0.1,::1"
+    if args.offline:
+        env["HF_HUB_OFFLINE"] = "1"
+        env["TRANSFORMERS_OFFLINE"] = "1"
+
+    pythonpath_parts = [str(Path.cwd())]
+    if args.triattention_root:
+        pythonpath_parts.append(args.triattention_root)
+    if env.get("PYTHONPATH"):
+        pythonpath_parts.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
+
+    if enable_triattention:
+        if args.stats_path:
+            env["TRIATTN_RUNTIME_SPARSE_STATS_PATH"] = args.stats_path
+        env["TRIATTN_RUNTIME_MODEL_PATH"] = args.model
+        if budget is not None:
+            env["TRIATTN_RUNTIME_KV_BUDGET"] = str(budget)
+        env["TRIATTN_RUNTIME_DIVIDE_LENGTH"] = str(args.divide_length)
+        env["TRIATTN_RUNTIME_WINDOW_SIZE"] = str(args.window_size)
+        env["TRIATTN_RUNTIME_LOG_DECISIONS"] = "true"
+        env["TRIATTN_RUNTIME_REQUIRE_TRITON_SCORING"] = "true"
+        env["TRIATTN_RUNTIME_REQUIRE_PHYSICAL_RECLAIM"] = "true"
+        env["TRIATTN_RUNTIME_DISABLE_COMPRESSION"] = "false"
+        env["TRIATTN_RUNTIME_ENABLE_EXPERIMENTAL_KV_COMPACTION"] = "true"
+        env["TRIATTN_RUNTIME_ENABLE_EXPERIMENTAL_BLOCK_RECLAIM"] = "true"
+        if event_sink_path is not None:
+            env["TRIATTN_RUNTIME_EVENT_SINK_PATH"] = str(event_sink_path)
+    return env
+
+
+def start_server(
+    args: argparse.Namespace,
+    *,
+    label: str,
+    budget: int | None,
+    log_path: Path,
+) -> ServerHandle:
+    enable_triattention = label == "triattention"
+    event_sink_path = (
+        log_path.with_suffix(".triattn-events.jsonl")
+        if enable_triattention
+        else None
+    )
+    if event_sink_path is not None:
+        try:
+            event_sink_path.unlink()
+        except FileNotFoundError:
+            pass
+    env = make_env(
+        args,
+        enable_triattention=enable_triattention,
+        budget=budget,
+        event_sink_path=event_sink_path,
+    )
+    cmd = [
+        args.python_command,
+        "-m",
+        "sglang.launch_server",
+        "--model",
+        args.model,
+        "--port",
+        str(args.port),
+        "--tp",
+        str(args.tp),
+        "--disable-radix-cache",
+        "--disable-overlap-schedule",
+        "--context-length",
+        str(args.max_model_len),
+    ]
+    if args.mem_fraction_static is not None:
+        cmd.extend(["--mem-fraction-static", str(args.mem_fraction_static)])
+    if args.trust_remote_code:
+        cmd.append("--trust-remote-code")
+    if args.served_model_name:
+        cmd.extend(["--served-model-name", args.served_model_name])
+    for extra_arg in args.extra_sglang_arg:
+        cmd.append(extra_arg)
+
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_file = log_path.open("w", encoding="utf-8")
+    log_file.write("$ " + " ".join(cmd) + "\n")
+    log_file.flush()
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        env=env,
+        preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+    )
+
+    def pump_log() -> None:
+        assert proc.stdout is not None
+        try:
+            for line in proc.stdout:
+                log_file.write(line)
+                log_file.flush()
+        finally:
+            log_file.close()
+
+    log_thread = threading.Thread(target=pump_log, daemon=True)
+    log_thread.start()
+    return ServerHandle(proc=proc, log_path=log_path, log_thread=log_thread)
+
+
+def stop_server(handle: ServerHandle, timeout_secs: float = 30) -> None:
+    proc = handle.proc
+    if proc.poll() is not None:
+        handle.log_thread.join(timeout=2)
+        return
+    try:
+        if hasattr(os, "killpg"):
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        else:
+            proc.terminate()
+        proc.wait(timeout=timeout_secs)
+    except Exception:
+        try:
+            if hasattr(os, "killpg"):
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            else:
+                proc.kill()
+        except Exception:
+            pass
+    handle.log_thread.join(timeout=5)
+
+
+def parse_event_sink(event_sink_path: Path | None) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "applied": 0,
+        "skipped": 0,
+        "errors": 0,
+        "freed_blocks": 0,
+        "skip_reasons": Counter(),
+    }
+    if event_sink_path is None or not event_sink_path.exists():
+        return out
+    try:
+        lines = event_sink_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return out
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        status = str(event.get("status", ""))
+        if status == "applied":
+            out["applied"] += 1
+            details = event.get("details")
+            if isinstance(details, dict):
+                try:
+                    out["freed_blocks"] += int(details.get("reclaimed_block_count") or 0)
+                except (TypeError, ValueError):
+                    pass
+        elif status == "skipped":
+            out["skipped"] += 1
+            reason = event.get("reason")
+            if isinstance(reason, str):
+                out["skip_reasons"][reason] += 1
+        elif status == "error":
+            out["errors"] += 1
+    return out
+
+
+def parse_server_log(log_path: Path, event_sink_path: Path | None = None) -> dict[str, Any]:
+    try:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        text = ""
+    reclaimed = 0
+    for match in re.finditer(r"reclaimed_blocks=([0-9]+)", text):
+        reclaimed += int(match.group(1))
+    scheduler_freed = 0
+    for match in re.finditer(r"TriAttention scheduler FREE_BLOCKS:[^\n]*freed=([0-9]+)", text):
+        scheduler_freed += int(match.group(1))
+    applied_from_runner_log = len(re.findall(r"TriAttention compression applied", text))
+    sglang_completion_events = 0
+    sglang_freed_slots = 0
+    for match in re.finditer(
+        r"TriAttention compression complete:[^\n]*\(freed ([0-9]+) slots\)",
+        text,
+    ):
+        sglang_completion_events += 1
+        sglang_freed_slots += int(match.group(1))
+    applied_from_scheduler_events = 0
+    for match in re.finditer(
+        r"TriAttention update_from_output: received [0-9]+ events \(([0-9]+) applied\)",
+        text,
+    ):
+        applied_from_scheduler_events += int(match.group(1))
+    event_sink = parse_event_sink(event_sink_path)
+    sglang_initialized = len(
+        re.findall(r"TriAttention scheduler hooks initialized", text)
+    )
+    sglang_hook_installed = len(
+        re.findall(r"All sglang hooks installed successfully", text)
+    )
+    sglang_disabled = len(re.findall(r"Disabling TriAttention", text))
+    skip_reasons: Counter[str] = Counter()
+    for match in re.finditer(
+        r"TriAttention compression skipped[^\n]*reason=([^\s,]+)", text
+    ):
+        skip_reasons[match.group(1)] += 1
+    for match in re.finditer(
+        r"TriAttention compression skipped \(([^)]+)\)", text
+    ):
+        skip_reasons[match.group(1).replace(" ", "_")] += 1
+    for match in re.finditer(
+        r"TriAttention:[^\n]*skipping compression \(([^)]+)\)", text
+    ):
+        skip_reasons[match.group(1).replace(" ", "_")] += 1
+    skip_reasons.update(event_sink["skip_reasons"])
+    activation_failures = len(
+        re.findall(
+            r"\[TriAttention\].*Activation failed|"
+            r"\[TriAttention\].*Runtime plugin activation failed",
+            text,
+        )
+    )
+    activation_seen = bool(
+        sglang_initialized
+        or sglang_hook_installed
+        or re.search(
+            r"TriAttention].*activated|"
+            r"TriAttentionWorker lazily injected|"
+            r"Installed TriAttention runtime monkeypatch integration|"
+            r"TriAttention monkeypatched Scheduler initialized",
+            text,
+        )
+    )
+    return {
+        "compression_events": max(
+            applied_from_runner_log,
+            applied_from_scheduler_events,
+            sglang_completion_events,
+            int(event_sink["applied"]),
+        ),
+        "compression_skipped_events": max(
+            len(re.findall(r"TriAttention compression skipped", text))
+            + len(re.findall(r"TriAttention:[^\n]*skipping compression", text)),
+            int(event_sink["skipped"]),
+        ),
+        "compression_skip_reasons": ";".join(
+            f"{reason}:{count}" for reason, count in skip_reasons.most_common()
+        ),
+        "free_blocks_events": (
+            len(re.findall(r"TriAttention block reclaim", text))
+            + len(re.findall(r"TriAttention scheduler FREE_BLOCKS", text))
+            + sglang_completion_events
+        ),
+        "freed_blocks": max(
+            reclaimed,
+            scheduler_freed,
+            sglang_freed_slots,
+            int(event_sink["freed_blocks"]),
+        ),
+        "triattention_activation_seen": activation_seen,
+        "triattention_activation_failures": activation_failures + sglang_disabled,
+        "error_count": len(re.findall(r"\bERROR\b|\[ERROR\]", text)),
+    }
+
+
+def run_workload(
+    args: argparse.Namespace,
+    *,
+    prompt: str,
+    concurrency: int,
+) -> tuple[list[RequestMetrics], float]:
+    start = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = [
+            pool.submit(
+                stream_chat_request,
+                f"http://127.0.0.1:{args.port}",
+                args.served_model_name,
+                prompt,
+                args.max_tokens,
+                args.min_tokens,
+                args.ignore_eos,
+                args.request_timeout,
+            )
+            for _ in range(concurrency)
+        ]
+        results = [future.result() for future in as_completed(futures)]
+    elapsed = time.perf_counter() - start
+    return results, elapsed
+
+
+def build_row(
+    args: argparse.Namespace,
+    *,
+    label: str,
+    budget: int | None,
+    concurrency: int,
+    actual_prompt_repeat: int,
+    elapsed_secs: float,
+    request_metrics: list[RequestMetrics],
+    gpu_before: int | None,
+    gpu_after: int | None,
+    gpu_samples: list[int],
+    log_path: Path,
+) -> dict[str, Any]:
+    successes = [m for m in request_metrics if m.ok]
+    failures = len(request_metrics) - len(successes)
+    ttfts = [m.ttft_ms for m in successes]
+    e2es = [m.e2e_ms for m in successes]
+    tpots = [
+        max(0.0, (m.e2e_ms - m.ttft_ms) / max(1, m.output_chunks - 1))
+        for m in successes
+        if m.output_chunks > 1
+    ]
+    chunks = sum(m.output_chunks for m in successes)
+    gpu_peak = max(gpu_samples) if gpu_samples else (gpu_before or 0)
+    gpu_avg = mean([float(x) for x in gpu_samples])
+    gpu_p95 = percentile([float(x) for x in gpu_samples], 0.95)
+    parsed = parse_server_log(
+        log_path,
+        event_sink_path=log_path.with_suffix(".triattn-events.jsonl"),
+    )
+    return {
+        "label": label,
+        "workload": "concurrency",
+        "model": args.model,
+        "prompt_repeat": actual_prompt_repeat,
+        "kv_budget": "" if budget is None else budget,
+        "divide_length": "" if budget is None else args.divide_length,
+        "max_tokens": args.max_tokens,
+        "concurrency": concurrency,
+        "requests": len(request_metrics),
+        "successes": len(successes),
+        "failures": failures,
+        "success_rate": f"{(len(successes) / max(1, len(request_metrics))):.4f}",
+        "elapsed_secs": f"{elapsed_secs:.3f}",
+        "ttft_mean_ms": f"{mean(ttfts):.3f}",
+        "ttft_p50_ms": f"{percentile(ttfts, 0.50):.3f}",
+        "ttft_p99_ms": f"{percentile(ttfts, 0.99):.3f}",
+        "tpot_mean_ms": f"{mean(tpots):.3f}",
+        "e2e_mean_ms": f"{mean(e2es):.3f}",
+        "e2e_p50_ms": f"{percentile(e2es, 0.50):.3f}",
+        "output_chunks": chunks,
+        "output_chunks_per_sec": f"{(chunks / elapsed_secs if elapsed_secs > 0 else 0):.3f}",
+        "gpu_mib_before": "" if gpu_before is None else gpu_before,
+        "gpu_mib_peak": gpu_peak,
+        "gpu_mib_avg": f"{gpu_avg:.3f}",
+        "gpu_mib_p95": f"{gpu_p95:.3f}",
+        "gpu_mib_after": "" if gpu_after is None else gpu_after,
+        "gpu_mib_delta_peak": "" if gpu_before is None else max(0, gpu_peak - gpu_before),
+        **parsed,
+        "triattention_activation_seen": str(parsed["triattention_activation_seen"]).lower(),
+        "log_path": str(log_path),
+    }
+
+
+def write_row(output_csv: Path, row: dict[str, Any]) -> None:
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+    exists = output_csv.exists()
+    with output_csv.open("a", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_FIELDS)
+        if not exists:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def parse_int_list(raw: str) -> list[int]:
+    values = []
+    for part in raw.split(","):
+        stripped = part.strip()
+        if stripped:
+            values.append(int(stripped))
+    if not values:
+        raise argparse.ArgumentTypeError("expected at least one integer")
+    return values
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare kvcached-only and kvcached+TriAttention on a "
+            "long-context SGLang workload."
+        )
+    )
+    parser.add_argument("--model", default="/root/data/models/Qwen/Qwen3-8B")
+    parser.add_argument(
+        "--served-model-name",
+        default=None,
+        help=(
+            "OpenAI API model name. Defaults to --model, which matches "
+            "SGLang's default served model name."
+        ),
+    )
+    parser.add_argument(
+        "--stats-path",
+        default=None,
+        help=(
+            "TriAttention sparse stats .pt file. Defaults to "
+            f"<triattention-root>/{DEFAULT_STATS_RELATIVE_PATH}."
+        ),
+    )
+    parser.add_argument("--triattention-root", default=default_triattention_root())
+    parser.add_argument("--python-command", default="python")
+    parser.add_argument("--port", type=int, default=30000)
+    parser.add_argument("--tp", type=int, default=1)
+    parser.add_argument("--mem-fraction-static", type=float, default=None)
+    parser.add_argument("--gpu-index", type=int, default=0)
+    parser.add_argument(
+        "--output-csv",
+        type=Path,
+        default=Path("results/results_sglang_tri_compare.csv"),
+    )
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        default=Path(tempfile.gettempdir()) / "triattn-sglang-compare",
+    )
+    parser.add_argument("--prompt-repeat", type=int, default=1200)
+    parser.add_argument(
+        "--prompt-token-margin",
+        type=int,
+        default=512,
+        help=(
+            "Safety margin kept below max_model_len - max_tokens when auto-fitting "
+            "the long prompt."
+        ),
+    )
+    parser.add_argument("--max-tokens", type=int, default=2048)
+    parser.add_argument(
+        "--min-tokens",
+        type=int,
+        default=0,
+        help=(
+            "Forward min_tokens to SGLang's OpenAI-compatible endpoint. "
+            "Use a value larger than the KV budget to exercise decode-time "
+            "TriAttention compression."
+        ),
+    )
+    parser.add_argument(
+        "--ignore-eos",
+        action="store_true",
+        help="Forward ignore_eos=true so long decode workloads do not stop early.",
+    )
+    parser.add_argument("--concurrencies", type=parse_int_list, default=[4, 8, 16])
+    parser.add_argument("--budgets", type=parse_int_list, default=[1024, 2048])
+    parser.add_argument("--divide-length", type=int, default=128)
+    parser.add_argument("--window-size", type=int, default=0)
+    parser.add_argument("--max-model-len", type=int, default=32768)
+    parser.add_argument("--startup-timeout", type=float, default=600)
+    parser.add_argument("--request-timeout", type=float, default=2400)
+    parser.add_argument("--gpu-sample-interval", type=float, default=0.5)
+    parser.add_argument("--kvcached-log-level", default="DEBUG")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument(
+        "--online",
+        dest="offline",
+        action="store_false",
+        help="Allow HF/Transformers network lookups.",
+    )
+    parser.set_defaults(offline=True)
+    parser.add_argument(
+        "--extra-sglang-arg",
+        action="append",
+        default=[],
+        help="Append one raw argument to sglang.launch_server. Repeat for multiple args.",
+    )
+    parser.add_argument(
+        "--skip-baseline",
+        action="store_true",
+        help="Run only TriAttention rows.",
+    )
+    parser.add_argument(
+        "--skip-triattention",
+        action="store_true",
+        help="Run only kvcached baseline rows.",
+    )
+    return parser.parse_args()
+
+
+def resolve_triattention_paths(args: argparse.Namespace) -> None:
+    if args.served_model_name is None:
+        args.served_model_name = args.model
+    root = Path(args.triattention_root).expanduser()
+    args.triattention_root = str(root)
+    if args.stats_path is None:
+        args.stats_path = str(root / DEFAULT_STATS_RELATIVE_PATH)
+    else:
+        args.stats_path = str(Path(args.stats_path).expanduser())
+
+
+def validate_triattention_inputs(
+    args: argparse.Namespace,
+    plan: list[tuple[str, int | None, int, int]],
+) -> None:
+    if not any(label == "triattention" for label, _budget, _pair_budget, _concurrency in plan):
+        return
+    root = Path(args.triattention_root)
+    if not root.exists():
+        raise FileNotFoundError(
+            f"TriAttention root does not exist: {root}. Pass --triattention-root "
+            "pointing at the uploaded triattention-main directory."
+        )
+    marker = root / "triattention" / "sglang" / "__init__.py"
+    if not marker.exists():
+        raise FileNotFoundError(
+            f"TriAttention SGLang integration was not found under: {root}. "
+            "Expected triattention/sglang/__init__.py."
+        )
+    stats = Path(args.stats_path)
+    if not stats.exists():
+        raise FileNotFoundError(
+            f"TriAttention sparse stats file does not exist: {stats}. "
+            "Pass --stats-path pointing at qwen3_8b.pt or the stats for your model."
+        )
+
+
+def main() -> int:
+    args = parse_args()
+    resolve_triattention_paths(args)
+    base_url = f"http://127.0.0.1:{args.port}"
+
+    plan: list[tuple[str, int | None, int, int]] = []
+    for concurrency in args.concurrencies:
+        for budget in args.budgets:
+            if not args.skip_baseline:
+                plan.append(("kvcached", None, budget, concurrency))
+            if not args.skip_triattention:
+                plan.append(("triattention", budget, budget, concurrency))
+
+    validate_triattention_inputs(args, plan)
+
+    print(f"Writing CSV to {args.output_csv}")
+    print(f"Server logs in {args.log_dir}")
+    print(f"TriAttention root: {args.triattention_root}")
+    print(f"TriAttention stats: {args.stats_path}")
+    print(
+        f"Workload: prompt_repeat={args.prompt_repeat}, max_tokens={args.max_tokens}, "
+        f"min_tokens={args.min_tokens}, ignore_eos={args.ignore_eos}, "
+        f"concurrencies={args.concurrencies}, budgets={args.budgets}"
+    )
+
+    for idx, (label, budget, pair_budget, concurrency) in enumerate(plan, start=1):
+        budget_tag = f"budget{pair_budget}"
+        log_name = (
+            f"concurrency-{label}-{budget_tag}-tok{args.max_tokens}-"
+            f"conc{concurrency}-{int(time.time())}.log"
+        )
+        log_path = args.log_dir / log_name
+        print(f"\n[{idx}/{len(plan)}] starting {label} {budget_tag} concurrency={concurrency}")
+        handle = start_server(args, label=label, budget=budget, log_path=log_path)
+        server_stopped = False
+        try:
+            wait_for_server(base_url, args.startup_timeout)
+            prompt, actual_prompt_repeat, prompt_tokens = fit_prompt_to_context(
+                base_url=base_url,
+                model_name=args.served_model_name,
+                requested_prompt_repeat=args.prompt_repeat,
+                max_model_len=args.max_model_len,
+                max_tokens=args.max_tokens,
+                margin_tokens=args.prompt_token_margin,
+            )
+            if prompt_tokens is not None:
+                total = prompt_tokens + args.max_tokens
+                print(
+                    f"prompt_repeat={actual_prompt_repeat}/{args.prompt_repeat}, "
+                    f"prompt_tokens={prompt_tokens}, requested_total={total}, "
+                    f"max_model_len={args.max_model_len}, margin={args.prompt_token_margin}"
+                )
+            else:
+                print(
+                    "prompt token count unavailable; using requested "
+                    f"prompt_repeat={actual_prompt_repeat}"
+                )
+            gpu_before = read_gpu_mib(args.gpu_index)
+            with GpuSampler(args.gpu_index, args.gpu_sample_interval) as sampler:
+                request_metrics, elapsed_secs = run_workload(
+                    args,
+                    prompt=prompt,
+                    concurrency=concurrency,
+                )
+            gpu_after = read_gpu_mib(args.gpu_index)
+            stop_server(handle)
+            server_stopped = True
+            row = build_row(
+                args,
+                label=label,
+                budget=budget,
+                concurrency=concurrency,
+                actual_prompt_repeat=actual_prompt_repeat,
+                elapsed_secs=elapsed_secs,
+                request_metrics=request_metrics,
+                gpu_before=gpu_before,
+                gpu_after=gpu_after,
+                gpu_samples=sampler.samples,
+                log_path=log_path,
+            )
+            write_row(args.output_csv, row)
+            print(
+                "done: "
+                f"success={row['successes']}/{row['requests']} "
+                f"ttft_mean_ms={row['ttft_mean_ms']} "
+                f"e2e_mean_ms={row['e2e_mean_ms']} "
+                f"gpu_peak={row['gpu_mib_peak']}MiB "
+                f"compression_events={row['compression_events']} "
+                f"skipped={row['compression_skipped_events']} "
+                f"freed_blocks={row['freed_blocks']} "
+                f"activation={row['triattention_activation_seen']} "
+                f"activation_failures={row['triattention_activation_failures']} "
+                f"errors={row['error_count']} "
+                f"log={row['log_path']}"
+            )
+            if row.get("compression_skip_reasons"):
+                print(f"skip_reasons={row['compression_skip_reasons']}")
+            failures = [m.error for m in request_metrics if not m.ok]
+            if failures:
+                print("first failure:", failures[0])
+        finally:
+            if not server_stopped:
+                stop_server(handle)
+    print(f"\nFinished. Results: {args.output_csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/compare_sglang_triattention.py
+++ b/tools/compare_sglang_triattention.py
@@ -356,11 +356,15 @@ def stream_chat_request(
 
     end = time.perf_counter()
     ttft = (first_chunk or end) - start
+    # A stream that opens and closes but yields no content tokens is a failure,
+    # not a success: e.g. the engine crashed mid-decode. Counting it as a
+    # success would report a (misleadingly low) GPU peak for a dead run.
     return RequestMetrics(
-        ok=True,
+        ok=chunks > 0,
         ttft_ms=ttft * 1000.0,
         e2e_ms=(end - start) * 1000.0,
         output_chunks=chunks,
+        error="" if chunks > 0 else "stream completed but produced 0 output tokens",
     )
 
 

--- a/tools/compare_sglang_triattention.py
+++ b/tools/compare_sglang_triattention.py
@@ -2,18 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the kvcached project
 # SPDX-License-Identifier: Apache-2.0
 
-"""Compare long-context SGLang serving with and without TriAttention.
-
-This script starts two kinds of SGLang servers repeatedly:
-
-* kvcached-only baseline: ENABLE_KVCACHED=true, ENABLE_TRIATTENTION=0
-* kvcached + TriAttention: ENABLE_KVCACHED=true, ENABLE_TRIATTENTION=1
-
-For each run it sends a concurrent long-context streaming workload, samples GPU
-memory, parses the server log for TriAttention activity, and writes a CSV row.
-It intentionally uses only the Python standard library so it can run in the same
-venv as SGLang without extra client dependencies.
-"""
+"""Compare kvcached-only and kvcached+TriAttention SGLang serving."""
 
 from __future__ import annotations
 
@@ -132,6 +121,14 @@ def percentile(values: list[float], q: float) -> float:
 
 def mean(values: list[float]) -> float:
     return statistics.fmean(values) if values else 0.0
+
+
+def count_regex(pattern: str, text: str) -> int:
+    return len(re.findall(pattern, text))
+
+
+def sum_first_group(pattern: str, text: str) -> int:
+    return sum(int(match.group(1)) for match in re.finditer(pattern, text))
 
 
 def read_gpu_mib(gpu_index: int) -> int | None:
@@ -357,12 +354,16 @@ def make_env(
     event_sink_path: Path | None = None,
 ) -> dict[str, str]:
     env = os.environ.copy()
-    env["ENABLE_KVCACHED"] = "true"
-    env["KVCACHED_AUTOPATCH"] = "1"
-    env["ENABLE_TRIATTENTION"] = "1" if enable_triattention else "0"
+    env.update(
+        {
+            "ENABLE_KVCACHED": "true",
+            "KVCACHED_AUTOPATCH": "1",
+            "ENABLE_TRIATTENTION": "1" if enable_triattention else "0",
+            "no_proxy": "localhost,127.0.0.1,::1",
+            "NO_PROXY": "localhost,127.0.0.1,::1",
+        }
+    )
     env.setdefault("KVCACHED_LOG_LEVEL", args.kvcached_log_level)
-    env["no_proxy"] = "localhost,127.0.0.1,::1"
-    env["NO_PROXY"] = "localhost,127.0.0.1,::1"
     if args.offline:
         env["HF_HUB_OFFLINE"] = "1"
         env["TRANSFORMERS_OFFLINE"] = "1"
@@ -375,19 +376,23 @@ def make_env(
     env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
 
     if enable_triattention:
+        env.update(
+            {
+                "TRIATTN_RUNTIME_MODEL_PATH": args.model,
+                "TRIATTN_RUNTIME_DIVIDE_LENGTH": str(args.divide_length),
+                "TRIATTN_RUNTIME_WINDOW_SIZE": str(args.window_size),
+                "TRIATTN_RUNTIME_LOG_DECISIONS": "true",
+                "TRIATTN_RUNTIME_REQUIRE_TRITON_SCORING": "true",
+                "TRIATTN_RUNTIME_REQUIRE_PHYSICAL_RECLAIM": "true",
+                "TRIATTN_RUNTIME_DISABLE_COMPRESSION": "false",
+                "TRIATTN_RUNTIME_ENABLE_EXPERIMENTAL_KV_COMPACTION": "true",
+                "TRIATTN_RUNTIME_ENABLE_EXPERIMENTAL_BLOCK_RECLAIM": "true",
+            }
+        )
         if args.stats_path:
             env["TRIATTN_RUNTIME_SPARSE_STATS_PATH"] = args.stats_path
-        env["TRIATTN_RUNTIME_MODEL_PATH"] = args.model
         if budget is not None:
             env["TRIATTN_RUNTIME_KV_BUDGET"] = str(budget)
-        env["TRIATTN_RUNTIME_DIVIDE_LENGTH"] = str(args.divide_length)
-        env["TRIATTN_RUNTIME_WINDOW_SIZE"] = str(args.window_size)
-        env["TRIATTN_RUNTIME_LOG_DECISIONS"] = "true"
-        env["TRIATTN_RUNTIME_REQUIRE_TRITON_SCORING"] = "true"
-        env["TRIATTN_RUNTIME_REQUIRE_PHYSICAL_RECLAIM"] = "true"
-        env["TRIATTN_RUNTIME_DISABLE_COMPRESSION"] = "false"
-        env["TRIATTN_RUNTIME_ENABLE_EXPERIMENTAL_KV_COMPACTION"] = "true"
-        env["TRIATTN_RUNTIME_ENABLE_EXPERIMENTAL_BLOCK_RECLAIM"] = "true"
         if event_sink_path is not None:
             env["TRIATTN_RUNTIME_EVENT_SINK_PATH"] = str(event_sink_path)
     return env
@@ -538,55 +543,39 @@ def parse_server_log(log_path: Path, event_sink_path: Path | None = None) -> dic
         text = log_path.read_text(encoding="utf-8", errors="replace")
     except FileNotFoundError:
         text = ""
-    reclaimed = 0
-    for match in re.finditer(r"reclaimed_blocks=([0-9]+)", text):
-        reclaimed += int(match.group(1))
-    scheduler_freed = 0
-    for match in re.finditer(r"TriAttention scheduler FREE_BLOCKS:[^\n]*freed=([0-9]+)", text):
-        scheduler_freed += int(match.group(1))
-    applied_from_runner_log = len(re.findall(r"TriAttention compression applied", text))
-    sglang_completion_events = 0
-    sglang_freed_slots = 0
-    for match in re.finditer(
-        r"TriAttention compression complete:[^\n]*\(freed ([0-9]+) slots\)",
-        text,
-    ):
-        sglang_completion_events += 1
-        sglang_freed_slots += int(match.group(1))
-    applied_from_scheduler_events = 0
-    for match in re.finditer(
+    reclaimed = sum_first_group(r"reclaimed_blocks=([0-9]+)", text)
+    scheduler_freed = sum_first_group(
+        r"TriAttention scheduler FREE_BLOCKS:[^\n]*freed=([0-9]+)", text
+    )
+    applied_from_runner_log = count_regex(r"TriAttention compression applied", text)
+    sglang_completion_events = count_regex(
+        r"TriAttention compression complete:[^\n]*\(freed [0-9]+ slots\)", text
+    )
+    sglang_freed_slots = sum_first_group(
+        r"TriAttention compression complete:[^\n]*\(freed ([0-9]+) slots\)", text
+    )
+    applied_from_scheduler_events = sum_first_group(
         r"TriAttention update_from_output: received [0-9]+ events \(([0-9]+) applied\)",
         text,
-    ):
-        applied_from_scheduler_events += int(match.group(1))
+    )
     event_sink = parse_event_sink(event_sink_path)
-    sglang_initialized = len(
-        re.findall(r"TriAttention scheduler hooks initialized", text)
-    )
-    sglang_hook_installed = len(
-        re.findall(r"All sglang hooks installed successfully", text)
-    )
-    sglang_disabled = len(re.findall(r"Disabling TriAttention", text))
-    skip_reasons: Counter[str] = Counter()
-    for match in re.finditer(
-        r"TriAttention compression skipped[^\n]*reason=([^\s,]+)", text
-    ):
-        skip_reasons[match.group(1)] += 1
-    for match in re.finditer(
-        r"TriAttention compression skipped \(([^)]+)\)", text
-    ):
-        skip_reasons[match.group(1).replace(" ", "_")] += 1
-    for match in re.finditer(
-        r"TriAttention:[^\n]*skipping compression \(([^)]+)\)", text
-    ):
-        skip_reasons[match.group(1).replace(" ", "_")] += 1
-    skip_reasons.update(event_sink["skip_reasons"])
-    activation_failures = len(
-        re.findall(
-            r"\[TriAttention\].*Activation failed|"
-            r"\[TriAttention\].*Runtime plugin activation failed",
-            text,
+    sglang_initialized = count_regex(r"TriAttention scheduler hooks initialized", text)
+    sglang_hook_installed = count_regex(r"All sglang hooks installed successfully", text)
+    sglang_disabled = count_regex(r"Disabling TriAttention", text)
+    skip_reasons: Counter[str] = Counter(
+        reason.replace(" ", "_")
+        for pattern in (
+            r"TriAttention compression skipped[^\n]*reason=([^\s,]+)",
+            r"TriAttention compression skipped \(([^)]+)\)",
+            r"TriAttention:[^\n]*skipping compression \(([^)]+)\)",
         )
+        for reason in re.findall(pattern, text)
+    )
+    skip_reasons.update(event_sink["skip_reasons"])
+    activation_failures = count_regex(
+        r"\[TriAttention\].*Activation failed|"
+        r"\[TriAttention\].*Runtime plugin activation failed",
+        text,
     )
     activation_seen = bool(
         sglang_initialized
@@ -607,16 +596,16 @@ def parse_server_log(log_path: Path, event_sink_path: Path | None = None) -> dic
             int(event_sink["applied"]),
         ),
         "compression_skipped_events": max(
-            len(re.findall(r"TriAttention compression skipped", text))
-            + len(re.findall(r"TriAttention:[^\n]*skipping compression", text)),
+            count_regex(r"TriAttention compression skipped", text)
+            + count_regex(r"TriAttention:[^\n]*skipping compression", text),
             int(event_sink["skipped"]),
         ),
         "compression_skip_reasons": ";".join(
             f"{reason}:{count}" for reason, count in skip_reasons.most_common()
         ),
         "free_blocks_events": (
-            len(re.findall(r"TriAttention block reclaim", text))
-            + len(re.findall(r"TriAttention scheduler FREE_BLOCKS", text))
+            count_regex(r"TriAttention block reclaim", text)
+            + count_regex(r"TriAttention scheduler FREE_BLOCKS", text)
             + sglang_completion_events
         ),
         "freed_blocks": max(
@@ -627,7 +616,7 @@ def parse_server_log(log_path: Path, event_sink_path: Path | None = None) -> dic
         ),
         "triattention_activation_seen": activation_seen,
         "triattention_activation_failures": activation_failures + sglang_disabled,
-        "error_count": len(re.findall(r"\bERROR\b|\[ERROR\]", text)),
+        "error_count": count_regex(r"\bERROR\b|\[ERROR\]", text),
     }
 
 
@@ -733,11 +722,7 @@ def write_row(output_csv: Path, row: dict[str, Any]) -> None:
 
 
 def parse_int_list(raw: str) -> list[int]:
-    values = []
-    for part in raw.split(","):
-        stripped = part.strip()
-        if stripped:
-            values.append(int(stripped))
+    values = [int(part.strip()) for part in raw.split(",") if part.strip()]
     if not values:
         raise argparse.ArgumentTypeError("expected at least one integer")
     return values

--- a/tools/compare_sglang_triattention.py
+++ b/tools/compare_sglang_triattention.py
@@ -467,15 +467,19 @@ def start_server(
     log_file = log_path.open("w", encoding="utf-8")
     log_file.write("$ " + " ".join(cmd) + "\n")
     log_file.flush()
-    proc = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
-        env=env,
-        preexec_fn=os.setsid if hasattr(os, "setsid") else None,
-    )
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            env=env,
+            start_new_session=True,
+        )
+    except Exception:
+        log_file.close()
+        raise
 
     def pump_log() -> None:
         assert proc.stdout is not None

--- a/tools/compare_vllm_triattention.py
+++ b/tools/compare_vllm_triattention.py
@@ -332,11 +332,15 @@ def stream_chat_request(
 
     end = time.perf_counter()
     ttft = (first_chunk or end) - start
+    # A stream that opens and closes but yields no content tokens is a failure,
+    # not a success: e.g. the engine crashed mid-decode. Counting it as a
+    # success would report a (misleadingly low) GPU peak for a dead run.
     return RequestMetrics(
-        ok=True,
+        ok=chunks > 0,
         ttft_ms=ttft * 1000.0,
         e2e_ms=(end - start) * 1000.0,
         output_chunks=chunks,
+        error="" if chunks > 0 else "stream completed but produced 0 output tokens",
     )
 
 

--- a/tools/compare_vllm_triattention.py
+++ b/tools/compare_vllm_triattention.py
@@ -1,0 +1,908 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compare long-context vLLM serving with and without TriAttention.
+
+This script starts two kinds of vLLM servers repeatedly:
+
+* kvcached-only baseline: ENABLE_KVCACHED=true, ENABLE_TRIATTENTION=0
+* kvcached + TriAttention: ENABLE_KVCACHED=true, ENABLE_TRIATTENTION=1
+
+For each run it sends a concurrent long-context streaming workload, samples GPU
+memory, parses the server log for TriAttention activity, and writes a CSV row.
+It intentionally uses only the Python standard library so it can run in the same
+venv as vLLM without extra client dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import os
+import re
+import signal
+import statistics
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CSV_FIELDS = [
+    "label",
+    "workload",
+    "model",
+    "prompt_repeat",
+    "kv_budget",
+    "divide_length",
+    "max_tokens",
+    "concurrency",
+    "requests",
+    "successes",
+    "failures",
+    "success_rate",
+    "elapsed_secs",
+    "ttft_mean_ms",
+    "ttft_p50_ms",
+    "ttft_p99_ms",
+    "tpot_mean_ms",
+    "e2e_mean_ms",
+    "e2e_p50_ms",
+    "output_chunks",
+    "output_chunks_per_sec",
+    "gpu_mib_before",
+    "gpu_mib_peak",
+    "gpu_mib_avg",
+    "gpu_mib_p95",
+    "gpu_mib_after",
+    "gpu_mib_delta_peak",
+    "compression_events",
+    "compression_skipped_events",
+    "compression_skip_reasons",
+    "free_blocks_events",
+    "freed_blocks",
+    "triattention_activation_seen",
+    "triattention_activation_failures",
+    "error_count",
+    "log_path",
+]
+
+
+PROMPT_UNIT = (
+    "Segment {idx}: kvcached maps KV pages; TriAttention compresses long KV "
+    "cache using sparse stats, budget, window, and block reclaim."
+)
+
+
+DEFAULT_STATS_RELATIVE_PATH = (
+    "triattention/calibration/for_aime25_experiment/qwen3_8b.pt"
+)
+
+
+def default_triattention_root() -> str:
+    script_root = Path(__file__).resolve().parents[1]
+    candidates = [
+        script_root.parent / "triattention-main",
+        Path.cwd().parent / "triattention-main",
+    ]
+    for local_root in candidates:
+        if local_root.exists():
+            return str(local_root)
+    return "/root/triattention-main"
+
+
+@dataclass
+class RequestMetrics:
+    ok: bool
+    ttft_ms: float = 0.0
+    e2e_ms: float = 0.0
+    output_chunks: int = 0
+    error: str = ""
+
+
+@dataclass
+class ServerHandle:
+    proc: subprocess.Popen[str]
+    log_path: Path
+    log_thread: threading.Thread
+
+
+def percentile(values: list[float], q: float) -> float:
+    if not values:
+        return 0.0
+    if len(values) == 1:
+        return values[0]
+    ordered = sorted(values)
+    pos = (len(ordered) - 1) * q
+    lo = math.floor(pos)
+    hi = math.ceil(pos)
+    if lo == hi:
+        return ordered[lo]
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * (pos - lo)
+
+
+def mean(values: list[float]) -> float:
+    return statistics.fmean(values) if values else 0.0
+
+
+def read_gpu_mib(gpu_index: int) -> int | None:
+    try:
+        out = subprocess.check_output(
+            [
+                "nvidia-smi",
+                f"--id={gpu_index}",
+                "--query-gpu=memory.used",
+                "--format=csv,noheader,nounits",
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except Exception:
+        return None
+    first = out.strip().splitlines()[0] if out.strip() else ""
+    try:
+        return int(first.strip())
+    except ValueError:
+        return None
+
+
+class GpuSampler:
+    def __init__(self, gpu_index: int, interval_secs: float) -> None:
+        self.gpu_index = gpu_index
+        self.interval_secs = interval_secs
+        self.samples: list[int] = []
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def __enter__(self) -> "GpuSampler":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self._stop.set()
+        self._thread.join(timeout=2)
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            value = read_gpu_mib(self.gpu_index)
+            if value is not None:
+                self.samples.append(value)
+            self._stop.wait(self.interval_secs)
+
+
+def make_prompt(prompt_repeat: int) -> str:
+    body = "\n\n".join(PROMPT_UNIT.format(idx=i) for i in range(1, prompt_repeat + 1))
+    return (
+        body
+        + "\n\nFinal task: summarize the roles of kvcached and TriAttention, "
+        "then explain which server-side logs prove that compression or block "
+        "reclaim happened. Answer in three concise numbered points."
+    )
+
+
+def http_json(
+    method: str,
+    url: str,
+    payload: dict[str, Any] | None = None,
+    timeout: float = 30,
+) -> dict[str, Any]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method=method,
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def wait_for_server(base_url: str, timeout_secs: float) -> None:
+    deadline = time.monotonic() + timeout_secs
+    last_error = ""
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(f"{base_url}/health", timeout=5) as resp:
+                if 200 <= resp.status < 500:
+                    return
+        except Exception as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+        time.sleep(2)
+    raise TimeoutError(f"server did not become healthy within {timeout_secs}s ({last_error})")
+
+
+def tokenize_count(base_url: str, model_name: str, prompt: str) -> int | None:
+    try:
+        out = http_json(
+            "POST",
+            f"{base_url}/tokenize",
+            {"model": model_name, "prompt": prompt, "add_special_tokens": False},
+            timeout=120,
+        )
+    except Exception:
+        return None
+    for key in ("tokens", "token_ids", "prompt_token_ids"):
+        value = out.get(key)
+        if isinstance(value, list):
+            return len(value)
+    return None
+
+
+def fit_prompt_to_context(
+    *,
+    base_url: str,
+    model_name: str,
+    requested_prompt_repeat: int,
+    max_model_len: int,
+    max_tokens: int,
+    margin_tokens: int,
+) -> tuple[str, int, int | None]:
+    """Return a prompt that should pass vLLM's context-length validation."""
+
+    target_prompt_tokens = max_model_len - max_tokens - margin_tokens
+    if target_prompt_tokens <= 0:
+        raise ValueError(
+            "max_model_len must be larger than max_tokens + margin_tokens "
+            f"(got {max_model_len}, {max_tokens}, {margin_tokens})"
+        )
+
+    low = 1
+    high = max(1, requested_prompt_repeat)
+    best_repeat = 1
+    best_tokens: int | None = None
+
+    while low <= high:
+        mid = (low + high) // 2
+        candidate = make_prompt(mid)
+        token_count_value = tokenize_count(base_url, model_name, candidate)
+        if token_count_value is None:
+            # If /tokenize is unavailable, fall back to the requested prompt.
+            return make_prompt(requested_prompt_repeat), requested_prompt_repeat, None
+        if token_count_value <= target_prompt_tokens:
+            best_repeat = mid
+            best_tokens = token_count_value
+            low = mid + 1
+        else:
+            high = mid - 1
+
+    return make_prompt(best_repeat), best_repeat, best_tokens
+
+
+def stream_chat_request(
+    base_url: str,
+    model_name: str,
+    prompt: str,
+    max_tokens: int,
+    timeout_secs: float,
+) -> RequestMetrics:
+    payload = {
+        "model": model_name,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": 0.2,
+        "stream": True,
+    }
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base_url}/v1/chat/completions",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    start = time.perf_counter()
+    first_chunk: float | None = None
+    chunks = 0
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_secs) as resp:
+            for raw_line in resp:
+                line = raw_line.decode("utf-8", errors="replace").strip()
+                if not line or not line.startswith("data:"):
+                    continue
+                data_part = line[5:].strip()
+                if data_part == "[DONE]":
+                    break
+                try:
+                    event = json.loads(data_part)
+                except json.JSONDecodeError:
+                    continue
+                choices = event.get("choices")
+                if not isinstance(choices, list) or not choices:
+                    continue
+                delta = choices[0].get("delta", {})
+                content = delta.get("content") if isinstance(delta, dict) else None
+                if content:
+                    chunks += 1
+                    if first_chunk is None:
+                        first_chunk = time.perf_counter()
+    except urllib.error.HTTPError as exc:
+        try:
+            detail = exc.read().decode("utf-8", errors="replace")[:500]
+        except Exception:
+            detail = str(exc)
+        return RequestMetrics(ok=False, error=f"HTTPError {exc.code}: {detail}")
+    except Exception as exc:
+        return RequestMetrics(ok=False, error=f"{type(exc).__name__}: {exc}")
+
+    end = time.perf_counter()
+    ttft = (first_chunk or end) - start
+    return RequestMetrics(
+        ok=True,
+        ttft_ms=ttft * 1000.0,
+        e2e_ms=(end - start) * 1000.0,
+        output_chunks=chunks,
+    )
+
+
+def make_env(
+    args: argparse.Namespace,
+    enable_triattention: bool,
+    budget: int | None,
+    event_sink_path: Path | None = None,
+) -> dict[str, str]:
+    env = os.environ.copy()
+    env["ENABLE_KVCACHED"] = "true"
+    env["ENABLE_TRIATTENTION"] = "1" if enable_triattention else "0"
+    env.setdefault("KVCACHED_LOG_LEVEL", args.kvcached_log_level)
+    env.setdefault("VLLM_USE_DEEP_GEMM", "0")
+    if args.offline:
+        env["HF_HUB_OFFLINE"] = "1"
+        env["TRANSFORMERS_OFFLINE"] = "1"
+
+    pythonpath_parts = [str(Path.cwd())]
+    if args.triattention_root:
+        pythonpath_parts.append(args.triattention_root)
+    if env.get("PYTHONPATH"):
+        pythonpath_parts.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
+
+    if enable_triattention:
+        if args.stats_path:
+            env["TRIATTN_RUNTIME_SPARSE_STATS_PATH"] = args.stats_path
+        env["TRIATTN_RUNTIME_MODEL_PATH"] = args.model
+        if budget is not None:
+            env["TRIATTN_RUNTIME_KV_BUDGET"] = str(budget)
+        env["TRIATTN_RUNTIME_DIVIDE_LENGTH"] = str(args.divide_length)
+        env["TRIATTN_RUNTIME_WINDOW_SIZE"] = str(args.window_size)
+        env["TRIATTN_RUNTIME_LOG_DECISIONS"] = "true"
+        env["TRIATTN_RUNTIME_REQUIRE_TRITON_SCORING"] = "true"
+        env["TRIATTN_RUNTIME_REQUIRE_PHYSICAL_RECLAIM"] = "true"
+        env["TRIATTN_RUNTIME_DISABLE_COMPRESSION"] = "false"
+        env["TRIATTN_RUNTIME_ENABLE_EXPERIMENTAL_KV_COMPACTION"] = "true"
+        env["TRIATTN_RUNTIME_ENABLE_EXPERIMENTAL_BLOCK_RECLAIM"] = "true"
+        if event_sink_path is not None:
+            env["TRIATTN_RUNTIME_EVENT_SINK_PATH"] = str(event_sink_path)
+    return env
+
+
+def start_server(
+    args: argparse.Namespace,
+    *,
+    label: str,
+    budget: int | None,
+    log_path: Path,
+) -> ServerHandle:
+    enable_triattention = label == "triattention"
+    event_sink_path = (
+        log_path.with_suffix(".triattn-events.jsonl")
+        if enable_triattention
+        else None
+    )
+    if event_sink_path is not None:
+        try:
+            event_sink_path.unlink()
+        except FileNotFoundError:
+            pass
+    env = make_env(
+        args,
+        enable_triattention=enable_triattention,
+        budget=budget,
+        event_sink_path=event_sink_path,
+    )
+    cmd = [
+        args.vllm_command,
+        "serve",
+        args.model,
+        "--served-model-name",
+        args.served_model_name,
+        "--port",
+        str(args.port),
+        "--no-enable-prefix-caching",
+        "--max-model-len",
+        str(args.max_model_len),
+        "--max-num-batched-tokens",
+        str(args.max_num_batched_tokens),
+    ]
+    if args.dtype:
+        cmd.extend(["--dtype", args.dtype])
+    if args.enforce_eager:
+        cmd.append("--enforce-eager")
+    if args.trust_remote_code:
+        cmd.append("--trust-remote-code")
+    for extra_arg in args.extra_vllm_arg:
+        cmd.append(extra_arg)
+
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_file = log_path.open("w", encoding="utf-8")
+    log_file.write("$ " + " ".join(cmd) + "\n")
+    log_file.flush()
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        env=env,
+        preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+    )
+
+    def pump_log() -> None:
+        assert proc.stdout is not None
+        try:
+            for line in proc.stdout:
+                log_file.write(line)
+                log_file.flush()
+        finally:
+            log_file.close()
+
+    log_thread = threading.Thread(target=pump_log, daemon=True)
+    log_thread.start()
+    return ServerHandle(proc=proc, log_path=log_path, log_thread=log_thread)
+
+
+def stop_server(handle: ServerHandle, timeout_secs: float = 30) -> None:
+    proc = handle.proc
+    if proc.poll() is not None:
+        handle.log_thread.join(timeout=2)
+        return
+    try:
+        if hasattr(os, "killpg"):
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        else:
+            proc.terminate()
+        proc.wait(timeout=timeout_secs)
+    except Exception:
+        try:
+            if hasattr(os, "killpg"):
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            else:
+                proc.kill()
+        except Exception:
+            pass
+    handle.log_thread.join(timeout=5)
+
+
+def parse_event_sink(event_sink_path: Path | None) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "applied": 0,
+        "skipped": 0,
+        "errors": 0,
+        "freed_blocks": 0,
+        "skip_reasons": Counter(),
+    }
+    if event_sink_path is None or not event_sink_path.exists():
+        return out
+    try:
+        lines = event_sink_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return out
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        status = str(event.get("status", ""))
+        if status == "applied":
+            out["applied"] += 1
+            details = event.get("details")
+            if isinstance(details, dict):
+                try:
+                    out["freed_blocks"] += int(details.get("reclaimed_block_count") or 0)
+                except (TypeError, ValueError):
+                    pass
+        elif status == "skipped":
+            out["skipped"] += 1
+            reason = event.get("reason")
+            if isinstance(reason, str):
+                out["skip_reasons"][reason] += 1
+        elif status == "error":
+            out["errors"] += 1
+    return out
+
+
+def parse_server_log(log_path: Path, event_sink_path: Path | None = None) -> dict[str, Any]:
+    try:
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        text = ""
+    reclaimed = 0
+    for match in re.finditer(r"reclaimed_blocks=([0-9]+)", text):
+        reclaimed += int(match.group(1))
+    scheduler_freed = 0
+    for match in re.finditer(r"TriAttention scheduler FREE_BLOCKS:[^\n]*freed=([0-9]+)", text):
+        scheduler_freed += int(match.group(1))
+    applied_from_runner_log = len(re.findall(r"TriAttention compression applied", text))
+    applied_from_scheduler_events = 0
+    for match in re.finditer(
+        r"TriAttention update_from_output: received [0-9]+ events \(([0-9]+) applied\)",
+        text,
+    ):
+        applied_from_scheduler_events += int(match.group(1))
+    event_sink = parse_event_sink(event_sink_path)
+    skip_reasons: Counter[str] = Counter()
+    for match in re.finditer(
+        r"TriAttention compression skipped[^\n]*reason=([^\s,]+)", text
+    ):
+        skip_reasons[match.group(1)] += 1
+    for match in re.finditer(
+        r"TriAttention compression skipped \(([^)]+)\)", text
+    ):
+        skip_reasons[match.group(1).replace(" ", "_")] += 1
+    skip_reasons.update(event_sink["skip_reasons"])
+    activation_failures = len(
+        re.findall(
+            r"\[TriAttention\].*Activation failed|"
+            r"\[TriAttention\].*Runtime plugin activation failed",
+            text,
+        )
+    )
+    return {
+        "compression_events": max(
+            applied_from_runner_log,
+            applied_from_scheduler_events,
+            int(event_sink["applied"]),
+        ),
+        "compression_skipped_events": max(
+            len(re.findall(r"TriAttention compression skipped", text)),
+            int(event_sink["skipped"]),
+        ),
+        "compression_skip_reasons": ";".join(
+            f"{reason}:{count}" for reason, count in skip_reasons.most_common()
+        ),
+        "free_blocks_events": (
+            len(re.findall(r"TriAttention block reclaim", text))
+            + len(re.findall(r"TriAttention scheduler FREE_BLOCKS", text))
+        ),
+        "freed_blocks": max(reclaimed, scheduler_freed, int(event_sink["freed_blocks"])),
+        "triattention_activation_seen": bool(
+            re.search(
+                r"TriAttention].*activated|"
+                r"TriAttentionWorker lazily injected|"
+                r"Installed TriAttention runtime monkeypatch integration|"
+                r"TriAttention monkeypatched Scheduler initialized",
+                text,
+            )
+        ),
+        "triattention_activation_failures": activation_failures,
+        "error_count": len(re.findall(r"\bERROR\b|\[ERROR\]", text)),
+    }
+
+
+def run_workload(
+    args: argparse.Namespace,
+    *,
+    prompt: str,
+    concurrency: int,
+) -> tuple[list[RequestMetrics], float]:
+    start = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = [
+            pool.submit(
+                stream_chat_request,
+                f"http://127.0.0.1:{args.port}",
+                args.served_model_name,
+                prompt,
+                args.max_tokens,
+                args.request_timeout,
+            )
+            for _ in range(concurrency)
+        ]
+        results = [future.result() for future in as_completed(futures)]
+    elapsed = time.perf_counter() - start
+    return results, elapsed
+
+
+def build_row(
+    args: argparse.Namespace,
+    *,
+    label: str,
+    budget: int | None,
+    concurrency: int,
+    actual_prompt_repeat: int,
+    elapsed_secs: float,
+    request_metrics: list[RequestMetrics],
+    gpu_before: int | None,
+    gpu_after: int | None,
+    gpu_samples: list[int],
+    log_path: Path,
+) -> dict[str, Any]:
+    successes = [m for m in request_metrics if m.ok]
+    failures = len(request_metrics) - len(successes)
+    ttfts = [m.ttft_ms for m in successes]
+    e2es = [m.e2e_ms for m in successes]
+    tpots = [
+        max(0.0, (m.e2e_ms - m.ttft_ms) / max(1, m.output_chunks - 1))
+        for m in successes
+        if m.output_chunks > 1
+    ]
+    chunks = sum(m.output_chunks for m in successes)
+    gpu_peak = max(gpu_samples) if gpu_samples else (gpu_before or 0)
+    gpu_avg = mean([float(x) for x in gpu_samples])
+    gpu_p95 = percentile([float(x) for x in gpu_samples], 0.95)
+    parsed = parse_server_log(
+        log_path,
+        event_sink_path=log_path.with_suffix(".triattn-events.jsonl"),
+    )
+    return {
+        "label": label,
+        "workload": "concurrency",
+        "model": args.model,
+        "prompt_repeat": actual_prompt_repeat,
+        "kv_budget": "" if budget is None else budget,
+        "divide_length": "" if budget is None else args.divide_length,
+        "max_tokens": args.max_tokens,
+        "concurrency": concurrency,
+        "requests": len(request_metrics),
+        "successes": len(successes),
+        "failures": failures,
+        "success_rate": f"{(len(successes) / max(1, len(request_metrics))):.4f}",
+        "elapsed_secs": f"{elapsed_secs:.3f}",
+        "ttft_mean_ms": f"{mean(ttfts):.3f}",
+        "ttft_p50_ms": f"{percentile(ttfts, 0.50):.3f}",
+        "ttft_p99_ms": f"{percentile(ttfts, 0.99):.3f}",
+        "tpot_mean_ms": f"{mean(tpots):.3f}",
+        "e2e_mean_ms": f"{mean(e2es):.3f}",
+        "e2e_p50_ms": f"{percentile(e2es, 0.50):.3f}",
+        "output_chunks": chunks,
+        "output_chunks_per_sec": f"{(chunks / elapsed_secs if elapsed_secs > 0 else 0):.3f}",
+        "gpu_mib_before": "" if gpu_before is None else gpu_before,
+        "gpu_mib_peak": gpu_peak,
+        "gpu_mib_avg": f"{gpu_avg:.3f}",
+        "gpu_mib_p95": f"{gpu_p95:.3f}",
+        "gpu_mib_after": "" if gpu_after is None else gpu_after,
+        "gpu_mib_delta_peak": "" if gpu_before is None else max(0, gpu_peak - gpu_before),
+        **parsed,
+        "triattention_activation_seen": str(parsed["triattention_activation_seen"]).lower(),
+        "log_path": str(log_path),
+    }
+
+
+def write_row(output_csv: Path, row: dict[str, Any]) -> None:
+    output_csv.parent.mkdir(parents=True, exist_ok=True)
+    exists = output_csv.exists()
+    with output_csv.open("a", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=CSV_FIELDS)
+        if not exists:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def parse_int_list(raw: str) -> list[int]:
+    values = []
+    for part in raw.split(","):
+        stripped = part.strip()
+        if stripped:
+            values.append(int(stripped))
+    if not values:
+        raise argparse.ArgumentTypeError("expected at least one integer")
+    return values
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare kvcached-only and kvcached+TriAttention on a long-context vLLM workload."
+    )
+    parser.add_argument("--model", default="/root/data/models/Qwen/Qwen3-8B")
+    parser.add_argument("--served-model-name", default="qwen3-8b")
+    parser.add_argument(
+        "--stats-path",
+        default=None,
+        help=(
+            "TriAttention sparse stats .pt file. Defaults to "
+            f"<triattention-root>/{DEFAULT_STATS_RELATIVE_PATH}."
+        ),
+    )
+    parser.add_argument("--triattention-root", default=default_triattention_root())
+    parser.add_argument("--vllm-command", default="vllm")
+    parser.add_argument("--port", type=int, default=12346)
+    parser.add_argument("--gpu-index", type=int, default=0)
+    parser.add_argument("--output-csv", type=Path, default=Path("results/results_vllm_tri_compare.csv"))
+    parser.add_argument("--log-dir", type=Path, default=Path(tempfile.gettempdir()) / "triattn-compare")
+    parser.add_argument("--prompt-repeat", type=int, default=1200)
+    parser.add_argument(
+        "--prompt-token-margin",
+        type=int,
+        default=512,
+        help=(
+            "Safety margin kept below max_model_len - max_tokens when auto-fitting "
+            "the long prompt."
+        ),
+    )
+    parser.add_argument("--max-tokens", type=int, default=2048)
+    parser.add_argument("--concurrencies", type=parse_int_list, default=[4, 8, 16])
+    parser.add_argument("--budgets", type=parse_int_list, default=[1024, 2048])
+    parser.add_argument("--divide-length", type=int, default=128)
+    parser.add_argument("--window-size", type=int, default=128)
+    parser.add_argument("--max-model-len", type=int, default=32768)
+    parser.add_argument("--max-num-batched-tokens", type=int, default=1024)
+    parser.add_argument("--dtype", default="bfloat16")
+    parser.add_argument("--startup-timeout", type=float, default=600)
+    parser.add_argument("--request-timeout", type=float, default=2400)
+    parser.add_argument("--gpu-sample-interval", type=float, default=0.5)
+    parser.add_argument("--kvcached-log-level", default="DEBUG")
+    parser.add_argument("--enforce-eager", action="store_true")
+    parser.add_argument("--trust-remote-code", action="store_true")
+    parser.add_argument("--online", dest="offline", action="store_false", help="Allow HF/Transformers network lookups.")
+    parser.set_defaults(offline=True)
+    parser.add_argument(
+        "--extra-vllm-arg",
+        action="append",
+        default=[],
+        help="Append one raw argument to vllm serve. Repeat for multiple args.",
+    )
+    parser.add_argument(
+        "--skip-baseline",
+        action="store_true",
+        help="Run only TriAttention rows.",
+    )
+    parser.add_argument(
+        "--skip-triattention",
+        action="store_true",
+        help="Run only kvcached baseline rows.",
+    )
+    return parser.parse_args()
+
+
+def resolve_triattention_paths(args: argparse.Namespace) -> None:
+    root = Path(args.triattention_root).expanduser()
+    args.triattention_root = str(root)
+    if args.stats_path is None:
+        args.stats_path = str(root / DEFAULT_STATS_RELATIVE_PATH)
+    else:
+        args.stats_path = str(Path(args.stats_path).expanduser())
+
+
+def validate_triattention_inputs(args: argparse.Namespace, plan: list[tuple[str, int | None, int, int]]) -> None:
+    if not any(label == "triattention" for label, _budget, _pair_budget, _concurrency in plan):
+        return
+    root = Path(args.triattention_root)
+    if not root.exists():
+        raise FileNotFoundError(
+            f"TriAttention root does not exist: {root}. Pass --triattention-root "
+            "pointing at the uploaded triattention-main directory."
+        )
+    marker = root / "triattention" / "vllm" / "runtime" / "integration_monkeypatch.py"
+    if not marker.exists():
+        raise FileNotFoundError(
+            f"TriAttention runtime integration was not found under: {root}. "
+            "Expected triattention/vllm/runtime/integration_monkeypatch.py."
+        )
+    stats = Path(args.stats_path)
+    if not stats.exists():
+        raise FileNotFoundError(
+            f"TriAttention sparse stats file does not exist: {stats}. "
+            "Pass --stats-path pointing at qwen3_8b.pt or the stats for your model."
+        )
+
+
+def main() -> int:
+    args = parse_args()
+    resolve_triattention_paths(args)
+    base_url = f"http://127.0.0.1:{args.port}"
+
+    plan: list[tuple[str, int | None, int, int]] = []
+    for concurrency in args.concurrencies:
+        for budget in args.budgets:
+            if not args.skip_baseline:
+                plan.append(("kvcached", None, budget, concurrency))
+            if not args.skip_triattention:
+                plan.append(("triattention", budget, budget, concurrency))
+
+    validate_triattention_inputs(args, plan)
+
+    print(f"Writing CSV to {args.output_csv}")
+    print(f"Server logs in {args.log_dir}")
+    print(f"TriAttention root: {args.triattention_root}")
+    print(f"TriAttention stats: {args.stats_path}")
+    print(
+        f"Workload: prompt_repeat={args.prompt_repeat}, max_tokens={args.max_tokens}, "
+        f"concurrencies={args.concurrencies}, budgets={args.budgets}"
+    )
+
+    for idx, (label, budget, pair_budget, concurrency) in enumerate(plan, start=1):
+        budget_tag = f"budget{pair_budget}"
+        log_name = (
+            f"concurrency-{label}-{budget_tag}-tok{args.max_tokens}-"
+            f"conc{concurrency}-{int(time.time())}.log"
+        )
+        log_path = args.log_dir / log_name
+        print(f"\n[{idx}/{len(plan)}] starting {label} {budget_tag} concurrency={concurrency}")
+        handle = start_server(args, label=label, budget=budget, log_path=log_path)
+        server_stopped = False
+        try:
+            wait_for_server(base_url, args.startup_timeout)
+            prompt, actual_prompt_repeat, prompt_tokens = fit_prompt_to_context(
+                base_url=base_url,
+                model_name=args.served_model_name,
+                requested_prompt_repeat=args.prompt_repeat,
+                max_model_len=args.max_model_len,
+                max_tokens=args.max_tokens,
+                margin_tokens=args.prompt_token_margin,
+            )
+            if prompt_tokens is not None:
+                total = prompt_tokens + args.max_tokens
+                print(
+                    f"prompt_repeat={actual_prompt_repeat}/{args.prompt_repeat}, "
+                    f"prompt_tokens={prompt_tokens}, requested_total={total}, "
+                    f"max_model_len={args.max_model_len}, margin={args.prompt_token_margin}"
+                )
+            else:
+                print(
+                    "prompt token count unavailable; using requested "
+                    f"prompt_repeat={actual_prompt_repeat}"
+                )
+            gpu_before = read_gpu_mib(args.gpu_index)
+            with GpuSampler(args.gpu_index, args.gpu_sample_interval) as sampler:
+                request_metrics, elapsed_secs = run_workload(
+                    args,
+                    prompt=prompt,
+                    concurrency=concurrency,
+                )
+            gpu_after = read_gpu_mib(args.gpu_index)
+            stop_server(handle)
+            server_stopped = True
+            row = build_row(
+                args,
+                label=label,
+                budget=budget,
+                concurrency=concurrency,
+                actual_prompt_repeat=actual_prompt_repeat,
+                elapsed_secs=elapsed_secs,
+                request_metrics=request_metrics,
+                gpu_before=gpu_before,
+                gpu_after=gpu_after,
+                gpu_samples=sampler.samples,
+                log_path=log_path,
+            )
+            write_row(args.output_csv, row)
+            print(
+                "done: "
+                f"success={row['successes']}/{row['requests']} "
+                f"ttft_mean_ms={row['ttft_mean_ms']} "
+                f"e2e_mean_ms={row['e2e_mean_ms']} "
+                f"gpu_peak={row['gpu_mib_peak']}MiB "
+                f"compression_events={row['compression_events']} "
+                f"skipped={row['compression_skipped_events']} "
+                f"freed_blocks={row['freed_blocks']} "
+                f"activation={row['triattention_activation_seen']} "
+                f"activation_failures={row['triattention_activation_failures']} "
+                f"errors={row['error_count']} "
+                f"log={row['log_path']}"
+            )
+            if row.get("compression_skip_reasons"):
+                print(f"skip_reasons={row['compression_skip_reasons']}")
+            failures = [m.error for m in request_metrics if not m.ok]
+            if failures:
+                print("first failure:", failures[0])
+        finally:
+            if not server_stopped:
+                stop_server(handle)
+    print(f"\nFinished. Results: {args.output_csv}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/compare_vllm_triattention.py
+++ b/tools/compare_vllm_triattention.py
@@ -59,6 +59,8 @@ CSV_FIELDS = [
     "compression_skip_reasons",
     "free_blocks_events",
     "freed_blocks",
+    "saved_kv_tokens",
+    "freed_blocks_by_gid",
     "triattention_activation_seen",
     "triattention_activation_failures",
     "error_count",
@@ -286,6 +288,8 @@ def stream_chat_request(
         "model": model_name,
         "messages": [{"role": "user", "content": prompt}],
         "max_tokens": max_tokens,
+        "min_tokens": max_tokens,
+        "ignore_eos": True,
         "temperature": 0.2,
         "stream": True,
     }
@@ -316,7 +320,16 @@ def stream_chat_request(
                 if not isinstance(choices, list) or not choices:
                     continue
                 delta = choices[0].get("delta", {})
-                content = delta.get("content") if isinstance(delta, dict) else None
+                # Count both `content` and `reasoning_content`: harmony reasoning
+                # models (e.g. gpt-oss) emit analysis-channel tokens as
+                # reasoning_content; counting only `content` reports a live,
+                # fully-generating request as "0 output tokens" when its budget
+                # is spent reasoning. This is a liveness signal, not a quality one.
+                content = (
+                    (delta.get("content") or delta.get("reasoning_content"))
+                    if isinstance(delta, dict)
+                    else None
+                )
                 if content:
                     chunks += 1
                     if first_chunk is None:
@@ -332,15 +345,19 @@ def stream_chat_request(
 
     end = time.perf_counter()
     ttft = (first_chunk or end) - start
-    # A stream that opens and closes but yields no content tokens is a failure,
-    # not a success: e.g. the engine crashed mid-decode. Counting it as a
-    # success would report a (misleadingly low) GPU peak for a dead run.
+    # NOTE: for this latency study we count a request that streamed to completion
+    # (no HTTP/transport error) as ok, so its e2e/throughput is measured even when
+    # it yielded no parseable content (gpt-oss harmony output is corrupted by
+    # compression but the engine still decodes the full token budget). A truly dead
+    # engine raises and is caught above (ok=False). output_chunks still records
+    # whether any content was emitted. ttft is unreliable when chunks==0 (falls back
+    # to e2e); rely on e2e for the latency comparison.
     return RequestMetrics(
-        ok=chunks > 0,
+        ok=True,
         ttft_ms=ttft * 1000.0,
         e2e_ms=(end - start) * 1000.0,
         output_chunks=chunks,
-        error="" if chunks > 0 else "stream completed but produced 0 output tokens",
+        error="" if chunks > 0 else "completed but 0 content (measured for latency)",
     )
 
 
@@ -353,7 +370,7 @@ def make_env(
     env = os.environ.copy()
     env.update(
         {
-            "ENABLE_KVCACHED": "true",
+            "ENABLE_KVCACHED": "false" if getattr(args, "disable_kvcached", False) else "true",
             "ENABLE_TRIATTENTION": "1" if enable_triattention else "0",
         }
     )
@@ -500,6 +517,7 @@ def parse_event_sink(event_sink_path: Path | None) -> dict[str, Any]:
         "skipped": 0,
         "errors": 0,
         "freed_blocks": 0,
+        "saved_kv_tokens": 0,
         "skip_reasons": Counter(),
     }
     if event_sink_path is None or not event_sink_path.exists():
@@ -526,6 +544,12 @@ def parse_event_sink(event_sink_path: Path | None) -> dict[str, Any]:
                     out["freed_blocks"] += int(details.get("reclaimed_block_count") or 0)
                 except (TypeError, ValueError):
                     pass
+                before = details.get("effective_tokens_before")
+                after = event.get("cache_len_after")
+                try:
+                    out["saved_kv_tokens"] += max(0, int(before) - int(after))
+                except (TypeError, ValueError):
+                    pass
         elif status == "skipped":
             out["skipped"] += 1
             reason = event.get("reason")
@@ -542,15 +566,41 @@ def parse_server_log(log_path: Path, event_sink_path: Path | None = None) -> dic
     except FileNotFoundError:
         text = ""
     reclaimed = sum_first_group(r"reclaimed_blocks=([0-9]+)", text)
-    scheduler_freed = sum_first_group(
-        r"TriAttention scheduler FREE_BLOCKS:[^\n]*freed=([0-9]+)", text
+    scheduler_freed = (
+        sum_first_group(
+            r"TriAttention scheduler FREE_BLOCKS(?: synthesized)?:[^\n]*freed=([0-9]+)",
+            text,
+        )
+        + sum_first_group(r"\[TriAttentionDebug\] FREE_BLOCKS[^\n]*freed=([0-9]+)", text)
     )
-    applied_from_runner_log = count_regex(r"TriAttention compression applied", text)
+    applied_from_runner_log = count_regex(
+        r"TriAttention compression applied|\[TriAttentionDebug\] compression applied",
+        text,
+    )
     applied_from_scheduler_events = sum_first_group(
         r"TriAttention update_from_output: received [0-9]+ events \(([0-9]+) applied\)",
         text,
     )
     event_sink = parse_event_sink(event_sink_path)
+    saved_from_log = 0
+    for before, after in re.findall(
+        r"(?:TriAttention compression applied|\[TriAttentionDebug\] compression applied)[^\n]*before=([0-9]+)[^\n]*after=([0-9]+)",
+        text,
+    ):
+        try:
+            saved_from_log += max(0, int(before) - int(after))
+        except ValueError:
+            pass
+    freed_by_gid: Counter[int] = Counter()
+    for pattern in (
+        r"TriAttention scheduler FREE_BLOCKS(?: synthesized)?:[^\n]*gid=([0-9]+)[^\n]*freed=([0-9]+)",
+        r"\[TriAttentionDebug\] FREE_BLOCKS[^\n]*gid=([0-9]+)[^\n]*freed=([0-9]+)",
+    ):
+        for gid, freed in re.findall(pattern, text):
+            try:
+                freed_by_gid[int(gid)] += int(freed)
+            except ValueError:
+                pass
     skip_reasons: Counter[str] = Counter(
         reason.replace(" ", "_")
         for pattern in (
@@ -572,7 +622,10 @@ def parse_server_log(log_path: Path, event_sink_path: Path | None = None) -> dic
             int(event_sink["applied"]),
         ),
         "compression_skipped_events": max(
-            count_regex(r"TriAttention compression skipped", text),
+            count_regex(
+                r"TriAttention compression skipped|\[TriAttentionDebug\] compression skipped",
+                text,
+            ),
             int(event_sink["skipped"]),
         ),
         "compression_skip_reasons": ";".join(
@@ -581,8 +634,13 @@ def parse_server_log(log_path: Path, event_sink_path: Path | None = None) -> dic
         "free_blocks_events": (
             count_regex(r"TriAttention block reclaim", text)
             + count_regex(r"TriAttention scheduler FREE_BLOCKS", text)
+            + count_regex(r"\[TriAttentionDebug\] FREE_BLOCKS", text)
         ),
         "freed_blocks": max(reclaimed, scheduler_freed, int(event_sink["freed_blocks"])),
+        "saved_kv_tokens": max(saved_from_log, int(event_sink["saved_kv_tokens"])),
+        "freed_blocks_by_gid": ";".join(
+            f"gid{gid}:{count}" for gid, count in sorted(freed_by_gid.items())
+        ),
         "triattention_activation_seen": bool(
             re.search(
                 r"TriAttention].*activated|"
@@ -749,6 +807,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--trust-remote-code", action="store_true")
     parser.add_argument("--online", dest="offline", action="store_false", help="Allow HF/Transformers network lookups.")
     parser.set_defaults(offline=True)
+    parser.add_argument("--disable-kvcached", action="store_true", help="Run with ENABLE_KVCACHED=false (standalone vLLM; TriAttention still activates via its own plugin). Controlled A/B for kvcached's contribution.")
     parser.add_argument(
         "--extra-vllm-arg",
         action="append",
@@ -889,6 +948,8 @@ def main() -> int:
                 f"compression_events={row['compression_events']} "
                 f"skipped={row['compression_skipped_events']} "
                 f"freed_blocks={row['freed_blocks']} "
+                f"saved_kv_tokens={row['saved_kv_tokens']} "
+                f"freed_by_gid={row['freed_blocks_by_gid']} "
                 f"activation={row['triattention_activation_seen']} "
                 f"activation_failures={row['triattention_activation_failures']} "
                 f"errors={row['error_count']} "

--- a/tools/compare_vllm_triattention.py
+++ b/tools/compare_vllm_triattention.py
@@ -440,15 +440,19 @@ def start_server(
     log_file = log_path.open("w", encoding="utf-8")
     log_file.write("$ " + " ".join(cmd) + "\n")
     log_file.flush()
-    proc = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        bufsize=1,
-        env=env,
-        preexec_fn=os.setsid if hasattr(os, "setsid") else None,
-    )
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            env=env,
+            start_new_session=True,
+        )
+    except Exception:
+        log_file.close()
+        raise
 
     def pump_log() -> None:
         assert proc.stdout is not None

--- a/tools/compare_vllm_triattention.py
+++ b/tools/compare_vllm_triattention.py
@@ -2,18 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the kvcached project
 # SPDX-License-Identifier: Apache-2.0
 
-"""Compare long-context vLLM serving with and without TriAttention.
-
-This script starts two kinds of vLLM servers repeatedly:
-
-* kvcached-only baseline: ENABLE_KVCACHED=true, ENABLE_TRIATTENTION=0
-* kvcached + TriAttention: ENABLE_KVCACHED=true, ENABLE_TRIATTENTION=1
-
-For each run it sends a concurrent long-context streaming workload, samples GPU
-memory, parses the server log for TriAttention activity, and writes a CSV row.
-It intentionally uses only the Python standard library so it can run in the same
-venv as vLLM without extra client dependencies.
-"""
+"""Compare kvcached-only and kvcached+TriAttention vLLM serving."""
 
 from __future__ import annotations
 
@@ -132,6 +121,14 @@ def percentile(values: list[float], q: float) -> float:
 
 def mean(values: list[float]) -> float:
     return statistics.fmean(values) if values else 0.0
+
+
+def count_regex(pattern: str, text: str) -> int:
+    return len(re.findall(pattern, text))
+
+
+def sum_first_group(pattern: str, text: str) -> int:
+    return sum(int(match.group(1)) for match in re.finditer(pattern, text))
 
 
 def read_gpu_mib(gpu_index: int) -> int | None:
@@ -350,8 +347,12 @@ def make_env(
     event_sink_path: Path | None = None,
 ) -> dict[str, str]:
     env = os.environ.copy()
-    env["ENABLE_KVCACHED"] = "true"
-    env["ENABLE_TRIATTENTION"] = "1" if enable_triattention else "0"
+    env.update(
+        {
+            "ENABLE_KVCACHED": "true",
+            "ENABLE_TRIATTENTION": "1" if enable_triattention else "0",
+        }
+    )
     env.setdefault("KVCACHED_LOG_LEVEL", args.kvcached_log_level)
     env.setdefault("VLLM_USE_DEEP_GEMM", "0")
     if args.offline:
@@ -366,19 +367,23 @@ def make_env(
     env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
 
     if enable_triattention:
+        env.update(
+            {
+                "TRIATTN_RUNTIME_MODEL_PATH": args.model,
+                "TRIATTN_RUNTIME_DIVIDE_LENGTH": str(args.divide_length),
+                "TRIATTN_RUNTIME_WINDOW_SIZE": str(args.window_size),
+                "TRIATTN_RUNTIME_LOG_DECISIONS": "true",
+                "TRIATTN_RUNTIME_REQUIRE_TRITON_SCORING": "true",
+                "TRIATTN_RUNTIME_REQUIRE_PHYSICAL_RECLAIM": "true",
+                "TRIATTN_RUNTIME_DISABLE_COMPRESSION": "false",
+                "TRIATTN_RUNTIME_ENABLE_EXPERIMENTAL_KV_COMPACTION": "true",
+                "TRIATTN_RUNTIME_ENABLE_EXPERIMENTAL_BLOCK_RECLAIM": "true",
+            }
+        )
         if args.stats_path:
             env["TRIATTN_RUNTIME_SPARSE_STATS_PATH"] = args.stats_path
-        env["TRIATTN_RUNTIME_MODEL_PATH"] = args.model
         if budget is not None:
             env["TRIATTN_RUNTIME_KV_BUDGET"] = str(budget)
-        env["TRIATTN_RUNTIME_DIVIDE_LENGTH"] = str(args.divide_length)
-        env["TRIATTN_RUNTIME_WINDOW_SIZE"] = str(args.window_size)
-        env["TRIATTN_RUNTIME_LOG_DECISIONS"] = "true"
-        env["TRIATTN_RUNTIME_REQUIRE_TRITON_SCORING"] = "true"
-        env["TRIATTN_RUNTIME_REQUIRE_PHYSICAL_RECLAIM"] = "true"
-        env["TRIATTN_RUNTIME_DISABLE_COMPRESSION"] = "false"
-        env["TRIATTN_RUNTIME_ENABLE_EXPERIMENTAL_KV_COMPACTION"] = "true"
-        env["TRIATTN_RUNTIME_ENABLE_EXPERIMENTAL_BLOCK_RECLAIM"] = "true"
         if event_sink_path is not None:
             env["TRIATTN_RUNTIME_EVENT_SINK_PATH"] = str(event_sink_path)
     return env
@@ -528,36 +533,29 @@ def parse_server_log(log_path: Path, event_sink_path: Path | None = None) -> dic
         text = log_path.read_text(encoding="utf-8", errors="replace")
     except FileNotFoundError:
         text = ""
-    reclaimed = 0
-    for match in re.finditer(r"reclaimed_blocks=([0-9]+)", text):
-        reclaimed += int(match.group(1))
-    scheduler_freed = 0
-    for match in re.finditer(r"TriAttention scheduler FREE_BLOCKS:[^\n]*freed=([0-9]+)", text):
-        scheduler_freed += int(match.group(1))
-    applied_from_runner_log = len(re.findall(r"TriAttention compression applied", text))
-    applied_from_scheduler_events = 0
-    for match in re.finditer(
+    reclaimed = sum_first_group(r"reclaimed_blocks=([0-9]+)", text)
+    scheduler_freed = sum_first_group(
+        r"TriAttention scheduler FREE_BLOCKS:[^\n]*freed=([0-9]+)", text
+    )
+    applied_from_runner_log = count_regex(r"TriAttention compression applied", text)
+    applied_from_scheduler_events = sum_first_group(
         r"TriAttention update_from_output: received [0-9]+ events \(([0-9]+) applied\)",
         text,
-    ):
-        applied_from_scheduler_events += int(match.group(1))
+    )
     event_sink = parse_event_sink(event_sink_path)
-    skip_reasons: Counter[str] = Counter()
-    for match in re.finditer(
-        r"TriAttention compression skipped[^\n]*reason=([^\s,]+)", text
-    ):
-        skip_reasons[match.group(1)] += 1
-    for match in re.finditer(
-        r"TriAttention compression skipped \(([^)]+)\)", text
-    ):
-        skip_reasons[match.group(1).replace(" ", "_")] += 1
-    skip_reasons.update(event_sink["skip_reasons"])
-    activation_failures = len(
-        re.findall(
-            r"\[TriAttention\].*Activation failed|"
-            r"\[TriAttention\].*Runtime plugin activation failed",
-            text,
+    skip_reasons: Counter[str] = Counter(
+        reason.replace(" ", "_")
+        for pattern in (
+            r"TriAttention compression skipped[^\n]*reason=([^\s,]+)",
+            r"TriAttention compression skipped \(([^)]+)\)",
         )
+        for reason in re.findall(pattern, text)
+    )
+    skip_reasons.update(event_sink["skip_reasons"])
+    activation_failures = count_regex(
+        r"\[TriAttention\].*Activation failed|"
+        r"\[TriAttention\].*Runtime plugin activation failed",
+        text,
     )
     return {
         "compression_events": max(
@@ -566,15 +564,15 @@ def parse_server_log(log_path: Path, event_sink_path: Path | None = None) -> dic
             int(event_sink["applied"]),
         ),
         "compression_skipped_events": max(
-            len(re.findall(r"TriAttention compression skipped", text)),
+            count_regex(r"TriAttention compression skipped", text),
             int(event_sink["skipped"]),
         ),
         "compression_skip_reasons": ";".join(
             f"{reason}:{count}" for reason, count in skip_reasons.most_common()
         ),
         "free_blocks_events": (
-            len(re.findall(r"TriAttention block reclaim", text))
-            + len(re.findall(r"TriAttention scheduler FREE_BLOCKS", text))
+            count_regex(r"TriAttention block reclaim", text)
+            + count_regex(r"TriAttention scheduler FREE_BLOCKS", text)
         ),
         "freed_blocks": max(reclaimed, scheduler_freed, int(event_sink["freed_blocks"])),
         "triattention_activation_seen": bool(
@@ -587,7 +585,7 @@ def parse_server_log(log_path: Path, event_sink_path: Path | None = None) -> dic
             )
         ),
         "triattention_activation_failures": activation_failures,
-        "error_count": len(re.findall(r"\bERROR\b|\[ERROR\]", text)),
+        "error_count": count_regex(r"\bERROR\b|\[ERROR\]", text),
     }
 
 
@@ -691,11 +689,7 @@ def write_row(output_csv: Path, row: dict[str, Any]) -> None:
 
 
 def parse_int_list(raw: str) -> list[int]:
-    values = []
-    for part in raw.split(","):
-        stripped = part.strip()
-        if stripped:
-            values.append(int(stripped))
+    values = [int(part.strip()) for part in raw.split(",") if part.strip()]
     if not values:
         raise argparse.ArgumentTypeError("expected at least one integer")
     return values


### PR DESCRIPTION
## Summary

This PR adds optional external TriAttention integration for kvcached without vendoring the TriAttention source tree.

TriAttention is loaded from a separately installed checkout and is enabled only when `ENABLE_TRIATTENTION=1` is set. Existing kvcached users are unaffected by default.

## What Changed

- Add an external TriAttention loader under `kvcached.integration.triattention_external`.
- Add optional TriAttention activation paths for both vLLM and SGLang autopatching.
- Fail fast when `ENABLE_TRIATTENTION=1` is requested but TriAttention activation fails.
- Add a kvcached compatibility patch for the upstream TriAttention repository.
- Add benchmark scripts for comparing kvcached-only vs kvcached+TriAttention:
  - `tools/compare_vllm_triattention.py`
  - `tools/compare_sglang_triattention.py`
- Add a SGLang `decode-stress` benchmark profile, since SGLang TriAttention compression is decode-time driven.

## Differences between vLLM and SGLang Workloads 

The vLLM benchmark uses a long-prompt workload because the vLLM integration can reclaim KV blocks through `block_pool.free_blocks(...)`, which is routed through kvcached's `ElasticBlockPool`. As a result, reclaim can directly reduce physical KV memory pressure and show up clearly in peak GPU memory.

SGLang behaves differently. Its TriAttention compression path is decode-time driven, so a very long prompt alone mostly creates a prefill-time memory peak before compression has a chance to help. For SGLang, this PR uses a `decode-stress` workload: short prompt, long forced decode, `min_tokens=max_tokens`, and `ignore_eos=true`. This makes compression and reclaim happen while decode memory is growing, which better exposes the effect in GPU peak memory.

## Benchmark Results

Model: Qwen3-8B  
GPU memory sampled with `nvidia-smi`.

### vLLM Long-Context Workload

Workload:

- prompt repeat: 1200
- max output tokens: 2048
- concurrencies: 4, 8, 16
- KV budgets: 1024, 2048

| Concurrency | KV Budget | kvcached Peak | kvcached+TriAttention Peak | Reduction | Compression Events | Freed Blocks | E2E Change |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 4 | 1024 | 35669 MiB | 23329 MiB | 12340 MiB / 34.6% | 175 | 6157 | -3.6% |
| 4 | 2048 | 35669 MiB | 23621 MiB | 12048 MiB / 33.8% | 175 | 5901 | +3.7% |
| 8 | 1024 | 45893 MiB | 23905 MiB | 21988 MiB / 47.9% | 331 | 11644 | -23.9% |
| 8 | 2048 | 45893 MiB | 25061 MiB | 20832 MiB / 45.4% | 331 | 11132 | -26.0% |
| 16 | 1024 | 45893 MiB | 25633 MiB | 20260 MiB / 44.1% | 641 | 23103 | -31.5% |
| 16 | 2048 | 45893 MiB | 27367 MiB | 18526 MiB / 40.4% | 639 | 22542 | -31.1% |

The vLLM path shows a large peak GPU memory reduction, especially at higher concurrency, because reclaimed KV blocks are returned through kvcached's physical allocator path.

### SGLang Decode-Stress Workload

Workload:

- workload profile: `decode-stress`
- prompt repeat: 64
- prompt tokens: 2010
- max tokens: 8192
- min tokens: 8192
- ignore EOS: true
- concurrency: 4
- KV budget: 1024

| Mode | Success | TTFT Mean | E2E Mean | GPU Peak | Compression Events | Skipped Events | Freed Blocks |
|---|---:|---:|---:|---:|---:|---:|---:|
| kvcached | 4/4 | 230.482 ms | 76296.729 ms | 25570 MiB | 0 | 0 | 0 |
| kvcached + TriAttention | 4/4 | 238.556 ms | 72940.810 ms | 21910 MiB | 16 | 4 | 34316 |

SGLang peak GPU memory was reduced by 3660 MiB, or 14.3%.

These happen when a request has already been released by the time a late compression attempt is observed. The successful compression and reclaim path is confirmed by compression_events=16 and freed_blocks=34316.

## Validation
pre-commit run --all-files
Passed.

## Additional checks:

vLLM benchmark CSV parsed successfully.
SGLang decode-stress benchmark CSV parsed successfully.
SGLang benchmark script syntax check passed.