### PR TITLE
fix: propagate TP and PP KV mapping failures

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import inspect
 import math
+import os
 import types
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Iterable, Optional
@@ -972,14 +973,15 @@ class EngineCorePatch(VersionAwarePatch, BasePatch):
             if enable_kvcached():
                 from kvcached.integration.vllm.interfaces import init_kvcached
 
-                # IMPORTANT: use tp_size only, NOT tp_size * pp_size.
-                # The kvcached IPC mechanism coordinates KV tensor readiness
-                # within a single PP stage's TP group (w0.sock … w(tp-1).sock).
-                # Each PP stage manages its own KV memory independently, so
-                # cross-stage IPC is neither needed nor correct.
+                pp_size = int(vllm_config.parallel_config.pipeline_parallel_size)
+                os.environ["KVCACHED_PP_SIZE"] = str(pp_size)
+
+                # Keep TP ranks local to each PP stage. A negative PP rank
+                # marks coordinator operations that must reach every stage.
                 init_kvcached(
                     tp_rank=0,
                     world_size=vllm_config.parallel_config.tensor_parallel_size,
+                    pp_rank=-1 if pp_size > 1 else 0,
                     is_worker=False,
                     async_sched=_should_enable_async_sched(vllm_config),
                 )
@@ -1071,14 +1073,22 @@ class KVCacheCoordinatorPatch(VersionAwarePatch, BasePatch):
             # on startup timing it can either raise or still report world size 1.
             tp_size = int(kvi.get_world_size())
 
-            # Use tp_size (not TP*PP global world size) for the KVCacheManager world_size.
-            # Each PP stage manages its own KV tensors independently. The IPC sockets
-            # are registered per TP rank within each stage (w0.sock … w(tp_size-1).sock).
+            vllm_config = getattr(self, "vllm_config", None)
+            parallel_config = getattr(vllm_config, "parallel_config", None)
+            pp_size = int(
+                getattr(parallel_config, "pipeline_parallel_size", 0)
+                or os.getenv("KVCACHED_PP_SIZE", "1")
+                or "1"
+            )
+
+            # Keep world_size equal to the TP width of one stage and fan
+            # coordinator operations out through the PP-specific socket paths.
             kvi.init_kvcached(
                 tp_rank=0,
                 world_size=tp_size,
+                pp_rank=-1 if pp_size > 1 else 0,
                 is_worker=False,
-                async_sched=_should_enable_async_sched(getattr(self, "vllm_config", None)),
+                async_sched=_should_enable_async_sched(vllm_config),
             )
 
             # Import ElasticBlockPool from the patched module

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -229,10 +229,19 @@ class KVCacheManager:
 
         try:
             total_wait = 0.0
-            while not _check_kv_tensors_created():
+            last_error: Exception | None = None
+            while True:
+                try:
+                    if _check_kv_tensors_created():
+                        break
+                except Exception as e:
+                    last_error = e
                 if total_wait >= KV_TENSOR_WAIT_TIMEOUT:
-                    raise TimeoutError("KV tensors not created after "
-                                       f"{KV_TENSOR_WAIT_TIMEOUT} seconds")
+                    message = ("KV tensors not created after "
+                               f"{KV_TENSOR_WAIT_TIMEOUT} seconds")
+                    if last_error is not None:
+                        message = f"{message}; last error: {last_error}"
+                    raise TimeoutError(message)
                 time.sleep(0.001)  # 1ms
                 total_wait += 0.001
             # KV tensors created now

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -158,11 +158,21 @@ class KVCacheManager:
                 )
 
                 # Wrap Python functions to match C++ callback signature
-                def map_callback(world_size: int, offsets: List[int], pp_rank: int = 0, group_id: int = 0) -> None:
+                def map_callback(
+                    world_size: int,
+                    offsets: List[int],
+                    pp_rank: int = self.pp_rank,
+                    group_id: int = self.group_id,
+                ) -> None:
                     """Wrapper for Python broadcast function"""
                     broadcast_map_to_kv_tensors(world_size, offsets, pp_rank, group_id)
 
-                def unmap_callback(world_size: int, offsets: List[int]) -> None:
+                def unmap_callback(
+                    world_size: int,
+                    offsets: List[int],
+                    pp_rank: int = self.pp_rank,
+                    group_id: int = self.group_id,
+                ) -> None:
                     """Wrapper for Python broadcast function"""
                     broadcast_unmap_from_kv_tensors(world_size, offsets, pp_rank, group_id)
 

--- a/kvcached/tp_ipc_util.py
+++ b/kvcached/tp_ipc_util.py
@@ -32,6 +32,13 @@ def _get_socket_dir_name() -> str:
 SOCKET_DIR = os.path.join("/tmp", _get_socket_dir_name())
 
 
+def _target_pp_ranks(pp_rank: int) -> list[int]:
+    if pp_rank >= 0:
+        return [pp_rank]
+    pp_size = int(os.getenv("KVCACHED_PP_SIZE", "1") or "1")
+    return list(range(max(pp_size, 1)))
+
+
 def get_worker_socket_path(rank: int, pp_rank: int = 0) -> str:
     """
     Get the path for the worker socket, namespaced by pp_rank.
@@ -207,17 +214,27 @@ async def _broadcast_map_to_kv_tensors(tp_size: int,
     """
     map_message = {"cmd": "map_to_kv_tensors", "offsets": offsets,
                    "group_id": group_id}
+    targets = [
+        (target_pp_rank, rank)
+        for target_pp_rank in _target_pp_ranks(pp_rank)
+        for rank in range(tp_size)
+    ]
     tasks = [
-        _send_and_receive_message(rank, map_message, pp_rank) for rank in range(tp_size)
+        _send_and_receive_message(rank, map_message, target_pp_rank)
+        for target_pp_rank, rank in targets
     ]
 
     responses = await asyncio.gather(*tasks, return_exceptions=True)
-    for rank, response in enumerate(responses):
+    for (target_pp_rank, rank), response in zip(targets, responses):
         if isinstance(response, Exception):
-            raise RuntimeError(f"Worker {rank} failed to map: {response}")
+            raise RuntimeError(
+                f"Worker pp{target_pp_rank}/rank{rank} failed to map: {response}"
+            )
         elif not isinstance(response,
                             dict) or response.get("status") != "success":
-            raise RuntimeError(f"Worker {rank} failed to map: {response}")
+            raise RuntimeError(
+                f"Worker pp{target_pp_rank}/rank{rank} failed to map: {response}"
+            )
 
 
 async def _broadcast_unmap_from_kv_tensors(tp_size: int,
@@ -229,18 +246,27 @@ async def _broadcast_unmap_from_kv_tensors(tp_size: int,
     """
     unmap_message = {"cmd": "unmap_from_kv_tensors", "offsets": offsets,
                      "group_id": group_id}
-    tasks = [
-        _send_and_receive_message(rank, unmap_message, pp_rank)
+    targets = [
+        (target_pp_rank, rank)
+        for target_pp_rank in _target_pp_ranks(pp_rank)
         for rank in range(tp_size)
+    ]
+    tasks = [
+        _send_and_receive_message(rank, unmap_message, target_pp_rank)
+        for target_pp_rank, rank in targets
     ]
 
     responses = await asyncio.gather(*tasks, return_exceptions=True)
-    for rank, response in enumerate(responses):
+    for (target_pp_rank, rank), response in zip(targets, responses):
         if isinstance(response, Exception):
-            raise RuntimeError(f"Worker {rank} failed to unmap: {response}")
+            raise RuntimeError(
+                f"Worker pp{target_pp_rank}/rank{rank} failed to unmap: {response}"
+            )
         elif not isinstance(response,
                             dict) or response.get("status") != "success":
-            raise RuntimeError(f"Worker {rank} failed to unmap: {response}")
+            raise RuntimeError(
+                f"Worker pp{target_pp_rank}/rank{rank} failed to unmap: {response}"
+            )
 
 
 async def _broadcast_kv_tensors_created(tp_size: int,
@@ -251,22 +277,29 @@ async def _broadcast_kv_tensors_created(tp_size: int,
     Returns True if all workers report that KV tensors are created, False otherwise.
     """
     check_message = {"cmd": "kv_tensors_created", "group_id": group_id}
-    tasks = [
-        _send_and_receive_message(rank, check_message, pp_rank)
+    targets = [
+        (target_pp_rank, rank)
+        for target_pp_rank in _target_pp_ranks(pp_rank)
         for rank in range(tp_size)
+    ]
+    tasks = [
+        _send_and_receive_message(rank, check_message, target_pp_rank)
+        for target_pp_rank, rank in targets
     ]
 
     responses = await asyncio.gather(*tasks, return_exceptions=True)
     all_created = True
-    for rank, response in enumerate(responses):
+    for (target_pp_rank, rank), response in zip(targets, responses):
         if isinstance(response, Exception):
             raise RuntimeError(
-                f"Worker {rank} failed to check KV tensors created: {response}"
+                f"Worker pp{target_pp_rank}/rank{rank} failed to check "
+                f"KV tensors created: {response}"
             )
         elif not isinstance(response,
                             dict) or response.get("status") != "success":
             raise RuntimeError(
-                f"Worker {rank} failed to check KV tensors created: {response}"
+                f"Worker pp{target_pp_rank}/rank{rank} failed to check "
+                f"KV tensors created: {response}"
             )
         elif not response.get("created", False):
             all_created = False

--- a/kvcached/tp_ipc_util.py
+++ b/kvcached/tp_ipc_util.py
@@ -129,10 +129,16 @@ def start_worker_listener_thread(rank: int, pp_rank: int = 0):
                 # print(f"Worker {rank} received message: {msg}")
                 group_id: int = msg.get("group_id", 0)
                 if msg["cmd"] == "map_to_kv_tensors":
-                    map_to_kv_tensors(msg["offsets"], group_id=group_id)
+                    if not map_to_kv_tensors(msg["offsets"], group_id=group_id):
+                        raise RuntimeError(
+                            f"Failed to map KV tensors for group_id={group_id}"
+                        )
                     send_msg(conn, {"status": "success"})
                 elif msg["cmd"] == "unmap_from_kv_tensors":
-                    unmap_from_kv_tensors(msg["offsets"], group_id=group_id)
+                    if not unmap_from_kv_tensors(msg["offsets"], group_id=group_id):
+                        raise RuntimeError(
+                            f"Failed to unmap KV tensors for group_id={group_id}"
+                        )
                     send_msg(conn, {"status": "success"})
                 elif msg["cmd"] == "kv_tensors_created":
                     created: bool = kv_tensors_created(group_id=group_id)

--- a/tests/manifests/cpu.txt
+++ b/tests/manifests/cpu.txt
@@ -4,6 +4,7 @@ tests/test_get_max_cached_blocks.py
 tests/test_ipc_name.py
 tests/test_ipc_timeout.py
 tests/test_kv_cache_shape_compat.py
+tests/test_kvcache_manager_post_init.py
 tests/test_make_cache_key.py
 tests/test_memory_limit_control.py
 tests/test_observability.py
@@ -16,7 +17,10 @@ tests/test_sglang_virtual_kv_capacity.py
 tests/test_shm_info_tracker.py
 tests/test_sleep_manager.py
 tests/test_test_classification.py
+tests/test_tp_ipc_pp_fanout.py
+tests/test_tp_ipc_worker_failures.py
 tests/test_vllm_nixl_compat.py
 tests/test_vllm_pool_exhaustion.py
+tests/test_vllm_pp_fanout.py
 tests/test_vllm_tp_world_size.py
 tests/test_vllm_virtual_kv_capacity.py

--- a/tests/test_kvcache_manager_post_init.py
+++ b/tests/test_kvcache_manager_post_init.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import threading
+import types
+from typing import Any
+
+import pytest
+
+
+def _import_kv_cache_manager(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", types.ModuleType("torch"))
+
+    vmm_ops: Any = types.ModuleType("kvcached.vmm_ops")
+    vmm_ops.kv_tensors_created = lambda *args, **kwargs: False
+    vmm_ops.map_to_kv_tensors = lambda *args, **kwargs: True
+    vmm_ops.unmap_from_kv_tensors = lambda *args, **kwargs: True
+    vmm_ops.PageAllocator = object
+    vmm_ops.InternalPage = object
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", vmm_ops)
+
+    interfaces: Any = types.ModuleType(
+        "kvcached.integration.vllm.interfaces"
+    )
+    interfaces.should_use_worker_ipc = lambda: False
+    monkeypatch.setitem(
+        sys.modules, "kvcached.integration.vllm.interfaces", interfaces
+    )
+
+    from kvcached import kv_cache_manager
+
+    return kv_cache_manager
+
+
+def test_post_init_timeout_keeps_last_observed_error(monkeypatch):
+    kv_cache_manager = _import_kv_cache_manager(monkeypatch)
+    manager = kv_cache_manager.KVCacheManager.__new__(
+        kv_cache_manager.KVCacheManager)
+    manager.null_block = None
+    manager.world_size = 1
+    manager.pp_rank = 0
+    manager.group_id = 0
+    manager._post_init_done = threading.Event()
+
+    calls = 0
+
+    def fake_kv_tensors_created(group_id=0):
+        nonlocal calls
+        assert group_id == 0
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("kv tensor map failed")
+        return False
+
+    monkeypatch.setattr(kv_cache_manager, "kv_tensors_created",
+                        fake_kv_tensors_created)
+    monkeypatch.setattr(kv_cache_manager, "KV_TENSOR_WAIT_TIMEOUT", 0.002)
+    monkeypatch.setattr(kv_cache_manager.time, "sleep", lambda _: None)
+
+    with pytest.raises(TimeoutError, match="last error: kv tensor map failed"):
+        manager._post_init()
+
+    assert manager._post_init_done.is_set()
+
+
+def test_broadcast_callbacks_preserve_runtime_group_context(monkeypatch):
+    kv_cache_manager = _import_kv_cache_manager(monkeypatch)
+    calls = []
+
+    class FakePageAllocator:
+        def __init__(self, *args, **kwargs):
+            self.map_callback = None
+            self.unmap_callback = None
+
+        def set_use_worker_ipc(self, enabled):
+            self.use_worker_ipc = enabled
+
+        def set_broadcast_map_callback(self, callback):
+            self.map_callback = callback
+
+        def set_broadcast_unmap_callback(self, callback):
+            self.unmap_callback = callback
+
+        def start_prealloc_thread(self):
+            pass
+
+    monkeypatch.setattr(kv_cache_manager, "PageAllocator", FakePageAllocator)
+    monkeypatch.setattr(kv_cache_manager, "broadcast_kv_tensors_created",
+                        lambda *args, **kwargs: False)
+    monkeypatch.setattr(kv_cache_manager, "KV_TENSOR_WAIT_TIMEOUT", 0.001)
+    monkeypatch.setattr(kv_cache_manager.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        kv_cache_manager.threading,
+        "Thread",
+        lambda *args, **kwargs: types.SimpleNamespace(start=lambda: None),
+    )
+
+    import kvcached.tp_ipc_util as tp_ipc_util
+
+    monkeypatch.setattr(
+        tp_ipc_util,
+        "broadcast_map_to_kv_tensors",
+        lambda world_size, offsets, pp_rank=0, group_id=0: calls.append(
+            ("map", world_size, offsets, pp_rank, group_id)
+        ),
+    )
+    monkeypatch.setattr(
+        tp_ipc_util,
+        "broadcast_unmap_from_kv_tensors",
+        lambda world_size, offsets, pp_rank=0, group_id=0: calls.append(
+            ("unmap", world_size, offsets, pp_rank, group_id)
+        ),
+    )
+
+    manager = kv_cache_manager.KVCacheManager(
+        num_blocks=4,
+        block_size=1,
+        cell_size=1,
+        num_layers=1,
+        world_size=4,
+        pp_rank=2,
+        async_sched=True,
+        group_id=1007,
+    )
+
+    manager.page_allocator.map_callback(4, [1, 2, 3])
+    manager.page_allocator.unmap_callback(4, [4, 5])
+
+    assert calls == [
+        ("map", 4, [1, 2, 3], 2, 1007),
+        ("unmap", 4, [4, 5], 2, 1007),
+    ]

--- a/tests/test_tp_ipc_pp_fanout.py
+++ b/tests/test_tp_ipc_pp_fanout.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import sys
+import types
+from importlib.machinery import ModuleSpec
+from typing import Any
+
+import pytest
+
+
+def _import_tp_ipc_util(monkeypatch):
+    torch = types.ModuleType("torch")
+    torch.__spec__ = ModuleSpec("torch", loader=None)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    vmm_ops: Any = types.ModuleType("kvcached.vmm_ops")
+    vmm_ops.__spec__ = ModuleSpec(vmm_ops.__name__, loader=None)
+    vmm_ops.kv_tensors_created = lambda group_id=0: True
+    vmm_ops.map_to_kv_tensors = lambda offsets, group_id=0: True
+    vmm_ops.unmap_from_kv_tensors = lambda offsets, group_id=0: True
+    monkeypatch.setitem(sys.modules, vmm_ops.__name__, vmm_ops)
+
+    from kvcached import tp_ipc_util
+
+    return tp_ipc_util
+
+
+def test_target_pp_ranks_uses_single_explicit_stage(monkeypatch):
+    tp_ipc_util = _import_tp_ipc_util(monkeypatch)
+    monkeypatch.setenv("KVCACHED_PP_SIZE", "4")
+
+    assert list(tp_ipc_util._target_pp_ranks(2)) == [2]
+
+
+def test_target_pp_ranks_expands_coordinator_marker(monkeypatch):
+    tp_ipc_util = _import_tp_ipc_util(monkeypatch)
+    monkeypatch.setenv("KVCACHED_PP_SIZE", "3")
+
+    assert list(tp_ipc_util._target_pp_ranks(-1)) == [0, 1, 2]
+
+
+def test_broadcast_map_fans_out_to_all_pp_stages(monkeypatch):
+    tp_ipc_util = _import_tp_ipc_util(monkeypatch)
+    calls = []
+
+    async def fake_send(rank, message, pp_rank=0):
+        calls.append((pp_rank, rank, message))
+        return {"status": "success"}
+
+    monkeypatch.setenv("KVCACHED_PP_SIZE", "2")
+    monkeypatch.setattr(tp_ipc_util, "_send_and_receive_message", fake_send)
+
+    asyncio.run(
+        tp_ipc_util._broadcast_map_to_kv_tensors(3, [7, 11], pp_rank=-1)
+    )
+
+    assert [(pp_rank, rank) for pp_rank, rank, _ in calls] == [
+        (0, 0),
+        (0, 1),
+        (0, 2),
+        (1, 0),
+        (1, 1),
+        (1, 2),
+    ]
+    assert all(call[2]["group_id"] == 0 for call in calls)
+
+
+def test_broadcast_error_reports_pp_and_rank(monkeypatch):
+    tp_ipc_util = _import_tp_ipc_util(monkeypatch)
+
+    async def fake_send(rank, message, pp_rank=0):
+        if pp_rank == 1 and rank == 0:
+            return {"status": "error", "message": "boom"}
+        return {"status": "success", "created": True}
+
+    monkeypatch.setenv("KVCACHED_PP_SIZE", "2")
+    monkeypatch.setattr(tp_ipc_util, "_send_and_receive_message", fake_send)
+
+    with pytest.raises(RuntimeError, match="pp1/rank0"):
+        asyncio.run(
+            tp_ipc_util._broadcast_kv_tensors_created(2, pp_rank=-1)
+        )

--- a/tests/test_tp_ipc_worker_failures.py
+++ b/tests/test_tp_ipc_worker_failures.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import sys
+import threading
+import types
+from typing import Any
+
+import pytest
+
+
+class _FakeConnection:
+    def close(self):
+        pass
+
+
+class _FakeServerSocket:
+    def __init__(self):
+        self._accepted = False
+        self._stop = threading.Event()
+
+    def bind(self, path):
+        self.path = path
+
+    def listen(self):
+        pass
+
+    def accept(self):
+        if not self._accepted:
+            self._accepted = True
+            return _FakeConnection(), None
+        self._stop.wait()
+        raise RuntimeError("test listener stopped")
+
+
+@pytest.mark.parametrize("command", ["map_to_kv_tensors", "unmap_from_kv_tensors"])
+def test_worker_reports_vmm_boolean_failures(monkeypatch, command):
+    vmm_ops: Any = types.ModuleType("kvcached.vmm_ops")
+    vmm_ops.kv_tensors_created = lambda group_id=0: True
+    vmm_ops.map_to_kv_tensors = lambda offsets, group_id=0: False
+    vmm_ops.unmap_from_kv_tensors = lambda offsets, group_id=0: False
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", vmm_ops)
+
+    tp_ipc_util = importlib.import_module("kvcached.tp_ipc_util")
+    tp_ipc_util = importlib.reload(tp_ipc_util)
+
+    server = _FakeServerSocket()
+    response = {}
+    completed = threading.Event()
+
+    monkeypatch.setattr(tp_ipc_util.socket, "AF_UNIX", 1, raising=False)
+    monkeypatch.setattr(tp_ipc_util.socket, "SOCK_STREAM", 1, raising=False)
+    monkeypatch.setattr(tp_ipc_util.socket, "socket", lambda *args: server)
+    monkeypatch.setattr(tp_ipc_util.os, "makedirs", lambda *args, **kwargs: None)
+    monkeypatch.setattr(tp_ipc_util.os.path, "exists", lambda path: False)
+    monkeypatch.setattr(
+        tp_ipc_util,
+        "recv_msg",
+        lambda conn: {"cmd": command, "offsets": [7], "group_id": 3},
+    )
+
+    def capture_response(conn, message):
+        response.update(message)
+        completed.set()
+
+    monkeypatch.setattr(tp_ipc_util, "send_msg", capture_response)
+
+    tp_ipc_util.start_worker_listener_thread(rank=0)
+    assert completed.wait(timeout=1)
+    assert response["status"] == "error"
+    assert "group_id=3" in response["message"]

--- a/tests/test_vllm_pp_fanout.py
+++ b/tests/test_vllm_pp_fanout.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import sys
+import types
+from importlib.machinery import ModuleSpec
+from types import SimpleNamespace
+from unittest import mock
+
+
+def test_engine_core_marks_multi_pp_for_fanout(monkeypatch):
+    torch = mock.MagicMock()
+    torch.__version__ = "2.6.0"
+    torch.__spec__ = ModuleSpec("torch", loader=None)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", mock.MagicMock())
+
+    interfaces = importlib.import_module("kvcached.integration.vllm.interfaces")
+    patches = importlib.import_module("kvcached.integration.vllm.patches")
+
+    init_kvcached = mock.Mock()
+    monkeypatch.setattr(interfaces, "init_kvcached", init_kvcached)
+    monkeypatch.setattr(patches, "enable_kvcached", lambda: True)
+
+    engine_mod = types.ModuleType("vllm.v1.engine.core")
+
+    class EngineCore:
+        def __init__(self, vllm_config):
+            self.vllm_config = vllm_config
+
+    setattr(engine_mod, "EngineCore", EngineCore)
+    assert patches.EngineCorePatch().patch_engine_init(engine_mod)
+
+    config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=4,
+            pipeline_parallel_size=2,
+        ),
+        scheduler_config=SimpleNamespace(async_scheduling=False),
+    )
+    EngineCore(config)
+
+    assert init_kvcached.call_args.kwargs["world_size"] == 4
+    assert init_kvcached.call_args.kwargs["pp_rank"] == -1
+    assert init_kvcached.call_args.kwargs["is_worker"] is False
+    assert patches.os.environ["KVCACHED_PP_SIZE"] == "2"

--- a/tests/test_vllm_tp_world_size.py
+++ b/tests/test_vllm_tp_world_size.py
@@ -76,13 +76,16 @@ def test_engine_core_records_tp_world_size_before_original_init(
     assert patches.EngineCorePatch().patch_engine_init(engine_mod)
 
     config = types.SimpleNamespace(
-        parallel_config=types.SimpleNamespace(tensor_parallel_size=4)
+        parallel_config=types.SimpleNamespace(
+            tensor_parallel_size=4, pipeline_parallel_size=1
+        )
     )
     engine_mod.EngineCore(config)
 
     init_kvcached.assert_called_once_with(
         tp_rank=0,
         world_size=4,
+        pp_rank=0,
         is_worker=False,
         async_sched=True,
     )
@@ -110,7 +113,9 @@ def test_engine_core_propagates_kvcached_initialization_failure(
     assert patches.EngineCorePatch().patch_engine_init(engine_mod)
 
     config = types.SimpleNamespace(
-        parallel_config=types.SimpleNamespace(tensor_parallel_size=4)
+        parallel_config=types.SimpleNamespace(
+            tensor_parallel_size=4, pipeline_parallel_size=1
+        )
     )
     with pytest.raises(RuntimeError, match="failed to record TP state"):
         engine_mod.EngineCore(config)


### PR DESCRIPTION
## Summary

Fixes #372.

This PR builds on the PP mapping fix and contains two commits:

1. `fix(vllm): fan out KV mapping across PP stages` preserves the original author and carries only the PP fan-out/context changes.
2. `fix: propagate TP and PP KV mapping failures` adds failure propagation, diagnostics, and regression tests.

## Behavior

- Keep TP ranks local to each PP stage and fan coordinator operations out through PP-specific sockets.
- Preserve each manager's `pp_rank` and `group_id`.
- Reject worker-side map/unmap boolean failures instead of replying success.
- Include the last KV tensor readiness exception in timeout diagnostics.
- Report the failing PP stage and TP rank.

CUDA synchronization changes are intentionally excluded so ordering policy can be evaluated separately from error propagation.

## Validation

```bash
python -m pytest \
  tests/test_tp_ipc_pp_fanout.py \
  tests/test_vllm_pp_fanout.py \
  tests/test_kvcache_manager_post_init.py \
  tests/test_tp_ipc_worker_failures.py -q
```

The focused test run reported `9 passed`.

`ruff`, `isort`, `codespell`, `py_compile`, and `git diff --check` passed. GitHub Actions also passed pre-commit and the MyPy matrix for Python 3.9-3.13.
