### PR TITLE
fix(vllm): reset block hash on prefix-cache eviction

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -274,6 +274,31 @@ def _make_cache_key(block_hash: Any, group_id: int) -> bytes:
     return bytes(block_hash) + group_id.to_bytes(4, "big", signed=False)
 
 
+def _reset_block_hash(block: Any) -> None:
+    """Clear vLLM's cached block hash before returning a block to kvcached."""
+    reset_hash = getattr(block, "reset_hash", None)
+    if callable(reset_hash):
+        reset_hash()
+        return
+    if hasattr(block, "_block_hash"):
+        block._block_hash = None
+    if hasattr(block, "_block_hash_num_tokens"):
+        block._block_hash_num_tokens = None
+
+
+def _set_block_hash(block: Any, key: Any) -> None:
+    """Set vLLM's cached block hash across API versions.
+
+    vLLM 0.24 and later expose a read-only property plus set_block_hash().
+    Older supported versions expose a writable block_hash property instead.
+    """
+    set_block_hash = getattr(block, "set_block_hash", None)
+    if callable(set_block_hash):
+        set_block_hash(key)
+    else:
+        block.block_hash = key
+
+
 class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
     """Inject ElasticBlockPool into vLLM's block pool module"""
 
@@ -461,6 +486,12 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                     if key in self._cached_blocks:
                         continue
 
+                    # ElasticBlockPool tracks cached blocks through its own maps,
+                    # but vLLM manager code may still read KVCacheBlock.block_hash
+                    # after cache_full_blocks. Preserve that metadata contract and
+                    # clear it before the block is evicted or reused.
+                    if getattr(block, "block_hash", None) is None:
+                        _set_block_hash(block, key)
                     self._cached_blocks[key] = block
                     self._block_id_to_key[block.block_id] = key
 
@@ -471,10 +502,11 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 """
                 ids_to_free: list[int] = []
                 for _ in range(min(num_to_evict, len(self._evictable_blocks))):
-                    bid, _block = self._evictable_blocks.popitem(last=False)
+                    bid, block = self._evictable_blocks.popitem(last=False)
                     key = self._block_id_to_key.pop(bid, None)
                     if key is not None:
                         self._cached_blocks.pop(key, None)
+                    _reset_block_hash(block)
                     ids_to_free.append(bid)
                 if ids_to_free:
                     self.kv_cache_manager.free(ids_to_free)
@@ -557,6 +589,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                             self._evictable_blocks[block.block_id] = block
                         else:
                             # Uncached block (e.g. partial): free immediately
+                            _reset_block_hash(block)
                             uncached_to_free.append(block.block_id)
                 if uncached_to_free:
                     self.kv_cache_manager.free(uncached_to_free)
@@ -576,10 +609,13 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 for bid in block_ids:
                     key = self._block_id_to_key.pop(bid, None)
                     if key is not None:
-                        self._cached_blocks.pop(key, None)
+                        block = self._cached_blocks.pop(key, None)
+                        if block is not None:
+                            _reset_block_hash(block)
                         removed += 1
                     if bid in self._evictable_blocks:
-                        self._evictable_blocks.pop(bid)
+                        block = self._evictable_blocks.pop(bid)
+                        _reset_block_hash(block)
                         ids_to_free.append(bid)
 
                 if ids_to_free:
@@ -593,6 +629,8 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
 
                 # Free all evictable blocks back to kvcached
                 if self._evictable_blocks:
+                    for block in self._evictable_blocks.values():
+                        _reset_block_hash(block)
                     ids_to_free = list(self._evictable_blocks.keys())
                     self._evictable_blocks.clear()
                     self.kv_cache_manager.free(ids_to_free)

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -10,6 +10,7 @@ to test the prefix cache logic in isolation without GPU or vLLM dependency.
 
 import sys
 import types
+from typing import Optional
 from unittest import mock
 
 # ---------------------------------------------------------------------------
@@ -51,6 +52,21 @@ class MockKVCacheBlock:
         self.block_id = block_id
         self.ref_cnt = ref_cnt
         self.is_null = False
+        self._block_hash: Optional[object] = None
+        self._block_hash_num_tokens: Optional[int] = None
+
+    @property
+    def block_hash(self):
+        return self._block_hash
+
+    def set_block_hash(self, value, num_tokens=None):
+        assert self._block_hash is None
+        self._block_hash = value
+        self._block_hash_num_tokens = num_tokens
+
+    def reset_hash(self):
+        self._block_hash = None
+        self._block_hash_num_tokens = None
 
 
 class MockKVCacheManager:
@@ -86,6 +102,18 @@ class MockRequest:
 
     def __init__(self, block_hashes: list):
         self.block_hashes = block_hashes
+
+
+def test_set_block_hash_supports_legacy_writable_property():
+    """vLLM before 0.24 uses a writable block_hash property."""
+    from kvcached.integration.vllm.patches import _set_block_hash
+
+    block = types.SimpleNamespace(block_hash=None)
+    key = b"legacy-key"
+
+    _set_block_hash(block, key)
+
+    assert block.block_hash == key
 
 
 # ---------------------------------------------------------------------------
@@ -178,6 +206,7 @@ class TestLazyEviction:
 
         # Request A
         blocks_a = _simulate_request(pool, hashes)
+        assert all(block.block_hash is not None for block in blocks_a)
         _finish_request(pool, blocks_a)
 
         # All blocks should be in evictable pool, NOT freed to kvcached
@@ -215,6 +244,7 @@ class TestLazyEviction:
         # Not cached -> freed immediately
         assert len(pool._evictable_blocks) == 0
         assert mgr.available_size() == initial_free
+        assert all(block.block_hash is None for block in blocks)
 
     def test_touch_removes_from_evictable_pool(self, pool_and_manager):
         """Touching an evictable block reactivates it (removes from pool)."""
@@ -305,12 +335,14 @@ class TestEvictOnDemand:
         _finish_request(pool, blocks)
 
         # Evict 3 -> should evict h0, h1, h2 (oldest)
+        evicted_blocks = blocks[:3]
         pool._evict_blocks_from_pool(3)
 
         assert pool.get_cached_block("h0", [0]) is None
         assert pool.get_cached_block("h1", [0]) is None
         assert pool.get_cached_block("h2", [0]) is None
         assert pool.get_cached_block("h3", [0]) is not None  # still cached
+        assert all(block.block_hash is None for block in evicted_blocks)
 
     def test_evict_all_then_alloc(self, pool_factory):
         """Can evict entire pool and allocate fresh blocks."""
@@ -381,6 +413,7 @@ class TestResetAndExplicitEviction:
         assert len(pool._cached_blocks) == 0
         assert len(pool._block_id_to_key) == 0
         assert mgr.available_size() == 20  # all freed (null_block still allocated)
+        assert all(block.block_hash is None for block in blocks)
 
     def test_reset_with_no_evictable(self, pool_and_manager):
         """reset_prefix_cache works even when evictable pool is empty."""
@@ -404,6 +437,8 @@ class TestResetAndExplicitEviction:
         assert pool.get_cached_block("h0", [0]) is None
         assert pool.get_cached_block("h1", [0]) is None
         assert pool.get_cached_block("h2", [0]) is not None
+        assert all(block.block_hash is None for block in blocks[:2])
+        assert all(block.block_hash is not None for block in blocks[2:])
 
     def test_evict_blocks_active_not_freed(self, pool_factory):
         """evict_blocks on active (ref_cnt>0) blocks removes cache entry
@@ -523,6 +558,7 @@ class TestEdgeCases:
         # Evict all
         pool._evict_blocks_from_pool(4)
         assert len(pool._cached_blocks) == 0
+        assert all(block.block_hash is None for block in blocks)
 
         # Reallocate -- may get same block IDs
         new_blocks = pool.get_new_blocks(4)


### PR DESCRIPTION
## Summary

Fixes stale or missing vLLM `KVCacheBlock.block_hash` metadata when kvcached caches, evicts, or frees prefix-cache blocks. The compatibility path covers the writable property used by older supported vLLM versions and the read-only property plus `set_block_hash()` introduced in vLLM 0.24.

Closes #362.

## Root Cause

`ElasticBlockPool` replaces vLLM's `BlockPool.cache_full_blocks`, so it must preserve the surrounding vLLM manager's block metadata contract even though kvcached uses its own cache indexes. Cached blocks need their current hash recorded, and evicted or freed blocks need both hash fields reset before reuse.

Without this lifecycle, a block can retain stale identity across prefixes. Conversely, leaving the hash unset also breaks vLLM consumers outside the replaced block-pool implementation.

## Concrete Benefits

- **Mamba same-step correctness:** `MambaManager` uses `block.block_hash` to prevent a request from reusing another request's just-cached block before its recurrent/SSM state is materialized. An unset hash bypasses this guard and can produce incorrect output.
- **NIXL PD transfer efficiency:** the decode side uses `block.block_hash is None` to determine which blocks still need transfer. An unset hash causes an already-held prefix to be transferred again. In a real 1P1D NIXL run, preserving this metadata reduced a repeated-request transfer from 45.6 MB to 1.6 MB (96.6%).

## Changes

- add compatibility helpers that use `set_block_hash()` when available, fall back to the legacy writable property, and use `reset_hash()` when available
- reset both `_block_hash` and `_block_hash_num_tokens` for older or mock objects without `reset_hash()`
- reset hashes on lazy-cache eviction, uncached immediate free, explicit `evict_blocks()`, and `reset_prefix_cache()`
- make the main test block match vLLM 0.24's read-only property and `set_block_hash()` API
- retain a regression test for the older writable-property fallback
- cover eviction, reset, explicit eviction, reallocation, and recache flows

## Validation

- `python -m pytest tests/test_prefix_cache.py -q` -> 29 passed
- complete `pre-commit run --all-files` under Python 3.11 -> all hooks passed
- manual mypy matrix under Python 3.9, 3.10, 3.11, 3.12, and 3.13 -> all passed
- CI containers used standard `runc` with GPU devices explicitly hidden

The PR remains one focused commit.