### PR TITLE
WIP: adapt vLLM raw KV reshape config

### DIFF
--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -252,15 +252,10 @@ def alloc_kv_cache(
                 for t in raw_kv_tensors
             ]
         else:
-            # Build attention view with as_strided. Two modes:
-            #   split-half (default): K occupies [0, v_offset), V occupies
-            #     [v_offset, 2*v_offset). K/V dim stride = v_offset_eles.
-            #   unified_pool (HYBRID_LINEAR): K and V interleaved per kernel
-            #     block. This mirrors native vLLM's
-            #     _update_hybrid_attention_mamba_layout and lets an attached
-            #     linear-attention / mamba layer read the same flat buffer
-            #     (mamba still indexes by virtual block; each virtual block
-            #     spans ``ratio`` kernel blocks).
+            # Build the attention view with vLLM's native split-half layout:
+            # K occupies [0, v_offset), V occupies [v_offset, 2*v_offset).
+            # HYBRID_LINEAR mamba reshaping is handled later by vLLM's
+            # _update_hybrid_attention_mamba_layout using the raw pool buffers.
             shape = list(kernel_kvcache_shape)
             strides = [0] * len(shape)
             strides[-1] = 1
@@ -268,23 +263,13 @@ def alloc_kv_cache(
                 strides[i] = strides[i + 1] * shape[i + 1]
             # hidden_size_eles uses kernel_block_size (shape[2]), not block_size.
             hidden_size_eles = strides[2] * shape[2]  # = kernel_bs * h * d
-            if unified_pool:
-                # Block-interleaved at kernel granularity: inter-(kernel-)block
-                # stride = 2*hidden_size; K/V dim stride = hidden_size.
-                if blocks_dim_idx == 1:          # FlashAttn (2, N*ratio, ...)
-                    strides[1] = 2 * hidden_size_eles
-                    strides[0] = hidden_size_eles
-                else:                             # FlashInfer (N*ratio, 2, ...)
-                    strides[0] = 2 * hidden_size_eles
-                    strides[1] = hidden_size_eles
-            else:
-                v_offset_eles = gpu_mem_bytes_per_layer_k_or_v // dtype.itemsize
-                if blocks_dim_idx == 1:          # FlashAttn (2, N*ratio, ...)
-                    strides[1] = hidden_size_eles
-                    strides[0] = v_offset_eles
-                else:                             # FlashInfer (N*ratio, 2, ...)
-                    strides[0] = hidden_size_eles
-                    strides[1] = v_offset_eles
+            v_offset_eles = gpu_mem_bytes_per_layer_k_or_v // dtype.itemsize
+            if blocks_dim_idx == 1:          # FlashAttn (2, N*ratio, ...)
+                strides[1] = hidden_size_eles
+                strides[0] = v_offset_eles
+            else:                             # FlashInfer (N*ratio, 2, ...)
+                strides[0] = hidden_size_eles
+                strides[1] = v_offset_eles
             for t in raw_kv_tensors:
                 kv_tensors.append(
                     torch.as_strided(t.view(dtype=dtype), shape, strides))

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -1287,25 +1287,52 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             kv_caches: dict[str, torch.Tensor] = {}
 
             mamba_info = getattr(self, "_kvcached_mamba_raw_info", None)
+            runner_only_attn_layers = set(
+                getattr(kv_cache_config, "runner_only_attn_layers", set())
+            )
+            layer_to_pool_idx = {}
+            for pool_idx, tensor_cfg in enumerate(
+                getattr(kv_cache_config, "kv_cache_tensors", [])
+            ):
+                for layer_name in getattr(tensor_cfg, "shared_by", []):
+                    layer_to_pool_idx[layer_name] = pool_idx
+
+            has_attn = False
+            has_mamba = False
+            kernel_block_sizes: list[int] = []
 
             for kv_cache_group in kv_cache_config.kv_cache_groups:
                 kv_cache_spec = kv_cache_group.kv_cache_spec
+                kernel_block_sizes.append(
+                    int(getattr(kv_cache_spec, "block_size", 0))
+                )
 
                 if _is_mamba_spec(kv_cache_spec):
+                    has_mamba = True
                     if mamba_info is None:
                         raise RuntimeError(
                             "Mamba layers found but no raw buffer info "
                             "available from kvcached"
                         )
                     for pool_idx, layer_name in enumerate(kv_cache_group.layer_names):
+                        pool_idx = layer_to_pool_idx.get(layer_name, pool_idx)
                         state_tensors = _reshape_mamba_non_contiguous(
                             mamba_info["buffers"][pool_idx],
                             kv_cache_spec, get_dtype_size,
                         )
                         kv_caches[layer_name] = state_tensors  # type: ignore[assignment]
                 else:
+                    has_attn = True
                     for pool_idx, layer_name in enumerate(kv_cache_group.layer_names):
+                        if layer_name in runner_only_attn_layers:
+                            continue
+                        pool_idx = layer_to_pool_idx.get(layer_name, pool_idx)
                         kv_caches[layer_name] = kv_cache_raw_tensors[pool_idx]
+
+            if has_attn and has_mamba:
+                self._update_hybrid_attention_mamba_layout(
+                    kv_caches, kernel_block_sizes
+                )
 
             return kv_caches
 

--- a/tests/test_vllm_hybrid_reshape_patch.py
+++ b/tests/test_vllm_hybrid_reshape_patch.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import types
+from importlib.machinery import ModuleSpec
+from types import SimpleNamespace
+
+
+def _install_fake_modules(monkeypatch):
+    torch = types.ModuleType("torch")
+    torch.__spec__ = ModuleSpec("torch", loader=None)
+    torch.Tensor = object
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    vllm = types.ModuleType("vllm")
+    vllm.__path__ = []
+    vllm.__version__ = "0.10.0"
+    vllm.__spec__ = ModuleSpec("vllm", loader=None, is_package=True)
+    monkeypatch.setitem(sys.modules, "vllm", vllm)
+
+    v1 = types.ModuleType("vllm.v1")
+    v1.__path__ = []
+    v1.__spec__ = ModuleSpec("vllm.v1", loader=None, is_package=True)
+    monkeypatch.setitem(sys.modules, "vllm.v1", v1)
+    setattr(vllm, "v1", v1)
+
+    kv_cache_interface = types.ModuleType("vllm.v1.kv_cache_interface")
+    kv_cache_interface.__spec__ = ModuleSpec(kv_cache_interface.__name__, loader=None)
+
+    class FullAttentionSpec:
+        def __init__(self, block_size=16):
+            self.block_size = block_size
+
+    class MambaSpec:
+        def __init__(self, block_size=4):
+            self.block_size = block_size
+
+    kv_cache_interface.FullAttentionSpec = FullAttentionSpec
+    kv_cache_interface.MambaSpec = MambaSpec
+    monkeypatch.setitem(sys.modules, kv_cache_interface.__name__, kv_cache_interface)
+    setattr(v1, "kv_cache_interface", kv_cache_interface)
+
+    utils = types.ModuleType("vllm.utils")
+    utils.__path__ = []
+    utils.__spec__ = ModuleSpec("vllm.utils", loader=None, is_package=True)
+    monkeypatch.setitem(sys.modules, "vllm.utils", utils)
+
+    torch_utils = types.ModuleType("vllm.utils.torch_utils")
+    torch_utils.__spec__ = ModuleSpec(torch_utils.__name__, loader=None)
+    torch_utils.get_dtype_size = lambda dtype: 1
+    monkeypatch.setitem(sys.modules, torch_utils.__name__, torch_utils)
+    setattr(utils, "torch_utils", torch_utils)
+
+    return FullAttentionSpec, MambaSpec
+
+
+def test_hybrid_reshape_uses_shared_pool_mapping_and_updates_layout(monkeypatch):
+    FullAttentionSpec, MambaSpec = _install_fake_modules(monkeypatch)
+
+    from kvcached.integration.vllm import patches
+
+    def fake_reshape_mamba(raw_buffer, kv_cache_spec, get_dtype_size):
+        return [f"mamba-state:{raw_buffer}"]
+
+    monkeypatch.setattr(patches, "_reshape_mamba_non_contiguous", fake_reshape_mamba)
+
+    class GPUModelRunner:
+        def __init__(self):
+            self._kvcached_mamba_raw_info = {
+                "buffers": ["raw-attn-pool", "raw-mamba-pool"]
+            }
+            self.hybrid_layout_calls = []
+
+        def _update_hybrid_attention_mamba_layout(self, kv_caches, kernel_block_sizes):
+            self.hybrid_layout_calls.append((dict(kv_caches), list(kernel_block_sizes)))
+
+    assert patches.GPUModelRunnerPatch().add_reshape_methods(GPUModelRunner) is True
+
+    runner = GPUModelRunner()
+    kv_cache_config = SimpleNamespace(
+        runner_only_attn_layers={"attn.runner_only"},
+        kv_cache_tensors=[
+            SimpleNamespace(shared_by=["attn.0", "attn.runner_only"]),
+            SimpleNamespace(shared_by=["mamba.0"]),
+        ],
+        kv_cache_groups=[
+            SimpleNamespace(
+                kv_cache_spec=FullAttentionSpec(block_size=16),
+                layer_names=["attn.0", "attn.runner_only"],
+            ),
+            SimpleNamespace(
+                kv_cache_spec=MambaSpec(block_size=4),
+                layer_names=["mamba.0"],
+            ),
+        ],
+    )
+
+    kv_caches = runner._reshape_kv_cache_tensors_from_kvcached(
+        kv_cache_config,
+        ["attn-view", "unused-attn-pool"],
+    )
+
+    assert kv_caches == {
+        "attn.0": "attn-view",
+        "mamba.0": ["mamba-state:raw-mamba-pool"],
+    }
+    assert runner.hybrid_layout_calls == [
+        (
+            {
+                "attn.0": "attn-view",
+                "mamba.0": ["mamba-state:raw-mamba-pool"],
+            },
+            [16, 4],
+        )
+    ]


### PR DESCRIPTION
### Summary

Partial follow-up for the related vLLM compatibility issue. This PR is not intended to close any issue by itself.

This narrows the vLLM integration change to the raw KV / hybrid reshape path. It preserves vLLM's split-half attention layout and lets vLLM's hybrid-layout updater handle the Mamba/linear-attention view, while mapping layers through `kv_cache_tensors[*].shared_by` when that metadata is available.

### Current scope

- preserve the native attention KV layout for hybrid raw KV buffers
- map reshaped tensors by `kv_cache_tensors[*].shared_by` when available
- skip `runner_only_attn_layers` during kvcached layer mapping
- call vLLM's hybrid attention/Mamba layout updater when both attention and Mamba groups are present
- avoid claiming full vLLM 0.22+ compatibility in this PR

### Still needed before the related compatibility issue can be closed

- broader vLLM 0.21 / 0.22 / 0.23 compatibility coverage
- smoke tests with real vLLM models and TP configurations
- review of adjacent vLLM API changes beyond reshape handling
- follow-up work for any remaining raw KV config variants

### Validation so far

- `python -m pytest tests/test_vllm_hybrid_reshape_patch.py -q`
- `python -m compileall -q kvcached/integration/vllm tests/test_vllm_hybrid_reshape_patch.py`
- `git diff --check`

Opening this as a draft to make the direction visible early, not as a complete compatibility claim.
