### PR TITLE
fix(vllm): fail loud when hybrid-linear KV block exceeds page size

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Optional
 
 from kvcached.integration.patch_base import BasePatch, enable_kvcached
 from kvcached.integration.version_utils import VersionAwarePatch, VersionRange, version_range
+from kvcached.utils import KVCachedConfigError
 
 if TYPE_CHECKING:
     # These types are imported from vLLM at runtime via getattr()
@@ -708,8 +709,13 @@ class KVCacheCoordinatorPatch(VersionAwarePatch, BasePatch):
 
             try:
                 self._setup_kvcached_coordinator()
-            except Exception:
-                logger.warning("Failed to patch kv_cache_coordinator")
+            except KVCachedConfigError:
+                # User-fixable misconfiguration (e.g. KV block larger than the
+                # page size). Abort loudly instead of silently disabling
+                # kvcached and falling back to vanilla allocation.
+                raise
+            except Exception as e:
+                logger.warning("Failed to patch kv_cache_coordinator: %s", e)
                 return
 
         def _setup_kvcached_coordinator(self) -> None:

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -24,6 +24,7 @@ from kvcached.utils import (
     PAGE_PREALLOC_ENABLED,
     PAGE_SIZE,
     SANITY_CHECK,
+    KVCachedConfigError,
     get_kvcached_logger,
 )
 from kvcached.vmm_ops import kv_tensors_created
@@ -94,6 +95,25 @@ class KVCacheManager:
 
         # The physical page size used by kvcached page allocator.
         self.page_size = PAGE_SIZE
+        # A block must fit within a single page; otherwise a page holds zero
+        # usable blocks, the KV pool is permanently empty, and the engine
+        # silently deadlocks during warmup (available_size() stays 0). This
+        # happens with hybrid linear-attention models (e.g. Qwen3.5/3.6 GDN,
+        # Mamba) whose per-block recurrent state exceeds the default 2MB page.
+        # Fail loudly here with the exact page size needed instead of hanging.
+        if self.block_mem_size > self.page_size:
+            base = 2 * 1024 * 1024  # KVCACHED_PAGE_SIZE_MB granularity
+            min_page_mb = ((self.block_mem_size + base - 1) // base) * 2
+            raise KVCachedConfigError(
+                f"kvcached KV block size ({self.block_mem_size} bytes, "
+                f"{self.block_mem_size / base * 2:.2f} MiB) is larger than the "
+                f"page size ({self.page_size} bytes, "
+                f"{self.page_size // (1024 * 1024)} MiB), so no block fits in a "
+                f"page and the KV pool would be empty. This typically happens "
+                f"with hybrid linear-attention models (e.g. Qwen3.5/3.6 GDN, "
+                f"Mamba) whose per-block state is large. Re-launch with "
+                f"KVCACHED_PAGE_SIZE_MB={min_page_mb} (or larger; must be a "
+                f"multiple of 2).")
         # NOTE: this is the memory size of the K or V tensor in one layer
         self.mem_size = self.num_blocks * self.block_mem_size
         self.world_size = world_size

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -106,7 +106,7 @@ class KVCacheManager:
             min_page_mb = ((self.block_mem_size + base - 1) // base) * 2
             raise KVCachedConfigError(
                 f"kvcached KV block size ({self.block_mem_size} bytes, "
-                f"{self.block_mem_size / base * 2:.2f} MiB) is larger than the "
+                f"{self.block_mem_size / (1024 * 1024):.2f} MiB) is larger than the "
                 f"page size ({self.page_size} bytes, "
                 f"{self.page_size // (1024 * 1024)} MiB), so no block fits in a "
                 f"page and the KV pool would be empty. This typically happens "

--- a/kvcached/utils.py
+++ b/kvcached/utils.py
@@ -6,6 +6,12 @@ import logging
 import os
 
 
+class KVCachedConfigError(RuntimeError):
+    """Raised for kvcached misconfiguration the user must fix (e.g. a KV block
+    larger than the page size). Integration patches re-raise this loudly to
+    abort startup instead of silently falling back to non-kvcached behavior."""
+
+
 def _sanitize_segment(segment: str) -> str:
     """Sanitize a segment to safe characters for SHM names."""
     allowed = []


### PR DESCRIPTION
## Problem

Hybrid linear-attention models (Qwen3.5/3.6 GDN, Mamba, …) can have a per-block state larger than the default 2 MB page. When `block_mem_size > page_size`, a page holds zero usable blocks, so the KV pool is permanently empty (`available_size()` stays 0) and the engine silently deadlocks at warmup — no traceback, never reaching "startup complete".

A guard alone wasn't enough: the `KVCacheCoordinator` patch's broad `except Exception` swallowed it into a vague `Failed to patch kv_cache_coordinator` warning and silently disabled kvcached (vanilla fallback).

## Fix

- **`utils.py`** — new `KVCachedConfigError`.
- **`kv_cache_manager.py`** — raise it when `block_mem_size > page_size`, naming the exact `KVCACHED_PAGE_SIZE_MB` to set.
- **`integration/vllm/patches.py`** — re-raise `KVCachedConfigError` (fatal) instead of swallowing it; other patch failures still tolerated.

## Verification (Qwen3.6-27B-FP8, 3.06 MiB block)

- `KVCACHED_PAGE_SIZE_MB=2` → aborts with `... Re-launch with KVCACHED_PAGE_SIZE_MB=4`.
- `KVCACHED_PAGE_SIZE_MB=4` → kvcached active, serves normally.

