### PR TITLE
fix: roll back partial KV allocation on page miss

### DIFF
--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -283,8 +283,25 @@ class KVCacheManager:
 
         while remaining_need > 0:  # Allocate the remaining blocks from pages
             if not self.avail_pages:
-                page = self.page_allocator.alloc_page()
-                page.init(self.block_mem_size)
+                try:
+                    page = self.page_allocator.alloc_page()
+                    page.init(self.block_mem_size)
+                except RuntimeError as exc:
+                    logger.warning(
+                        "Physical KV page allocation failed; returning "
+                        "allocation miss instead of crashing scheduler: %s",
+                        exc,
+                    )
+                    if ret_index:
+                        try:
+                            self._free(ret_index, release_empty_pages=False)
+                        except Exception as rollback_exc:
+                            logger.warning(
+                                "Failed to roll back partially allocated KV "
+                                "blocks after page allocation miss: %s",
+                                rollback_exc,
+                            )
+                    return None
                 # A page may have zero usable blocks when block_mem_size is
                 # large (e.g. HYBRID_LINEAR) and every aligned block would
                 # straddle the page boundary. Park it in full_pages so it's
@@ -344,8 +361,7 @@ class KVCacheManager:
         assert chosen is not None, "caller guarantees avail_pages is non-empty"
         return self.avail_pages.pop(chosen)
 
-    @synchronized
-    def free(self, indices: List[int]):
+    def _free(self, indices: List[int], *, release_empty_pages: bool):
         self._wait_post_init()
 
         if len(indices) == 0:
@@ -384,8 +400,11 @@ class KVCacheManager:
             page.free_batch(idxs)
 
             if page.empty():
-                pages_to_free.append(page.page_id)
-                self.num_avail_blocks -= page.num_free_blocks()
+                if release_empty_pages:
+                    pages_to_free.append(page.page_id)
+                    self.num_avail_blocks -= page.num_free_blocks()
+                else:
+                    self.avail_pages[page_id] = page
             else:
                 self.avail_pages[page_id] = page
 
@@ -399,6 +418,10 @@ class KVCacheManager:
                                            self.block_mem_size)
                 self.in_shrink = False
                 self.target_num_blocks = None
+
+    @synchronized
+    def free(self, indices: List[int]):
+        self._free(indices, release_empty_pages=True)
 
     @synchronized
     def try_to_reserve(self, need_size: int) -> bool:

--- a/tests/test_kvcache_manager_alloc_miss.py
+++ b/tests/test_kvcache_manager_alloc_miss.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for KVCacheManager allocation miss rollback."""
+
+import sys
+from unittest import mock
+
+_torch_mock = mock.MagicMock()
+_torch_mock.__version__ = "2.6.0"
+sys.modules.setdefault("torch", _torch_mock)
+sys.modules.setdefault("torch.cuda", _torch_mock.cuda)
+sys.modules.setdefault("torch.utils", _torch_mock.utils)
+sys.modules.setdefault("torch.utils.cpp_extension", _torch_mock.utils.cpp_extension)
+sys.modules.setdefault("posix_ipc", mock.MagicMock())
+sys.modules.setdefault("kvcached.vmm_ops", mock.MagicMock())
+
+class FailingPageAllocator:
+    def __init__(self):
+        self.freed_pages = []
+
+    def get_resize_target(self):
+        return 0
+
+    def alloc_page(self):
+        raise RuntimeError("physical pool exhausted")
+
+    def group_indices_by_page(self, indices, block_mem_size):
+        return {FakePage.page_id: list(indices)}
+
+    def free_pages(self, page_ids):
+        self.freed_pages.extend(page_ids)
+
+
+class FakePage:
+    page_id = 7
+
+    def __init__(self, free_blocks=None, capacity=2):
+        self.capacity = capacity
+        self._free = list(free_blocks if free_blocks is not None else [100, 101])
+
+    def num_free_blocks(self):
+        return len(self._free)
+
+    def alloc(self, n):
+        out = self._free[:n]
+        self._free = self._free[n:]
+        return out
+
+    def full(self):
+        return not self._free
+
+    def empty(self):
+        return len(self._free) == self.capacity
+
+    def free_batch(self, indices):
+        self._free.extend(indices)
+        self._free.sort()
+
+
+def _manager_with_allocator(free_size):
+    from kvcached.kv_cache_manager import KVCacheManager
+    from kvcached.locks import NoOpLock
+
+    manager = object.__new__(KVCacheManager)
+    manager._lock = NoOpLock()
+    manager.page_allocator = FailingPageAllocator()
+    manager.block_mem_size = 1
+    manager.reserved_blocks = []
+    manager.avail_pages = {}
+    manager.full_pages = {}
+    manager.num_avail_blocks = 0
+    manager.resize = mock.Mock()
+    setattr(manager, "available_size", mock.Mock(return_value=free_size))
+    manager._wait_post_init = mock.Mock()  # type: ignore[method-assign]
+    manager.in_shrink = False
+    manager.target_num_blocks = None
+    return manager
+
+
+def test_alloc_page_failure_rolls_back_reserved_blocks():
+    manager = _manager_with_allocator(free_size=2)
+    page = FakePage(free_blocks=[], capacity=1)
+    manager.full_pages = {page.page_id: page}
+    manager.reserved_blocks = [10]
+
+    result = manager._alloc(2, _skip_wait=True)
+
+    assert result is None
+    assert manager.page_allocator.freed_pages == []
+    assert manager.avail_pages[page.page_id].empty()
+    assert manager.reserved_blocks == []
+
+
+def test_alloc_page_failure_rolls_back_blocks_from_existing_page():
+    manager = _manager_with_allocator(free_size=3)
+    page = FakePage()
+    manager.avail_pages = {page.page_id: page}
+    manager.num_avail_blocks = page.num_free_blocks()
+
+    result = manager._alloc(3, _skip_wait=True)
+
+    assert result is None
+    assert manager.page_allocator.freed_pages == []
+    assert manager.avail_pages[page.page_id].empty()
+    assert manager.num_avail_blocks == page.capacity
+
+
+def test_alloc_page_failure_without_partial_allocation_returns_none():
+    manager = _manager_with_allocator(free_size=1)
+
+    result = manager._alloc(1, _skip_wait=True)
+
+    assert result is None
+    assert manager.page_allocator.freed_pages == []


### PR DESCRIPTION
## Summary

Fixes #364.

Fixes a lower-level allocation failure path in `KVCacheManager.alloc()` where `PageAllocator.alloc_page()` can raise after some block ids have already been reserved for the current allocation request.

## Root Cause

`available_size()` and physical page allocation are not atomic across multiple instances sharing the same physical pool. A caller may pass the capacity check, consume reserved blocks or blocks from an existing page, and then fail when requesting a new physical page.

Before this change, that `RuntimeError` escaped without rolling back the partially allocated block ids.

## What Changed

- Catch `RuntimeError` around `page_allocator.alloc_page()`.
- Return `None` as an allocation miss instead of crashing the allocation path.
- Roll back any partially allocated block ids before returning `None`.
- Use an internal `_free(..., release_empty_pages=False)` rollback path so a partial-allocation rollback does not unmap/release physical pages that were not intentionally returned to the physical pool.
- Keep normal public `free()` behavior unchanged for real releases.
- Add unit coverage for:
  - reserved-block partial allocation rollback;
  - existing-page partial allocation rollback;
  - failure before any partial allocation.

## Tests

```bash
python -m pytest tests/test_kvcache_manager_alloc_miss.py -q
python -m py_compile kvcached/kv_cache_manager.py tests/test_kvcache_manager_alloc_miss.py
```
