### PR TITLE
feat(sglang): account DeepSeek-V4 runtime reservations

### DIFF
--- a/kvcached/integration/sglang/autopatch.py
+++ b/kvcached/integration/sglang/autopatch.py
@@ -9,6 +9,7 @@ from wrapt.importer import when_imported
 from kvcached.integration.patch_base import PatchManager, log_patch_results
 from kvcached.integration.sglang.patches import (
     SGLANG_ALL_RANGE,
+    DeepSeekV4RuntimeReservationPatch,
     ElasticAllocatorPatch,
     ElasticHybridLinearKVPoolPatch,
     ElasticMambaPoolPatch,
@@ -42,6 +43,7 @@ def _patch_sglang(_sglang: types.ModuleType) -> None:
             (ElasticMLAMemoryPoolPatch(), SGLANG_ALL_RANGE),
             (ElasticMambaPoolPatch(), SGLANG_ALL_RANGE),
             (ElasticHybridLinearKVPoolPatch(), SGLANG_ALL_RANGE),
+            (DeepSeekV4RuntimeReservationPatch(), SGLANG_ALL_RANGE),
             (SchedulerMemoryLeakPatch(), SGLANG_ALL_RANGE),
             (RadixCacheLimitPatch(), SGLANG_ALL_RANGE),
         ]

--- a/kvcached/integration/sglang/autopatch.py
+++ b/kvcached/integration/sglang/autopatch.py
@@ -9,6 +9,7 @@ from wrapt.importer import when_imported
 from kvcached.integration.patch_base import PatchManager, log_patch_results
 from kvcached.integration.sglang.patches import (
     SGLANG_ALL_RANGE,
+    DeepSeekV4RuntimeReservationPatch,
     ElasticAllocatorPatch,
     ElasticHybridLinearKVPoolPatch,
     ElasticMambaPoolPatch,
@@ -43,6 +44,7 @@ def _patch_sglang(_sglang: types.ModuleType) -> None:
             (ElasticMLAMemoryPoolPatch(), SGLANG_ALL_RANGE),
             (ElasticMambaPoolPatch(), SGLANG_ALL_RANGE),
             (ElasticHybridLinearKVPoolPatch(), SGLANG_ALL_RANGE),
+            (DeepSeekV4RuntimeReservationPatch(), SGLANG_ALL_RANGE),
             # Importing ModelRunner captures memory-pool classes in module
             # globals, so apply this only after every pool alias is installed.
             (SGLangVirtualKVCapacityPatch(), ">=0.5.11"),

--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -23,6 +23,7 @@ _async_sched = False
 _contiguous_layout = CONTIGUOUS_LAYOUT
 _world_size: int = 1
 _pp_rank: int = 0
+_runtime_owned_reservations: Dict[str, Dict[str, int]] = {}
 
 
 def init_kvcached(
@@ -55,12 +56,44 @@ def init_kvcached(
 def shutdown_kvcached() -> None:
     global _kvcached_initialized, _kvcached_device, _async_sched
     if not _kvcached_initialized:
+        _runtime_owned_reservations.clear()
         return
 
     _shutdown_kvcached_impl()
     _kvcached_initialized = False
     _kvcached_device = None
     _async_sched = False
+    _runtime_owned_reservations.clear()
+
+
+def register_runtime_owned_reservation(
+    device: str,
+    pool_name: str,
+    num_bytes: int,
+) -> None:
+    """Record memory owned by the serving runtime outside kvcached.
+
+    Some runtimes allocate model-specific side pools that kvcached should not
+    manage directly.  The reservation is still consumed by the same GPU, so
+    kvcached's later virtual KV budgets must subtract it to avoid overbooking
+    colocated pools.
+    """
+    device = normalize_gpu_device(device)
+    if num_bytes < 0:
+        raise ValueError(f"runtime reservation for {pool_name} is negative: {num_bytes}")
+    if num_bytes == 0:
+        return
+    _runtime_owned_reservations.setdefault(device, {})[pool_name] = int(num_bytes)
+
+
+def get_runtime_owned_reservation_bytes(device: str) -> int:
+    device = normalize_gpu_device(device)
+    return sum(_runtime_owned_reservations.get(device, {}).values())
+
+
+def get_runtime_owned_reservation_breakdown(device: str) -> Dict[str, int]:
+    device = normalize_gpu_device(device)
+    return dict(_runtime_owned_reservations.get(device, {}))
 
 
 def alloc_kv_cache(
@@ -102,7 +135,17 @@ def alloc_kv_cache(
     block_size = page_size
     block_mem_size = block_size * math.prod(kvcache_shape[1:]) * dtype.itemsize
 
+    runtime_reserved_bytes = get_runtime_owned_reservation_bytes(device)
     gpu_mem_bytes = torch.cuda.get_device_properties(device).total_memory
+    if runtime_reserved_bytes:
+        gpu_mem_bytes = max(0, gpu_mem_bytes - runtime_reserved_bytes)
+        logger.info(
+            "Reserved %.2f GB for runtime-owned SGLang pools on %s; "
+            "remaining kvcached budget is %.2f GB",
+            runtime_reserved_bytes / (1024**3),
+            device,
+            gpu_mem_bytes / (1024**3),
+        )
     gpu_mem_bytes_per_layer_k_or_v = gpu_mem_bytes // num_layers // num_k_or_v
     # Round down to 2 * PAGE_SIZE for MLA backend.
     # The get_v_base_offset() requires the ftensor size (which equals

--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -32,6 +32,7 @@ _async_sched = False
 _contiguous_layout = CONTIGUOUS_LAYOUT
 _world_size: int = 1
 _pp_rank: int = 0
+_runtime_owned_reservations: Dict[str, Dict[str, int]] = {}
 
 
 def init_kvcached(
@@ -65,6 +66,7 @@ def shutdown_kvcached() -> None:
     global _kvcached_initialized, _kvcached_device, _async_sched
     if not _kvcached_initialized:
         clear_registered_kv_cache_pools(integration="sglang")
+        _runtime_owned_reservations.clear()
         return
 
     _shutdown_kvcached_impl()
@@ -72,6 +74,42 @@ def shutdown_kvcached() -> None:
     _kvcached_initialized = False
     _kvcached_device = None
     _async_sched = False
+    _runtime_owned_reservations.clear()
+
+
+def register_runtime_owned_reservation(
+    device: str,
+    pool_name: str,
+    num_bytes: int,
+) -> None:
+    """Record memory owned by the serving runtime outside kvcached.
+
+    Some runtimes allocate model-specific side pools that kvcached should not
+    manage directly.  The reservation is still consumed by the same GPU, so
+    kvcached's later virtual KV budgets must subtract it to avoid overbooking
+    colocated pools.
+    """
+    device = normalize_gpu_device(device)
+    if num_bytes < 0:
+        raise ValueError(f"runtime reservation for {pool_name} is negative: {num_bytes}")
+    if num_bytes == 0:
+        device_reservations = _runtime_owned_reservations.get(device)
+        if device_reservations is not None:
+            device_reservations.pop(pool_name, None)
+            if not device_reservations:
+                _runtime_owned_reservations.pop(device, None)
+        return
+    _runtime_owned_reservations.setdefault(device, {})[pool_name] = int(num_bytes)
+
+
+def get_runtime_owned_reservation_bytes(device: str) -> int:
+    device = normalize_gpu_device(device)
+    return sum(_runtime_owned_reservations.get(device, {}).values())
+
+
+def get_runtime_owned_reservation_breakdown(device: str) -> Dict[str, int]:
+    device = normalize_gpu_device(device)
+    return dict(_runtime_owned_reservations.get(device, {}))
 
 
 def observability_snapshot():
@@ -141,7 +179,17 @@ def alloc_kv_cache(
     block_size = page_size
     block_mem_size = block_size * math.prod(kvcache_shape[1:]) * dtype.itemsize
 
+    runtime_reserved_bytes = get_runtime_owned_reservation_bytes(device)
     gpu_mem_bytes = torch.cuda.get_device_properties(device).total_memory
+    if runtime_reserved_bytes:
+        gpu_mem_bytes = max(0, gpu_mem_bytes - runtime_reserved_bytes)
+        logger.info(
+            "Reserved %.2f GB for runtime-owned SGLang pools on %s; "
+            "remaining kvcached budget is %.2f GB",
+            runtime_reserved_bytes / (1024**3),
+            device,
+            gpu_mem_bytes / (1024**3),
+        )
     gpu_mem_bytes_per_layer_k_or_v = gpu_mem_bytes // num_layers // num_k_or_v
     # Round down to 2 * PAGE_SIZE for MLA backend.
     # The get_v_base_offset() requires the ftensor size (which equals

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -1370,6 +1370,140 @@ class ElasticHybridLinearKVPoolPatch(VersionAwarePatch, BasePatch):
             return False
 
 
+class DeepSeekV4RuntimeReservationPatch(VersionAwarePatch, BasePatch):
+    """Account for DeepSeek-V4 pools that remain owned by SGLang."""
+
+    library = "sglang"
+    target_module = "sglang.srt.mem_cache.deepseek_v4_memory_pool"
+    patch_name = "deepseek_v4_runtime_reservation"
+
+    def apply(self, dsv4_pool_mod: types.ModuleType) -> bool:
+        if not self.initialize_version_info():
+            return False
+        return self.patch_dsv4_pool_init(dsv4_pool_mod)
+
+    @version_range(SGLANG_ALL_RANGE)
+    def patch_dsv4_pool_init(self, dsv4_pool_mod: types.ModuleType) -> bool:
+        pool_class = getattr(dsv4_pool_mod, "DeepSeekV4TokenToKVPool", None)
+        if pool_class is None:
+            self.logger.debug(
+                "DeepSeekV4TokenToKVPool not found; skipping reservation patch"
+            )
+            return True
+
+        original_init = getattr(pool_class, "__init__", None)
+        if original_init is None:
+            self.logger.warning("DeepSeekV4TokenToKVPool.__init__ not found")
+            return False
+        if self._is_already_patched(original_init):
+            return True
+
+        @functools.wraps(original_init)
+        def _wrapped_init(pool_self: Any, *args: Any, **kwargs: Any) -> None:
+            original_init(pool_self, *args, **kwargs)
+            breakdown = _collect_dsv4_runtime_reservations(pool_self)
+            _register_dsv4_runtime_reservations(pool_self, breakdown)
+
+        self._mark_as_patched(_wrapped_init)
+        pool_class.__init__ = _wrapped_init
+        self.logger.info("Enabled DeepSeek-V4 runtime reservation accounting")
+        return True
+
+
+def _is_kvcached_managed_pool(pool: Any) -> bool:
+    return pool is not None and bool(getattr(pool, "_kvcached_managed", False))
+
+
+def _pool_buffer_nbytes(pool: Any, buffer_name: str) -> int:
+    if pool is None or _is_kvcached_managed_pool(pool):
+        return 0
+    return _sum_buffer_nbytes(getattr(pool, buffer_name, None))
+
+
+def _collect_dsv4_runtime_reservations(kvcache: Any) -> dict[str, int]:
+    return {
+        "dsv4.unified_kv_pool": _pool_buffer_nbytes(
+            getattr(kvcache, "unified_kv_pool", None), "kv_buffer"
+        ),
+        "dsv4.swa_kv_pool": _pool_buffer_nbytes(
+            getattr(kvcache, "swa_kv_pool", None), "kv_buffer"
+        ),
+        "dsv4.c4_kv_pool": _pool_buffer_nbytes(
+            getattr(kvcache, "c4_kv_pool", None), "kv_buffer"
+        ),
+        "dsv4.c128_kv_pool": _pool_buffer_nbytes(
+            getattr(kvcache, "c128_kv_pool", None), "kv_buffer"
+        ),
+        "dsv4.c4_indexer_kv_pool": _pool_buffer_nbytes(
+            getattr(kvcache, "c4_indexer_kv_pool", None),
+            "index_k_with_scale_buffer",
+        ),
+        "dsv4.compress_state_pools": _sum_dsv4_state_pool_nbytes(
+            getattr(kvcache, "compress_state_pools", None)
+        ),
+        "dsv4.indexer_compress_state_pools": _sum_dsv4_state_pool_nbytes(
+            getattr(kvcache, "indexer_compress_state_pools", None)
+        ),
+    }
+
+
+def _register_dsv4_runtime_reservations(
+    kvcache: Any,
+    breakdown: dict[str, int],
+) -> None:
+    import kvcached.integration.sglang.interfaces as kvi
+
+    device = getattr(kvcache, "device", None)
+    if device is None:
+        raise ValueError("DeepSeek-V4 pool does not expose device")
+
+    for pool_name, num_bytes in breakdown.items():
+        kvi.register_runtime_owned_reservation(
+            str(device),
+            pool_name,
+            num_bytes,
+        )
+
+    setattr(kvcache, "_kvcached_runtime_reservation_breakdown", dict(breakdown))
+    logger.info(
+        "Registered DeepSeek-V4 runtime-owned reservations on %s: "
+        "total=%.2f GB, breakdown=%s",
+        device,
+        sum(breakdown.values()) / BYTES_PER_GB,
+        {
+            key: round(value / BYTES_PER_GB, 3)
+            for key, value in breakdown.items()
+            if value > 0
+        },
+    )
+
+
+def _sum_buffer_nbytes(buffers: Any) -> int:
+    if buffers is None:
+        return 0
+    if hasattr(buffers, "nbytes"):
+        return int(buffers.nbytes)
+    return sum(
+        int(getattr(buffer, "nbytes", 0))
+        for buffer in buffers
+        if buffer is not None
+    )
+
+
+def _sum_dsv4_state_pool_nbytes(pools: Any) -> int:
+    if pools is None:
+        return 0
+
+    total = 0
+    for pool in pools:
+        if pool is None or _is_kvcached_managed_pool(pool):
+            continue
+        kv_score_buffer = getattr(pool, "kv_score_buffer", None)
+        kv_score = getattr(kv_score_buffer, "kv_score", None)
+        total += int(getattr(kv_score, "nbytes", 0))
+    return total
+
+
 class SchedulerMemoryLeakPatch(VersionAwarePatch, BasePatch):
     """Patch SGLang scheduler to suppress memory leak check when kvcached is enabled"""
 

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -7,6 +7,7 @@ SGLang-specific patches using unified patch infrastructure.
 
 import inspect
 import math
+import os
 import types
 from typing import Any, Callable, List, Optional, Tuple, Union, cast
 
@@ -32,6 +33,10 @@ def _resolve_tp_device(device: Any, tp_rank: int) -> str:
     if device_str in {"cuda", "hip"}:
         return f"{device_str}:{tp_rank}"
     return str(device)
+
+
+def _env_truthy(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 class _LogicalKVCachedAllocator:
@@ -60,11 +65,14 @@ class _LogicalKVCachedAllocator:
         return block_ids
 
     def free(self, block_ids: Any) -> None:
-        ids = [int(block_id) for block_id in block_ids]
+        ids = [
+            int(block_id)
+            for block_id in block_ids
+            if int(block_id) in self._allocated
+        ]
         for block_id in ids:
-            if block_id in self._allocated:
-                self._allocated.remove(block_id)
-                self._free.append(block_id)
+            self._allocated.remove(block_id)
+            self._free.append(block_id)
 
     def clear(self) -> None:
         self._allocated.clear()
@@ -101,7 +109,11 @@ class _CappedKVCachedAllocator:
         return block_ids
 
     def free(self, block_ids: Any) -> None:
-        ids = [int(block_id) for block_id in block_ids]
+        ids = [
+            int(block_id)
+            for block_id in block_ids
+            if int(block_id) in self._allocated
+        ]
         if not ids:
             return
         self._manager.free(ids)
@@ -280,7 +292,9 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
             paged_mod = alloc_mod
             if not hasattr(paged_mod, "alloc_extend_kernel"):
                 try:
-                    from sglang.srt.mem_cache.allocator import paged as paged_mod
+                    from sglang.srt.mem_cache.allocator import paged as imported_paged_mod
+
+                    paged_mod = imported_paged_mod
                 except Exception:
                     paged_mod = alloc_mod
 
@@ -644,7 +658,7 @@ class ElasticMemoryPoolPatch(VersionAwarePatch, BasePatch):
                             tp_rank, tp_size, pp_rank = 0, 1, 0
 
                     # Initialize kvcached with overlap scheduling to be conservative
-                    target_device = _resolve_tp_device(self.device, tp_rank)
+                    target_device = _resolve_tp_device(getattr(self, "device"), tp_rank)
                     self.device = target_device
                     self._kvcached_tp_rank = tp_rank
                     self._kvcached_tp_size = tp_size
@@ -657,7 +671,7 @@ class ElasticMemoryPoolPatch(VersionAwarePatch, BasePatch):
                         async_sched=True,
                     )
 
-                    if not _is_supported_gpu_device(self.device):
+                    if not _is_supported_gpu_device(target_device):
                         raise ValueError(
                             "ElasticMHATokenToKVPool only supports GPU devices "
                             "(cuda/hip)")
@@ -792,11 +806,14 @@ class ElasticMLAMemoryPoolPatch(VersionAwarePatch, BasePatch):
                         self.use_nsa and dtype == torch.float8_e4m3fn
                     )
                     override_kv_cache_dim = kwargs.get("override_kv_cache_dim", None)
-                    self.kv_cache_dim = (
+                    kv_cache_dim = (
                         override_kv_cache_dim
                         if self.use_nsa and self.nsa_kv_cache_store_fp8
                         else (kv_lora_rank + qk_rope_head_dim)
                     )
+                    if kv_cache_dim is None:
+                        kv_cache_dim = kv_lora_rank + qk_rope_head_dim
+                    self.kv_cache_dim = int(kv_cache_dim)
                     # Attributes from parent that we skip but inherited methods may need
                     self.custom_mem_pool = None
 
@@ -833,7 +850,7 @@ class ElasticMLAMemoryPoolPatch(VersionAwarePatch, BasePatch):
                         async_sched=True,
                     )
 
-                    if not _is_supported_gpu_device(device):
+                    if not _is_supported_gpu_device(target_device):
                         raise ValueError(
                             "ElasticMLATokenToKVPool only supports GPU devices "
                             "(cuda/hip)")
@@ -1428,6 +1445,147 @@ class ElasticHybridLinearKVPoolPatch(VersionAwarePatch, BasePatch):
             self.logger.warning(
                 f"Failed to alias HybridLinearKVPool to elastic one: {e}")
             return False
+
+
+class DeepSeekV4RuntimeReservationPatch(VersionAwarePatch, BasePatch):
+    """Account SGLang DeepSeek-V4 runtime-owned pools without taking ownership.
+
+    DeepSeek-V4 keeps model-specific side pools for SWA KV, compressed KV,
+    indexer KV, and compressor state.  kvcached should not bind allocators to
+    those fast-moving implementation details yet, but it must subtract their
+    physical footprint before budgeting elastic KV for colocated models.
+    """
+
+    library = "sglang"
+    target_module = "sglang.srt.mem_cache.deepseek_v4_memory_pool"
+    patch_name = "deepseek_v4_runtime_reservation"
+
+    def apply(self, dsv4_pool_mod: types.ModuleType) -> bool:
+        if not _env_truthy("KVCACHED_SGLANG_DSV4_RUNTIME_RESERVATION"):
+            self.logger.debug(
+                "DeepSeek-V4 runtime reservation accounting disabled by env"
+            )
+            return True
+
+        if not self.initialize_version_info():
+            return False
+
+        return self.patch_dsv4_pool_init(dsv4_pool_mod)
+
+    @version_range(SGLANG_ALL_RANGE)
+    def patch_dsv4_pool_init(self, dsv4_pool_mod: types.ModuleType) -> bool:
+        DeepSeekV4TokenToKVPool = getattr(dsv4_pool_mod, "DeepSeekV4TokenToKVPool", None)
+        if DeepSeekV4TokenToKVPool is None:
+            self.logger.debug("DeepSeekV4TokenToKVPool not found; skipping reservation patch")
+            return True
+
+        original_init = getattr(DeepSeekV4TokenToKVPool, "__init__", None)
+        if original_init is None:
+            self.logger.warning("DeepSeekV4TokenToKVPool.__init__ not found")
+            return False
+        if self._is_already_patched(original_init):
+            self.logger.debug("DeepSeek-V4 runtime reservation patch already applied")
+            return True
+
+        def _wrapped_init(pool_self: Any, *args: Any, **kwargs: Any) -> None:
+            original_init(pool_self, *args, **kwargs)
+            try:
+                breakdown = _collect_dsv4_runtime_reservations(pool_self)
+                _register_dsv4_runtime_reservations(pool_self, breakdown)
+            except Exception as exc:
+                if os.getenv("KVCACHED_REQUIRE", "false").lower() in {
+                    "1",
+                    "true",
+                    "yes",
+                    "on",
+                }:
+                    raise
+                self.logger.warning(
+                    "DeepSeek-V4 runtime reservation accounting unavailable: %s",
+                    exc,
+                )
+
+        self._mark_as_patched(_wrapped_init)
+        DeepSeekV4TokenToKVPool.__init__ = _wrapped_init
+        self.logger.info("Enabled DeepSeek-V4 runtime reservation accounting")
+        return True
+
+
+def _collect_dsv4_runtime_reservations(kvcache: Any) -> dict[str, int]:
+    return {
+        "dsv4.swa_kv_pool": _sum_buffer_nbytes(
+            getattr(getattr(kvcache, "swa_kv_pool", None), "kv_buffer", None)
+        ),
+        "dsv4.c4_kv_pool": _sum_buffer_nbytes(
+            getattr(getattr(kvcache, "c4_kv_pool", None), "kv_buffer", None)
+        ),
+        "dsv4.c128_kv_pool": _sum_buffer_nbytes(
+            getattr(getattr(kvcache, "c128_kv_pool", None), "kv_buffer", None)
+        ),
+        "dsv4.c4_indexer_kv_pool": _sum_buffer_nbytes(
+            getattr(
+                getattr(kvcache, "c4_indexer_kv_pool", None),
+                "index_k_with_scale_buffer",
+                None,
+            )
+        ),
+        "dsv4.compress_state_pools": _sum_dsv4_state_pool_nbytes(
+            getattr(kvcache, "compress_state_pools", None)
+        ),
+        "dsv4.indexer_compress_state_pools": _sum_dsv4_state_pool_nbytes(
+            getattr(kvcache, "indexer_compress_state_pools", None)
+        ),
+    }
+
+
+def _register_dsv4_runtime_reservations(kvcache: Any, breakdown: dict[str, int]) -> None:
+    import kvcached.integration.sglang.interfaces as kvi
+
+    device = getattr(kvcache, "device", None)
+    if device is None:
+        raise ValueError("DeepSeek-V4 pool does not expose device")
+
+    total_bytes = 0
+    for pool_name, num_bytes in breakdown.items():
+        if num_bytes <= 0:
+            continue
+        kvi.register_runtime_owned_reservation(str(device), pool_name, num_bytes)
+        total_bytes += num_bytes
+
+    setattr(kvcache, "_kvcached_runtime_reservation_breakdown", dict(breakdown))
+    logger.info(
+        "Registered DeepSeek-V4 runtime-owned reservations on %s: total=%.2f GB, "
+        "breakdown=%s",
+        device,
+        total_bytes / BYTES_PER_GB,
+        {
+            key: round(value / BYTES_PER_GB, 3)
+            for key, value in breakdown.items()
+            if value > 0
+        },
+    )
+
+
+def _sum_buffer_nbytes(buffers: Any) -> int:
+    if buffers is None:
+        return 0
+    if hasattr(buffers, "nbytes"):
+        return int(buffers.nbytes)
+    return sum(int(getattr(buffer, "nbytes", 0)) for buffer in buffers if buffer is not None)
+
+
+def _sum_dsv4_state_pool_nbytes(pools: Any) -> int:
+    if pools is None:
+        return 0
+
+    total = 0
+    for pool in pools:
+        if pool is None:
+            continue
+        kv_score_buffer = getattr(pool, "kv_score_buffer", None)
+        kv_score = getattr(kv_score_buffer, "kv_score", None)
+        total += int(getattr(kv_score, "nbytes", 0))
+    return total
 
 
 class SchedulerMemoryLeakPatch(VersionAwarePatch, BasePatch):

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -27,6 +27,121 @@ def _is_supported_gpu_device(device: str) -> bool:
     return device_str.startswith("cuda") or device_str.startswith("hip")
 
 
+def _resolve_tp_device(device: Any, tp_rank: int) -> str:
+    device_str = str(device).lower()
+    if device_str in {"cuda", "hip"}:
+        return f"{device_str}:{tp_rank}"
+    return str(device)
+
+
+class _LogicalKVCachedAllocator:
+    def __init__(self, capacity_blocks: int) -> None:
+        self._capacity_blocks = capacity_blocks
+        self._allocated: set[int] = set()
+        self._free: list[int] = []
+        self._next = 1
+
+    def available_size(self) -> int:
+        return max(0, self._capacity_blocks - len(self._allocated))
+
+    def alloc(self, need_size: int):
+        if need_size <= 0:
+            return []
+        if need_size > self.available_size():
+            return None
+
+        block_ids: list[int] = []
+        while self._free and len(block_ids) < need_size:
+            block_ids.append(self._free.pop())
+        while len(block_ids) < need_size:
+            block_ids.append(self._next)
+            self._next += 1
+        self._allocated.update(block_ids)
+        return block_ids
+
+    def free(self, block_ids: Any) -> None:
+        ids = [int(block_id) for block_id in block_ids]
+        for block_id in ids:
+            if block_id in self._allocated:
+                self._allocated.remove(block_id)
+                self._free.append(block_id)
+
+    def clear(self) -> None:
+        self._allocated.clear()
+        self._free.clear()
+        self._next = 1
+
+
+class _CappedKVCachedAllocator:
+    def __init__(self, manager: Any, capacity_blocks: int) -> None:
+        self._manager = manager
+        self._capacity_blocks = capacity_blocks
+        self._allocated: set[int] = set()
+
+    def available_size(self) -> int:
+        return max(0, self._capacity_blocks - len(self._allocated))
+
+    def _physical_available_size(self) -> int:
+        try:
+            return int(self._manager.available_size())
+        except Exception:
+            return self.available_size()
+
+    def alloc(self, need_size: int):
+        if need_size <= 0:
+            return []
+        if need_size > self.available_size():
+            return None
+        if need_size > self._physical_available_size():
+            return None
+        block_ids = self._manager.alloc(need_size)
+        if block_ids is None:
+            return None
+        self._allocated.update(int(block_id) for block_id in block_ids)
+        return block_ids
+
+    def free(self, block_ids: Any) -> None:
+        ids = [int(block_id) for block_id in block_ids]
+        if not ids:
+            return
+        self._manager.free(ids)
+        for block_id in ids:
+            self._allocated.discard(block_id)
+
+    def clear(self) -> None:
+        if not self._allocated:
+            return
+        self.free(list(self._allocated))
+
+
+def _new_tp_scoped_kvcached_allocator(
+    kvi: Any,
+    *,
+    tp_rank: int,
+    tp_size: int,
+    num_blocks: int,
+    block_size: int,
+    cell_size: int,
+    num_layers: int,
+    reserve_null_block: bool = True,
+    num_kv_buffers: int = 2,
+    group_id: int = 0,
+) -> Any:
+    logical_capacity = max(0, num_blocks - (1 if reserve_null_block else 0))
+    if tp_rank != 0 and tp_size > 1:
+        return _LogicalKVCachedAllocator(logical_capacity)
+    manager = kvi.get_kv_cache_manager(
+        num_blocks=num_blocks,
+        block_size=block_size,
+        cell_size=cell_size,
+        num_layers=num_layers,
+        reserve_null_block=reserve_null_block,
+        num_kv_buffers=num_kv_buffers,
+        group_id=group_id,
+    )
+    return _CappedKVCachedAllocator(manager, logical_capacity)
+
+
 class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
     """Inject ElasticTokenToKVPoolAllocator into SGLang's allocator module"""
 
@@ -68,10 +183,23 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
             import torch
 
             BaseTokenToKVPoolAllocator = getattr(alloc_mod, "BaseTokenToKVPoolAllocator")
+            NativeTokenToKVPoolAllocator = getattr(
+                alloc_mod, "TokenToKVPoolAllocator", None
+            )
 
             class ElasticTokenToKVPoolAllocator(
                 BaseTokenToKVPoolAllocator  # type: ignore[misc, valid-type]
             ):
+                def __new__(
+                    cls, size: int, dtype, device: str, kvcache, *args, **kwargs
+                ):
+                    if not hasattr(kvcache, "kvcached_allocator"):
+                        if NativeTokenToKVPoolAllocator is not None:
+                            return NativeTokenToKVPoolAllocator(
+                                size, dtype, device, kvcache, *args, **kwargs
+                            )
+                    return super().__new__(cls)
+
                 def __init__(self, size: int, dtype, device: str, kvcache, *args, **kwargs) -> None:
                     super().__init__(size, 1, dtype, device, kvcache, *args, **kwargs)
                     if not hasattr(kvcache, "kvcached_allocator"):
@@ -149,15 +277,42 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
         try:
             import torch
 
+            paged_mod = alloc_mod
+            if not hasattr(paged_mod, "alloc_extend_kernel"):
+                try:
+                    from sglang.srt.mem_cache.allocator import paged as paged_mod
+                except Exception:
+                    paged_mod = alloc_mod
+
             BaseTokenToKVPoolAllocator = getattr(alloc_mod, "BaseTokenToKVPoolAllocator")
-            alloc_extend_kernel = getattr(alloc_mod, "alloc_extend_kernel")
-            alloc_decode_kernel = getattr(alloc_mod, "alloc_decode_kernel")
+            NativePagedTokenToKVPoolAllocator = getattr(
+                alloc_mod, "PagedTokenToKVPoolAllocator", None
+            )
+            alloc_extend_kernel = getattr(paged_mod, "alloc_extend_kernel")
+            alloc_decode_kernel = getattr(paged_mod, "alloc_decode_kernel")
+            extend_kernel_fn = getattr(alloc_extend_kernel, "fn", alloc_extend_kernel)
+            try:
+                extend_kernel_param_count = len(
+                    inspect.signature(extend_kernel_fn).parameters
+                )
+            except (TypeError, ValueError):
+                extend_kernel_param_count = 8
 
             from sglang.srt.utils import get_num_new_pages, next_power_of_2
 
             class ElasticPagedTokenToKVPoolAllocator(
                 BaseTokenToKVPoolAllocator  # type: ignore[misc, valid-type]
             ):
+                def __new__(
+                    cls, size: int, page_size: int, dtype, device: str, kvcache, *args, **kwargs
+                ):
+                    if not hasattr(kvcache, "kvcached_allocator"):
+                        if NativePagedTokenToKVPoolAllocator is not None:
+                            return NativePagedTokenToKVPoolAllocator(
+                                size, page_size, dtype, device, kvcache, *args, **kwargs
+                            )
+                    return super().__new__(cls)
+
                 def __init__(
                     self, size: int, page_size: int, dtype, device: str, kvcache, *args, **kwargs
                 ) -> None:
@@ -205,6 +360,7 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
                     seq_lens_cpu: torch.Tensor,
                     last_loc: torch.Tensor,
                     extend_num_tokens: int,
+                    num_new_pages: Optional[int] = None,
                 ):
                     self.seen_max_num_extend_tokens_next_power_of_2 = max(
                         self.seen_max_num_extend_tokens_next_power_of_2,
@@ -212,11 +368,12 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
                     )
                     bs = len(prefix_lens)
 
-                    num_new_pages = get_num_new_pages(
-                        seq_lens=seq_lens_cpu,
-                        page_size=self.page_size,
-                        prefix_lens=prefix_lens_cpu,
-                    )
+                    if num_new_pages is None:
+                        num_new_pages = get_num_new_pages(
+                            seq_lens=seq_lens_cpu,
+                            page_size=self.page_size,
+                            prefix_lens=prefix_lens_cpu,
+                        )
 
                     if num_new_pages > 0:
                         block_ids = self.kvcached_allocator.alloc(num_new_pages)
@@ -231,16 +388,27 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
                     out_indices = torch.empty(
                         (extend_num_tokens,), dtype=torch.int64, device=self.device
                     )
-                    alloc_extend_kernel[(bs,)](
-                        prefix_lens,
-                        seq_lens,
-                        last_loc,
-                        free_pages,
-                        out_indices,
-                        next_power_of_2(bs),
-                        self.page_size,
-                        self.seen_max_num_extend_tokens_next_power_of_2,
-                    )
+                    if extend_kernel_param_count >= 8:
+                        alloc_extend_kernel[(bs,)](
+                            prefix_lens,
+                            seq_lens,
+                            last_loc,
+                            free_pages,
+                            out_indices,
+                            next_power_of_2(bs),
+                            self.page_size,
+                            self.seen_max_num_extend_tokens_next_power_of_2,
+                        )
+                    else:
+                        alloc_extend_kernel[(bs,)](
+                            prefix_lens,
+                            seq_lens,
+                            last_loc,
+                            free_pages,
+                            out_indices,
+                            next_power_of_2(bs),
+                            self.page_size,
+                        )
                     return out_indices
 
                 def alloc_decode(
@@ -312,6 +480,12 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
                 "ElasticPagedTokenToKVPoolAllocator",
                 ElasticPagedTokenToKVPoolAllocator,
             )
+            if paged_mod is not alloc_mod:
+                setattr(
+                    paged_mod,
+                    "ElasticPagedTokenToKVPoolAllocator",
+                    ElasticPagedTokenToKVPoolAllocator,
+                )
             return True
         except Exception as e:
             self.logger.error(f"Failed to inject ElasticPagedTokenToKVPoolAllocator: {e}")
@@ -330,6 +504,12 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
             if ElasticPagedTokenToKVPoolAllocator is None:
                 return False
             alloc_mod.PagedTokenToKVPoolAllocator = ElasticPagedTokenToKVPoolAllocator  # type: ignore
+            try:
+                from sglang.srt.mem_cache.allocator import paged as paged_mod
+
+                paged_mod.PagedTokenToKVPoolAllocator = ElasticPagedTokenToKVPoolAllocator  # type: ignore[attr-defined]
+            except Exception:
+                pass
             self._mark_as_patched(alloc_mod, "__kvcached_paged_allocator_aliased__")
             return True
         except Exception as e:
@@ -408,9 +588,17 @@ class ElasticMemoryPoolPatch(VersionAwarePatch, BasePatch):
                     )
                     import kvcached.integration.sglang.interfaces as kvi
 
-                    self.cell_size = self.head_num * self.head_dim * dtype.itemsize
-                    self.kvcached_allocator = kvi.get_kv_cache_manager(
-                        math.ceil(size / page_size) + 1, page_size, self.cell_size, layer_num,
+                    self.cell_size = (
+                        self.head_num * self.head_dim * self._storage_dtype().itemsize
+                    )
+                    self.kvcached_allocator = _new_tp_scoped_kvcached_allocator(
+                        kvi,
+                        tp_rank=getattr(self, "_kvcached_tp_rank", 0),
+                        tp_size=getattr(self, "_kvcached_tp_size", 1),
+                        num_blocks=math.ceil(size / page_size) + 1,
+                        block_size=page_size,
+                        cell_size=self.cell_size,
+                        num_layers=layer_num,
                         group_id=self._group_id,
                     )
 
@@ -456,7 +644,18 @@ class ElasticMemoryPoolPatch(VersionAwarePatch, BasePatch):
                             tp_rank, tp_size, pp_rank = 0, 1, 0
 
                     # Initialize kvcached with overlap scheduling to be conservative
-                    kvi.init_kvcached(tp_rank=tp_rank, world_size=tp_size, pp_rank=pp_rank, async_sched=True)
+                    target_device = _resolve_tp_device(self.device, tp_rank)
+                    self.device = target_device
+                    self._kvcached_tp_rank = tp_rank
+                    self._kvcached_tp_size = tp_size
+                    self._kvcached_pp_rank = pp_rank
+                    kvi.init_kvcached(
+                        tp_rank=tp_rank,
+                        world_size=tp_size,
+                        pp_rank=pp_rank,
+                        device=target_device,
+                        async_sched=True,
+                    )
 
                     if not _is_supported_gpu_device(self.device):
                         raise ValueError(
@@ -470,8 +669,8 @@ class ElasticMemoryPoolPatch(VersionAwarePatch, BasePatch):
                                 self.head_num,
                                 self.head_dim,
                             ),
-                            dtype=self.dtype,
-                            device=self.device,
+                            dtype=self._storage_dtype(),
+                            device=target_device,
                             num_layers=self.layer_num,
                             page_size=self.page_size,
                             attention_type="MHA",
@@ -488,12 +687,15 @@ class ElasticMemoryPoolPatch(VersionAwarePatch, BasePatch):
                     """
                     total_tokens = self.size + self.page_size
                     elems_per_token = self.head_num * self.head_dim
-                    bytes_per_elem = self.dtype.itemsize
+                    bytes_per_elem = self._storage_dtype().itemsize
 
                     k_size_bytes = self.layer_num * total_tokens * elems_per_token * bytes_per_elem
                     v_size_bytes = k_size_bytes
 
                     return k_size_bytes, v_size_bytes
+
+                def _storage_dtype(self):
+                    return getattr(self, "store_dtype", self.dtype)
 
             setattr(mem_pool_mod, "ElasticMHATokenToKVPool", ElasticMHATokenToKVPool)
             return True
@@ -621,7 +823,15 @@ class ElasticMLAMemoryPoolPatch(VersionAwarePatch, BasePatch):
                         except Exception:
                             tp_rank, tp_size, pp_rank = 0, 1, 0
 
-                    kvi.init_kvcached(tp_rank=tp_rank, world_size=tp_size, pp_rank=pp_rank, async_sched=True)
+                    target_device = _resolve_tp_device(device, tp_rank)
+                    self.device = target_device
+                    kvi.init_kvcached(
+                        tp_rank=tp_rank,
+                        world_size=tp_size,
+                        pp_rank=pp_rank,
+                        device=target_device,
+                        async_sched=True,
+                    )
 
                     if not _is_supported_gpu_device(device):
                         raise ValueError(
@@ -636,7 +846,7 @@ class ElasticMLAMemoryPoolPatch(VersionAwarePatch, BasePatch):
                                 self.kv_cache_dim,
                             ),
                             dtype=dtype,
-                            device=device,
+                            device=target_device,
                             num_layers=layer_num,
                             page_size=page_size,
                             attention_type="MLA",
@@ -650,8 +860,14 @@ class ElasticMLAMemoryPoolPatch(VersionAwarePatch, BasePatch):
                     )
 
                     self.cell_size = (kv_lora_rank + qk_rope_head_dim) * dtype.itemsize
-                    self.kvcached_allocator = kvi.get_kv_cache_manager(
-                        size + page_size, page_size, self.cell_size, layer_num,
+                    self.kvcached_allocator = _new_tp_scoped_kvcached_allocator(
+                        kvi,
+                        tp_rank=tp_rank,
+                        tp_size=tp_size,
+                        num_blocks=size + page_size,
+                        block_size=page_size,
+                        cell_size=self.cell_size,
+                        num_layers=layer_num,
                         num_kv_buffers=1,
                     )
 
@@ -871,18 +1087,21 @@ class ElasticMambaPoolPatch(VersionAwarePatch, BasePatch):
 
                     kvi.init_kvcached(
                         tp_rank=tp_rank, world_size=tp_size,
-                        pp_rank=pp_rank, async_sched=True,
+                        pp_rank=pp_rank,
+                        device=_resolve_tp_device(device, tp_rank),
+                        async_sched=True,
                     )
 
                     if not _is_supported_gpu_device(device):
                         raise ValueError(
                             "ElasticMambaPool only supports GPU devices (cuda/hip)")
+                    target_device = _resolve_tp_device(device, tp_rank)
 
                     self._group_id = ElasticMambaPool._next_group_id
                     ElasticMambaPool._next_group_id += 1
 
                     self.size = size
-                    self.device = device
+                    self.device = target_device
                     # SGLang passes the layer list as either a mamba_layer_ids
                     # kwarg or cache_params.layers, depending on version.
                     if mamba_layer_ids is not None:
@@ -905,7 +1124,7 @@ class ElasticMambaPoolPatch(VersionAwarePatch, BasePatch):
                         num_slots=num_slots,
                         num_mamba_layers=num_mamba_layers,
                         cache_params=cache_params,
-                        device=device,
+                        device=target_device,
                         group_id=self._group_id,
                     )
                     self._kvcached_layout = layout
@@ -937,7 +1156,7 @@ class ElasticMambaPoolPatch(VersionAwarePatch, BasePatch):
                                     temporal_state_shape[2],
                                 ),
                                 dtype=cache_params.dtype.temporal,
-                                device="cuda",
+                                device=target_device,
                             )
                             intermediate_conv_window_cache = [
                                 torch.zeros(
@@ -949,7 +1168,7 @@ class ElasticMambaPoolPatch(VersionAwarePatch, BasePatch):
                                         conv_shape[1],
                                     ),
                                     dtype=cache_params.dtype.conv,
-                                    device="cuda",
+                                    device=target_device,
                                 )
                                 for conv_shape in conv_state_shape
                             ]
@@ -974,7 +1193,10 @@ class ElasticMambaPoolPatch(VersionAwarePatch, BasePatch):
 
                     # block_size=1 → one block == one mamba slot.
                     # num_kv_buffers=1 → single super-cell per slot per layer.
-                    self.kvcached_allocator = kvi.get_kv_cache_manager(
+                    self.kvcached_allocator = _new_tp_scoped_kvcached_allocator(
+                        kvi,
+                        tp_rank=tp_rank,
+                        tp_size=tp_size,
                         num_blocks=num_slots,
                         block_size=1,
                         cell_size=layout["cell_size"],

--- a/tests/manifests/cpu.txt
+++ b/tests/manifests/cpu.txt
@@ -12,6 +12,7 @@ tests/test_prefix_cache.py
 tests/test_resize_reserved_order.py
 tests/test_sglang_allocator_patch.py
 tests/test_sglang_autopatch_order.py
+tests/test_sglang_dsv4_runtime_reservation_patch.py
 tests/test_sglang_virtual_kv_capacity.py
 tests/test_shm_info_tracker.py
 tests/test_sleep_manager.py

--- a/tests/test_sglang_dsv4_runtime_reservation_patch.py
+++ b/tests/test_sglang_dsv4_runtime_reservation_patch.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import sys
+import types
+from typing import Any
+from unittest import mock
+
+
+class FakeTensor:
+    def __init__(self, nbytes=0):
+        self.nbytes = nbytes
+        self.views = []
+
+    def view(self, *args, **kwargs):
+        self.views.append((args, kwargs))
+        return self
+
+    def __getitem__(self, _key):
+        return self
+
+
+def _load_sglang_modules(monkeypatch):
+    torch_mock = mock.MagicMock()
+    torch_mock.__version__ = "2.6.0"
+    torch_mock.cuda.is_available.return_value = True
+    torch_mock.cuda.current_device.return_value = 0
+    torch_mock.cuda.get_device_properties.return_value = types.SimpleNamespace(
+        total_memory=64 * 1024 * 1024
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch_mock)
+    monkeypatch.setitem(sys.modules, "torch.cuda", torch_mock.cuda)
+    monkeypatch.setitem(sys.modules, "posix_ipc", mock.MagicMock())
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", mock.MagicMock())
+
+    from kvcached.integration.sglang import interfaces, patches
+
+    importlib.reload(interfaces)
+    importlib.reload(patches)
+    return interfaces, patches, torch_mock
+
+
+def test_dsv4_runtime_reservation_patch_registers_per_pool_breakdown(monkeypatch):
+    interfaces, patches, _torch_mock = _load_sglang_modules(monkeypatch)
+    monkeypatch.setenv("KVCACHED_SGLANG_DSV4_RUNTIME_RESERVATION", "1")
+    fake_mod: Any = types.SimpleNamespace()
+    registrations: list[tuple[str, str, int]] = []
+
+    class DeepSeekV4TokenToKVPool:
+        def __init__(self):
+            self.device = "cuda:0"
+            self.swa_kv_pool = types.SimpleNamespace(
+                kv_buffer=[FakeTensor(11), FakeTensor(13)]
+            )
+            self.c4_kv_pool = types.SimpleNamespace(kv_buffer=[FakeTensor(17)])
+            self.c128_kv_pool = types.SimpleNamespace(kv_buffer=[FakeTensor(19)])
+            self.c4_indexer_kv_pool = types.SimpleNamespace(
+                index_k_with_scale_buffer=[FakeTensor(23)]
+            )
+            self.compress_state_pools = [
+                types.SimpleNamespace(
+                    kv_score_buffer=types.SimpleNamespace(kv_score=FakeTensor(29))
+                ),
+                None,
+            ]
+            self.indexer_compress_state_pools = [
+                types.SimpleNamespace(
+                    kv_score_buffer=types.SimpleNamespace(kv_score=FakeTensor(31))
+                )
+            ]
+
+    fake_mod.DeepSeekV4TokenToKVPool = DeepSeekV4TokenToKVPool
+    monkeypatch.setattr(
+        patches.DeepSeekV4RuntimeReservationPatch,
+        "initialize_version_info",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        interfaces,
+        "register_runtime_owned_reservation",
+        lambda device, pool, num_bytes: registrations.append((device, pool, num_bytes)),
+    )
+
+    patch = patches.DeepSeekV4RuntimeReservationPatch()
+    assert patch.apply(fake_mod)
+
+    pool: Any = fake_mod.DeepSeekV4TokenToKVPool()
+
+    assert registrations == [
+        ("cuda:0", "dsv4.swa_kv_pool", 24),
+        ("cuda:0", "dsv4.c4_kv_pool", 17),
+        ("cuda:0", "dsv4.c128_kv_pool", 19),
+        ("cuda:0", "dsv4.c4_indexer_kv_pool", 23),
+        ("cuda:0", "dsv4.compress_state_pools", 29),
+        ("cuda:0", "dsv4.indexer_compress_state_pools", 31),
+    ]
+    assert pool._kvcached_runtime_reservation_breakdown == {
+        "dsv4.swa_kv_pool": 24,
+        "dsv4.c4_kv_pool": 17,
+        "dsv4.c128_kv_pool": 19,
+        "dsv4.c4_indexer_kv_pool": 23,
+        "dsv4.compress_state_pools": 29,
+        "dsv4.indexer_compress_state_pools": 31,
+    }
+
+
+def test_dsv4_runtime_reservation_patch_is_opt_in(monkeypatch):
+    _interfaces, patches, _torch_mock = _load_sglang_modules(monkeypatch)
+    fake_mod: Any = types.SimpleNamespace()
+    calls: list[str] = []
+
+    class DeepSeekV4TokenToKVPool:
+        def __init__(self):
+            calls.append("original")
+
+    fake_mod.DeepSeekV4TokenToKVPool = DeepSeekV4TokenToKVPool
+    monkeypatch.setattr(
+        patches.DeepSeekV4RuntimeReservationPatch,
+        "initialize_version_info",
+        lambda self: (_ for _ in ()).throw(
+            AssertionError("version check should not run when env is unset")
+        ),
+    )
+
+    patch = patches.DeepSeekV4RuntimeReservationPatch()
+    assert patch.apply(fake_mod)
+
+    pool = fake_mod.DeepSeekV4TokenToKVPool()
+    assert calls == ["original"]
+    assert not hasattr(pool, "_kvcached_runtime_reservation_breakdown")
+
+
+def test_sglang_alloc_kv_cache_subtracts_runtime_owned_reservations(monkeypatch):
+    interfaces, _patches, torch_mock = _load_sglang_modules(monkeypatch)
+    page_size = interfaces.PAGE_SIZE
+    captured: dict[str, Any] = {}
+
+    torch_mock.cuda.get_device_properties.return_value = types.SimpleNamespace(
+        total_memory=16 * page_size
+    )
+
+    def fake_create_kv_tensors(mem_size, *args, **kwargs):
+        captured["mem_size"] = mem_size
+        return [FakeTensor()]
+
+    monkeypatch.setattr(interfaces, "create_kv_tensors", fake_create_kv_tensors)
+    monkeypatch.setattr(interfaces, "_kvcached_initialized", True)
+    monkeypatch.setattr(interfaces, "_contiguous_layout", False)
+    interfaces._runtime_owned_reservations.clear()
+    interfaces.register_runtime_owned_reservation("cuda:0", "dsv4.swa_kv_pool", 3 * page_size)
+
+    interfaces.alloc_kv_cache(
+        kvcache_shape=(1, 1, 1),
+        dtype=types.SimpleNamespace(itemsize=1),
+        device="cuda:0",
+        num_layers=1,
+        page_size=1,
+        attention_type="MLA",
+    )
+
+    # MLA allocations are aligned to 2 * PAGE_SIZE.  (16P - 3P) rounds down to 12P.
+    assert captured["mem_size"] == 12 * page_size
+
+
+def test_sglang_shutdown_clears_runtime_owned_reservations(monkeypatch):
+    interfaces, _patches, _torch_mock = _load_sglang_modules(monkeypatch)
+    interfaces.register_runtime_owned_reservation(
+        "cuda:0", "dsv4.swa_kv_pool", 4096
+    )
+
+    assert interfaces.get_runtime_owned_reservation_bytes("cuda:0") == 4096
+
+    interfaces.shutdown_kvcached()
+
+    assert interfaces.get_runtime_owned_reservation_bytes("cuda:0") == 0

--- a/tests/test_sglang_dsv4_runtime_reservation_patch.py
+++ b/tests/test_sglang_dsv4_runtime_reservation_patch.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import sys
+import types
+from typing import Any
+from unittest import mock
+
+
+class FakeTensor:
+    def __init__(self, nbytes=0):
+        self.nbytes = nbytes
+        self.views = []
+
+    def view(self, *args, **kwargs):
+        self.views.append((args, kwargs))
+        return self
+
+    def __getitem__(self, _key):
+        return self
+
+
+def _load_sglang_modules(monkeypatch):
+    torch_mock = mock.MagicMock()
+    torch_mock.__version__ = "2.6.0"
+    torch_mock.cuda.is_available.return_value = True
+    torch_mock.cuda.current_device.return_value = 0
+    torch_mock.cuda.get_device_properties.return_value = types.SimpleNamespace(
+        total_memory=64 * 1024 * 1024
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch_mock)
+    monkeypatch.setitem(sys.modules, "torch.cuda", torch_mock.cuda)
+    monkeypatch.setitem(sys.modules, "posix_ipc", mock.MagicMock())
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", mock.MagicMock())
+
+    from kvcached.integration.sglang import interfaces, patches
+
+    importlib.reload(interfaces)
+    importlib.reload(patches)
+    return interfaces, patches, torch_mock
+
+
+def test_dsv4_runtime_reservation_patch_registers_per_pool_breakdown(monkeypatch):
+    interfaces, patches, _torch_mock = _load_sglang_modules(monkeypatch)
+    fake_mod: Any = types.SimpleNamespace()
+    registrations: list[tuple[str, str, int]] = []
+
+    class DeepSeekV4TokenToKVPool:
+        def __init__(self):
+            self.device = "cuda:0"
+            self.unified_kv_pool = types.SimpleNamespace(
+                kv_buffer=[FakeTensor(5), FakeTensor(7)]
+            )
+            self.swa_kv_pool = types.SimpleNamespace(
+                kv_buffer=[FakeTensor(11), FakeTensor(13)],
+                _kvcached_managed=True,
+            )
+            self.c4_kv_pool = types.SimpleNamespace(kv_buffer=[FakeTensor(17)])
+            self.c128_kv_pool = types.SimpleNamespace(kv_buffer=[FakeTensor(19)])
+            self.c4_indexer_kv_pool = types.SimpleNamespace(
+                index_k_with_scale_buffer=[FakeTensor(23)]
+            )
+            self.compress_state_pools = [
+                types.SimpleNamespace(
+                    kv_score_buffer=types.SimpleNamespace(kv_score=FakeTensor(29))
+                ),
+                types.SimpleNamespace(
+                    kv_score_buffer=types.SimpleNamespace(kv_score=FakeTensor(37)),
+                    _kvcached_managed=True,
+                ),
+                None,
+            ]
+            self.indexer_compress_state_pools = [
+                types.SimpleNamespace(
+                    kv_score_buffer=types.SimpleNamespace(kv_score=FakeTensor(31))
+                )
+            ]
+
+    fake_mod.DeepSeekV4TokenToKVPool = DeepSeekV4TokenToKVPool
+    monkeypatch.setattr(
+        patches.DeepSeekV4RuntimeReservationPatch,
+        "initialize_version_info",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        interfaces,
+        "register_runtime_owned_reservation",
+        lambda device, pool, num_bytes: registrations.append((device, pool, num_bytes)),
+    )
+
+    patch = patches.DeepSeekV4RuntimeReservationPatch()
+    assert patch.apply(fake_mod)
+
+    pool: Any = fake_mod.DeepSeekV4TokenToKVPool()
+
+    assert registrations == [
+        ("cuda:0", "dsv4.unified_kv_pool", 12),
+        ("cuda:0", "dsv4.swa_kv_pool", 0),
+        ("cuda:0", "dsv4.c4_kv_pool", 17),
+        ("cuda:0", "dsv4.c128_kv_pool", 19),
+        ("cuda:0", "dsv4.c4_indexer_kv_pool", 23),
+        ("cuda:0", "dsv4.compress_state_pools", 29),
+        ("cuda:0", "dsv4.indexer_compress_state_pools", 31),
+    ]
+    assert pool._kvcached_runtime_reservation_breakdown == {
+        "dsv4.unified_kv_pool": 12,
+        "dsv4.swa_kv_pool": 0,
+        "dsv4.c4_kv_pool": 17,
+        "dsv4.c128_kv_pool": 19,
+        "dsv4.c4_indexer_kv_pool": 23,
+        "dsv4.compress_state_pools": 29,
+        "dsv4.indexer_compress_state_pools": 31,
+    }
+
+
+def test_dsv4_runtime_reservation_patch_is_automatic(monkeypatch):
+    interfaces, patches, _torch_mock = _load_sglang_modules(monkeypatch)
+    fake_mod: Any = types.SimpleNamespace()
+    registrations: list[tuple[str, str, int]] = []
+
+    class DeepSeekV4TokenToKVPool:
+        def __init__(self):
+            self.device = "cuda:0"
+            self.swa_kv_pool = types.SimpleNamespace(kv_buffer=[FakeTensor(7)])
+
+    fake_mod.DeepSeekV4TokenToKVPool = DeepSeekV4TokenToKVPool
+    monkeypatch.setattr(
+        patches.DeepSeekV4RuntimeReservationPatch,
+        "initialize_version_info",
+        lambda self: True,
+    )
+    monkeypatch.setattr(
+        interfaces,
+        "register_runtime_owned_reservation",
+        lambda device, pool, num_bytes: registrations.append(
+            (device, pool, num_bytes)
+        ),
+    )
+
+    patch = patches.DeepSeekV4RuntimeReservationPatch()
+    assert patch.apply(fake_mod)
+
+    pool: Any = fake_mod.DeepSeekV4TokenToKVPool()
+    assert ("cuda:0", "dsv4.swa_kv_pool", 7) in registrations
+    assert pool._kvcached_runtime_reservation_breakdown["dsv4.swa_kv_pool"] == 7
+
+
+def test_zero_reservation_clears_stale_pool_value(monkeypatch):
+    interfaces, _patches, _torch_mock = _load_sglang_modules(monkeypatch)
+
+    interfaces.register_runtime_owned_reservation(
+        "cuda:0", "dsv4.swa_kv_pool", 4096
+    )
+    interfaces.register_runtime_owned_reservation(
+        "cuda:0", "dsv4.c4_kv_pool", 8192
+    )
+    interfaces.register_runtime_owned_reservation(
+        "cuda:0", "dsv4.swa_kv_pool", 0
+    )
+
+    assert interfaces.get_runtime_owned_reservation_breakdown("cuda:0") == {
+        "dsv4.c4_kv_pool": 8192
+    }
+
+
+def test_sglang_alloc_kv_cache_subtracts_runtime_owned_reservations(monkeypatch):
+    interfaces, _patches, torch_mock = _load_sglang_modules(monkeypatch)
+    page_size = interfaces.PAGE_SIZE
+    captured: dict[str, Any] = {}
+
+    torch_mock.cuda.get_device_properties.return_value = types.SimpleNamespace(
+        total_memory=16 * page_size
+    )
+
+    def fake_create_kv_tensors(mem_size, *args, **kwargs):
+        captured["mem_size"] = mem_size
+        return [FakeTensor()]
+
+    monkeypatch.setattr(interfaces, "create_kv_tensors", fake_create_kv_tensors)
+    monkeypatch.setattr(interfaces, "_kvcached_initialized", True)
+    monkeypatch.setattr(interfaces, "_contiguous_layout", False)
+    interfaces._runtime_owned_reservations.clear()
+    interfaces.register_runtime_owned_reservation("cuda:0", "dsv4.swa_kv_pool", 3 * page_size)
+
+    interfaces.alloc_kv_cache(
+        kvcache_shape=(1, 1, 1),
+        dtype=types.SimpleNamespace(itemsize=1),
+        device="cuda:0",
+        num_layers=1,
+        page_size=1,
+        attention_type="MLA",
+    )
+
+    # MLA allocations are aligned to 2 * PAGE_SIZE.  (16P - 3P) rounds down to 12P.
+    assert captured["mem_size"] == 12 * page_size
+
+
+def test_sglang_shutdown_clears_runtime_owned_reservations(monkeypatch):
+    interfaces, _patches, _torch_mock = _load_sglang_modules(monkeypatch)
+    interfaces.register_runtime_owned_reservation(
+        "cuda:0", "dsv4.swa_kv_pool", 4096
+    )
+
+    assert interfaces.get_runtime_owned_reservation_bytes("cuda:0") == 4096
+
+    interfaces.shutdown_kvcached()
+
+    assert interfaces.get_runtime_owned_reservation_bytes("cuda:0") == 0

--- a/tests/test_sglang_elastic_allocator_patch.py
+++ b/tests/test_sglang_elastic_allocator_patch.py
@@ -5,12 +5,32 @@ import importlib
 import importlib.machinery
 import sys
 import types
+from typing import Any, cast
 from unittest import mock
 
 
 class FakeTensor(list):
+    def __getitem__(self, index):
+        value = super().__getitem__(index)
+        if isinstance(index, slice):
+            return FakeTensor(value)
+        return value
+
     def numel(self):
         return len(self)
+
+    def detach(self):
+        return self
+
+    def cpu(self):
+        return self
+
+    def tolist(self):
+        return list(self)
+
+    def split(self, size):
+        assert size == 1
+        return [FakeTensor([value]) for value in self]
 
 
 class FakeKVCachedAllocator:
@@ -32,10 +52,16 @@ def _load_sglang_patches(monkeypatch):
     torch_mock.empty.side_effect = lambda shape, **_kwargs: FakeTensor(
         [0] * (shape if isinstance(shape, int) else shape[0])
     )
+    torch_mock.arange.side_effect = lambda start, end=None, **_kwargs: FakeTensor(
+        range(start if end is not None else 0, end if end is not None else start)
+    )
     torch_mock.tensor.side_effect = lambda values, **_kwargs: FakeTensor(values)
+    torch_mock.cat.side_effect = lambda tensors, **_kwargs: FakeTensor(
+        [value for tensor in tensors for value in tensor]
+    )
     monkeypatch.setitem(sys.modules, "torch", torch_mock)
 
-    utils_mod = types.ModuleType("sglang.srt.utils")
+    utils_mod: Any = types.ModuleType("sglang.srt.utils")
     utils_mod.next_power_of_2 = lambda value: 1 << (int(value) - 1).bit_length()
 
     def get_num_new_pages(**_kwargs):
@@ -53,6 +79,15 @@ def _load_sglang_patches(monkeypatch):
 
     importlib.reload(patches)
     return patches
+
+
+def _install_sglang_interfaces(monkeypatch, interfaces):
+    import kvcached.integration.sglang as sglang_integration
+
+    monkeypatch.setitem(
+        sys.modules, "kvcached.integration.sglang.interfaces", interfaces
+    )
+    monkeypatch.setattr(sglang_integration, "interfaces", interfaces)
 
 
 def test_elastic_paged_alloc_extend_accepts_precomputed_num_new_pages(monkeypatch):
@@ -77,7 +112,7 @@ def test_elastic_paged_alloc_extend_accepts_precomputed_num_new_pages(monkeypatc
             return run
 
     alloc_extend_kernel = Kernel()
-    alloc_mod = types.SimpleNamespace(
+    alloc_mod: Any = types.SimpleNamespace(
         BaseTokenToKVPoolAllocator=BaseTokenToKVPoolAllocator,
         alloc_extend_kernel=alloc_extend_kernel,
         alloc_decode_kernel=Kernel(),
@@ -146,16 +181,18 @@ def test_elastic_paged_allocator_supports_split_sglang_allocator_module(monkeypa
             return run
 
     alloc_extend_kernel = Kernel()
-    paged_mod = types.ModuleType("sglang.srt.mem_cache.allocator.paged")
+    paged_mod: Any = types.ModuleType("sglang.srt.mem_cache.allocator.paged")
     paged_mod.alloc_extend_kernel = alloc_extend_kernel
     paged_mod.alloc_decode_kernel = Kernel()
     monkeypatch.setitem(sys.modules, "sglang.srt.mem_cache", types.ModuleType("sglang.srt.mem_cache"))
-    allocator_pkg = types.ModuleType("sglang.srt.mem_cache.allocator")
+    allocator_pkg: Any = types.ModuleType("sglang.srt.mem_cache.allocator")
     allocator_pkg.paged = paged_mod
     monkeypatch.setitem(sys.modules, "sglang.srt.mem_cache.allocator", allocator_pkg)
     monkeypatch.setitem(sys.modules, "sglang.srt.mem_cache.allocator.paged", paged_mod)
 
-    alloc_mod = types.SimpleNamespace(BaseTokenToKVPoolAllocator=BaseTokenToKVPoolAllocator)
+    alloc_mod: Any = types.SimpleNamespace(
+        BaseTokenToKVPoolAllocator=BaseTokenToKVPoolAllocator
+    )
 
     patch = patches.ElasticAllocatorPatch()
     assert patch.inject_elastic_paged_allocator(alloc_mod)
@@ -207,7 +244,7 @@ def test_elastic_paged_allocator_falls_back_for_native_pools(monkeypatch):
 
             return run
 
-    alloc_mod = types.SimpleNamespace(
+    alloc_mod: Any = types.SimpleNamespace(
         BaseTokenToKVPoolAllocator=BaseTokenToKVPoolAllocator,
         PagedTokenToKVPoolAllocator=NativePagedTokenToKVPoolAllocator,
         alloc_extend_kernel=Kernel(),
@@ -242,7 +279,7 @@ def test_elastic_allocator_falls_back_for_native_pools(monkeypatch):
         def __init__(self, size, _dtype, device, _kvcache):
             super().__init__(size, 1, _dtype, device, _kvcache)
 
-    alloc_mod = types.SimpleNamespace(
+    alloc_mod: Any = types.SimpleNamespace(
         BaseTokenToKVPoolAllocator=BaseTokenToKVPoolAllocator,
         TokenToKVPoolAllocator=NativeTokenToKVPoolAllocator,
     )
@@ -266,7 +303,7 @@ def test_elastic_mha_pool_uses_storage_dtype(monkeypatch):
 
     logical_dtype = types.SimpleNamespace(itemsize=1, name="float8_e4m3fn")
     storage_dtype = types.SimpleNamespace(itemsize=1, name="uint8")
-    calls = {}
+    calls: dict[str, Any] = {}
 
     class MHATokenToKVPool:
         def __init__(
@@ -298,19 +335,22 @@ def test_elastic_mha_pool_uses_storage_dtype(monkeypatch):
         def get_kv_size_bytes(self):
             return (self.layer_num * self.size, self.layer_num * self.size)
 
+        def _create_buffers(self):
+            return None
+
     def fake_alloc_kv_cache(**kwargs):
         calls["alloc_kv_cache"] = kwargs
         return ([object()], [object()])
 
-    interfaces = types.ModuleType("kvcached.integration.sglang.interfaces")
+    interfaces: Any = types.ModuleType("kvcached.integration.sglang.interfaces")
     interfaces.init_kvcached = lambda **kwargs: calls.setdefault("init_kvcached", kwargs)
     interfaces.get_kv_cache_manager = (
         lambda *args, **kwargs: types.SimpleNamespace(args=args, kwargs=kwargs)
     )
     interfaces.alloc_kv_cache = fake_alloc_kv_cache
-    monkeypatch.setitem(sys.modules, "kvcached.integration.sglang.interfaces", interfaces)
+    _install_sglang_interfaces(monkeypatch, interfaces)
 
-    mem_pool_mod = types.SimpleNamespace(MHATokenToKVPool=MHATokenToKVPool)
+    mem_pool_mod: Any = types.SimpleNamespace(MHATokenToKVPool=MHATokenToKVPool)
     patch = patches.ElasticMemoryPoolPatch()
     assert patch.inject_elastic_mem_pool(mem_pool_mod)
 
@@ -335,13 +375,13 @@ def test_elastic_mha_pool_uses_storage_dtype(monkeypatch):
 def test_elastic_mha_nonzero_tp_rank_uses_logical_allocator(monkeypatch):
     patches = _load_sglang_patches(monkeypatch)
 
-    dist_mod = types.ModuleType("sglang.srt.distributed")
+    dist_mod: Any = types.ModuleType("sglang.srt.distributed")
     dist_mod.get_tensor_model_parallel_rank = lambda: 2
     dist_mod.get_tensor_model_parallel_world_size = lambda: 4
     dist_mod.get_pipeline_model_parallel_rank = lambda: 0
     monkeypatch.setitem(sys.modules, "sglang.srt.distributed", dist_mod)
 
-    calls = {}
+    calls: dict[str, Any] = {}
 
     class MHATokenToKVPool:
         def __init__(
@@ -373,7 +413,10 @@ def test_elastic_mha_nonzero_tp_rank_uses_logical_allocator(monkeypatch):
         def get_kv_size_bytes(self):
             return (self.layer_num * self.size, self.layer_num * self.size)
 
-    interfaces = types.ModuleType("kvcached.integration.sglang.interfaces")
+        def _create_buffers(self):
+            return None
+
+    interfaces: Any = types.ModuleType("kvcached.integration.sglang.interfaces")
     interfaces.init_kvcached = lambda **kwargs: calls.setdefault("init_kvcached", kwargs)
 
     def fake_alloc_kv_cache(**kwargs):
@@ -386,9 +429,9 @@ def test_elastic_mha_nonzero_tp_rank_uses_logical_allocator(monkeypatch):
         raise AssertionError("nonzero TP rank should not drive physical KV manager")
 
     interfaces.get_kv_cache_manager = fail_get_manager
-    monkeypatch.setitem(sys.modules, "kvcached.integration.sglang.interfaces", interfaces)
+    _install_sglang_interfaces(monkeypatch, interfaces)
 
-    mem_pool_mod = types.SimpleNamespace(MHATokenToKVPool=MHATokenToKVPool)
+    mem_pool_mod: Any = types.SimpleNamespace(MHATokenToKVPool=MHATokenToKVPool)
     patch = patches.ElasticMemoryPoolPatch()
     assert patch.inject_elastic_mem_pool(mem_pool_mod)
 
@@ -447,17 +490,54 @@ def test_capped_allocator_reports_logical_available_but_checks_physical(monkeypa
     assert allocator.available_size() == 2
 
 
+def test_capped_allocator_only_frees_allocated_ids(monkeypatch):
+    patches = _load_sglang_patches(monkeypatch)
+
+    class Manager:
+        def __init__(self):
+            self.freed = []
+
+        def available_size(self):
+            return 8
+
+        def alloc(self, need_size):
+            return list(range(1, need_size + 1))
+
+        def free(self, block_ids):
+            self.freed.append(list(block_ids))
+
+    manager = Manager()
+    allocator = patches._CappedKVCachedAllocator(manager, capacity_blocks=4)
+
+    assert allocator.alloc(2) == [1, 2]
+    allocator.free([0, 1, 99])
+
+    assert manager.freed == [[1]]
+    assert allocator.available_size() == 3
+
+
+def test_logical_allocator_only_frees_allocated_ids(monkeypatch):
+    patches = _load_sglang_patches(monkeypatch)
+
+    allocator = patches._LogicalKVCachedAllocator(capacity_blocks=4)
+
+    assert allocator.alloc(2) == [1, 2]
+    allocator.free([0, 1, 99])
+
+    assert sorted(allocator.alloc(2)) == [1, 3]
+
+
 def test_elastic_mamba_pool_uses_rank_local_device_for_spec_buffers(monkeypatch):
     patches = _load_sglang_patches(monkeypatch)
 
-    torch_mod = sys.modules["torch"]
+    torch_mod = cast(Any, sys.modules["torch"])
     torch_mod.zeros.side_effect = lambda size, **kwargs: types.SimpleNamespace(
         size=size,
         kwargs=kwargs,
         mem_usage_bytes=lambda: 0,
     )
 
-    calls = {"zeros": []}
+    calls: dict[str, Any] = {"zeros": []}
 
     def fake_zeros(*args, **kwargs):
         calls["zeros"].append(kwargs)
@@ -469,13 +549,13 @@ def test_elastic_mamba_pool_uses_rank_local_device_for_spec_buffers(monkeypatch)
 
     torch_mod.zeros.side_effect = fake_zeros
 
-    dist_mod = types.ModuleType("sglang.srt.distributed")
+    dist_mod: Any = types.ModuleType("sglang.srt.distributed")
     dist_mod.get_tensor_model_parallel_rank = lambda: 2
     dist_mod.get_tensor_model_parallel_world_size = lambda: 4
     dist_mod.get_pipeline_model_parallel_rank = lambda: 0
     monkeypatch.setitem(sys.modules, "sglang.srt.distributed", dist_mod)
 
-    interfaces = types.ModuleType("kvcached.integration.sglang.interfaces")
+    interfaces: Any = types.ModuleType("kvcached.integration.sglang.interfaces")
     interfaces.init_kvcached = lambda **kwargs: calls.setdefault("init_kvcached", kwargs)
     interfaces.alloc_mamba_states = lambda **kwargs: (
         [types.SimpleNamespace(mem_usage_bytes=lambda: 0)],
@@ -487,7 +567,7 @@ def test_elastic_mamba_pool_uses_rank_local_device_for_spec_buffers(monkeypatch)
         kwargs=kwargs,
         available_size=lambda: 8,
     )
-    monkeypatch.setitem(sys.modules, "kvcached.integration.sglang.interfaces", interfaces)
+    _install_sglang_interfaces(monkeypatch, interfaces)
 
     class CacheParams:
         layers = [0]
@@ -509,7 +589,7 @@ def test_elastic_mamba_pool_uses_rank_local_device_for_spec_buffers(monkeypatch)
                 self.intermediate_ssm = intermediate_ssm
                 self.intermediate_conv_window = intermediate_conv_window
 
-    mem_pool_mod = types.SimpleNamespace(MambaPool=MambaPool)
+    mem_pool_mod: Any = types.SimpleNamespace(MambaPool=MambaPool)
     patch = patches.ElasticMambaPoolPatch()
     assert patch.inject_elastic_mamba_pool(mem_pool_mod)
 

--- a/tests/test_sglang_elastic_allocator_patch.py
+++ b/tests/test_sglang_elastic_allocator_patch.py
@@ -87,7 +87,9 @@ def _install_sglang_interfaces(monkeypatch, interfaces):
     monkeypatch.setitem(
         sys.modules, "kvcached.integration.sglang.interfaces", interfaces
     )
-    monkeypatch.setattr(sglang_integration, "interfaces", interfaces)
+    monkeypatch.setattr(
+        sglang_integration, "interfaces", interfaces, raising=False
+    )
 
 
 def test_elastic_paged_alloc_extend_accepts_precomputed_num_new_pages(monkeypatch):

--- a/tests/test_sglang_elastic_allocator_patch.py
+++ b/tests/test_sglang_elastic_allocator_patch.py
@@ -1,0 +1,527 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import importlib.machinery
+import sys
+import types
+from unittest import mock
+
+
+class FakeTensor(list):
+    def numel(self):
+        return len(self)
+
+
+class FakeKVCachedAllocator:
+    def __init__(self):
+        self.alloc_calls = []
+
+    def alloc(self, need_size):
+        self.alloc_calls.append(need_size)
+        return list(range(need_size))
+
+    def available_size(self):
+        return 16
+
+
+def _load_sglang_patches(monkeypatch):
+    torch_mock = mock.MagicMock()
+    torch_mock.__version__ = "2.6.0"
+    torch_mock.int64 = "int64"
+    torch_mock.empty.side_effect = lambda shape, **_kwargs: FakeTensor(
+        [0] * (shape if isinstance(shape, int) else shape[0])
+    )
+    torch_mock.tensor.side_effect = lambda values, **_kwargs: FakeTensor(values)
+    monkeypatch.setitem(sys.modules, "torch", torch_mock)
+
+    utils_mod = types.ModuleType("sglang.srt.utils")
+    utils_mod.next_power_of_2 = lambda value: 1 << (int(value) - 1).bit_length()
+
+    def get_num_new_pages(**_kwargs):
+        raise AssertionError("get_num_new_pages should not be called")
+
+    utils_mod.get_num_new_pages = get_num_new_pages
+
+    for name in ("sglang", "sglang.srt"):
+        module = types.ModuleType(name)
+        module.__spec__ = importlib.machinery.ModuleSpec(name, loader=None)
+        monkeypatch.setitem(sys.modules, name, module)
+    monkeypatch.setitem(sys.modules, "sglang.srt.utils", utils_mod)
+
+    from kvcached.integration.sglang import patches
+
+    importlib.reload(patches)
+    return patches
+
+
+def test_elastic_paged_alloc_extend_accepts_precomputed_num_new_pages(monkeypatch):
+    patches = _load_sglang_patches(monkeypatch)
+
+    class BaseTokenToKVPoolAllocator:
+        def __init__(self, size, page_size, _dtype, device, _kvcache):
+            self.size = size
+            self.page_size = page_size
+            self.device = device
+            self.free_group = []
+            self.is_not_in_free_group = True
+
+    class Kernel:
+        def __init__(self):
+            self.calls = []
+
+        def __getitem__(self, grid):
+            def run(*args):
+                self.calls.append((grid, args))
+
+            return run
+
+    alloc_extend_kernel = Kernel()
+    alloc_mod = types.SimpleNamespace(
+        BaseTokenToKVPoolAllocator=BaseTokenToKVPoolAllocator,
+        alloc_extend_kernel=alloc_extend_kernel,
+        alloc_decode_kernel=Kernel(),
+    )
+
+    patch = patches.ElasticAllocatorPatch()
+    assert patch.inject_elastic_paged_allocator(alloc_mod)
+
+    allocator = FakeKVCachedAllocator()
+    kvcache = types.SimpleNamespace(kvcached_allocator=allocator)
+    paged = alloc_mod.ElasticPagedTokenToKVPoolAllocator(
+        128,
+        16,
+        object(),
+        "cuda:0",
+        kvcache,
+    )
+
+    out = paged.alloc_extend(
+        prefix_lens=[0, 0],
+        prefix_lens_cpu=[0, 0],
+        seq_lens=[8, 24],
+        seq_lens_cpu=[8, 24],
+        last_loc=FakeTensor([0, 0]),
+        extend_num_tokens=32,
+        num_new_pages=2,
+    )
+
+    assert len(out) == 32
+    assert allocator.alloc_calls == [2]
+    assert len(alloc_extend_kernel.calls) == 1
+
+
+def test_elastic_paged_allocator_supports_split_sglang_allocator_module(monkeypatch):
+    patches = _load_sglang_patches(monkeypatch)
+
+    class BaseTokenToKVPoolAllocator:
+        def __init__(self, size, page_size, _dtype, device, _kvcache):
+            self.size = size
+            self.page_size = page_size
+            self.device = device
+            self.free_group = []
+            self.is_not_in_free_group = True
+
+    class Kernel:
+        def __init__(self):
+            self.calls = []
+
+            def fn(
+                prefix_lens,
+                seq_lens,
+                last_loc,
+                free_pages,
+                out_indices,
+                bs_upper,
+                page_size,
+            ):
+                return None
+
+            self.fn = fn
+
+        def __getitem__(self, grid):
+            def run(*args):
+                self.calls.append((grid, args))
+
+            return run
+
+    alloc_extend_kernel = Kernel()
+    paged_mod = types.ModuleType("sglang.srt.mem_cache.allocator.paged")
+    paged_mod.alloc_extend_kernel = alloc_extend_kernel
+    paged_mod.alloc_decode_kernel = Kernel()
+    monkeypatch.setitem(sys.modules, "sglang.srt.mem_cache", types.ModuleType("sglang.srt.mem_cache"))
+    allocator_pkg = types.ModuleType("sglang.srt.mem_cache.allocator")
+    allocator_pkg.paged = paged_mod
+    monkeypatch.setitem(sys.modules, "sglang.srt.mem_cache.allocator", allocator_pkg)
+    monkeypatch.setitem(sys.modules, "sglang.srt.mem_cache.allocator.paged", paged_mod)
+
+    alloc_mod = types.SimpleNamespace(BaseTokenToKVPoolAllocator=BaseTokenToKVPoolAllocator)
+
+    patch = patches.ElasticAllocatorPatch()
+    assert patch.inject_elastic_paged_allocator(alloc_mod)
+    assert patch.alias_paged_allocator_to_elastic(alloc_mod)
+    assert paged_mod.PagedTokenToKVPoolAllocator is alloc_mod.ElasticPagedTokenToKVPoolAllocator
+
+    allocator = FakeKVCachedAllocator()
+    kvcache = types.SimpleNamespace(kvcached_allocator=allocator)
+    paged = alloc_mod.PagedTokenToKVPoolAllocator(
+        128,
+        16,
+        object(),
+        "cuda:0",
+        kvcache,
+    )
+
+    out = paged.alloc_extend(
+        prefix_lens=[0, 0],
+        prefix_lens_cpu=[0, 0],
+        seq_lens=[8, 24],
+        seq_lens_cpu=[8, 24],
+        last_loc=FakeTensor([0, 0]),
+        extend_num_tokens=32,
+        num_new_pages=2,
+    )
+
+    assert len(out) == 32
+    assert allocator.alloc_calls == [2]
+    assert len(alloc_extend_kernel.calls) == 1
+    assert len(alloc_extend_kernel.calls[0][1]) == 7
+
+
+def test_elastic_paged_allocator_falls_back_for_native_pools(monkeypatch):
+    patches = _load_sglang_patches(monkeypatch)
+
+    class BaseTokenToKVPoolAllocator:
+        def __init__(self, size, page_size, _dtype, device, _kvcache):
+            self.size = size
+            self.page_size = page_size
+            self.device = device
+
+    class NativePagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
+        pass
+
+    class Kernel:
+        def __getitem__(self, grid):
+            def run(*_args):
+                return None
+
+            return run
+
+    alloc_mod = types.SimpleNamespace(
+        BaseTokenToKVPoolAllocator=BaseTokenToKVPoolAllocator,
+        PagedTokenToKVPoolAllocator=NativePagedTokenToKVPoolAllocator,
+        alloc_extend_kernel=Kernel(),
+        alloc_decode_kernel=Kernel(),
+    )
+
+    patch = patches.ElasticAllocatorPatch()
+    assert patch.inject_elastic_paged_allocator(alloc_mod)
+    assert patch.alias_paged_allocator_to_elastic(alloc_mod)
+
+    native = alloc_mod.PagedTokenToKVPoolAllocator(
+        128,
+        16,
+        object(),
+        "cuda:0",
+        types.SimpleNamespace(),
+    )
+
+    assert isinstance(native, NativePagedTokenToKVPoolAllocator)
+
+
+def test_elastic_allocator_falls_back_for_native_pools(monkeypatch):
+    patches = _load_sglang_patches(monkeypatch)
+
+    class BaseTokenToKVPoolAllocator:
+        def __init__(self, size, page_size, _dtype, device, _kvcache):
+            self.size = size
+            self.page_size = page_size
+            self.device = device
+
+    class NativeTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
+        def __init__(self, size, _dtype, device, _kvcache):
+            super().__init__(size, 1, _dtype, device, _kvcache)
+
+    alloc_mod = types.SimpleNamespace(
+        BaseTokenToKVPoolAllocator=BaseTokenToKVPoolAllocator,
+        TokenToKVPoolAllocator=NativeTokenToKVPoolAllocator,
+    )
+
+    patch = patches.ElasticAllocatorPatch()
+    assert patch.inject_elastic_allocator(alloc_mod)
+    assert patch.alias_allocator_to_elastic(alloc_mod)
+
+    native = alloc_mod.TokenToKVPoolAllocator(
+        128,
+        object(),
+        "cuda:0",
+        types.SimpleNamespace(),
+    )
+
+    assert isinstance(native, NativeTokenToKVPoolAllocator)
+
+
+def test_elastic_mha_pool_uses_storage_dtype(monkeypatch):
+    patches = _load_sglang_patches(monkeypatch)
+
+    logical_dtype = types.SimpleNamespace(itemsize=1, name="float8_e4m3fn")
+    storage_dtype = types.SimpleNamespace(itemsize=1, name="uint8")
+    calls = {}
+
+    class MHATokenToKVPool:
+        def __init__(
+            self,
+            size,
+            page_size,
+            dtype,
+            head_num,
+            head_dim,
+            layer_num,
+            device,
+            enable_memory_saver,
+            start_layer=None,
+            end_layer=None,
+        ):
+            self.size = size
+            self.page_size = page_size
+            self.dtype = dtype
+            self.store_dtype = storage_dtype
+            self.head_num = head_num
+            self.head_dim = head_dim
+            self.layer_num = layer_num
+            self.device = device
+            self.enable_memory_saver = enable_memory_saver
+            self.start_layer = start_layer
+            self.end_layer = end_layer
+            self._create_buffers()
+
+        def get_kv_size_bytes(self):
+            return (self.layer_num * self.size, self.layer_num * self.size)
+
+    def fake_alloc_kv_cache(**kwargs):
+        calls["alloc_kv_cache"] = kwargs
+        return ([object()], [object()])
+
+    interfaces = types.ModuleType("kvcached.integration.sglang.interfaces")
+    interfaces.init_kvcached = lambda **kwargs: calls.setdefault("init_kvcached", kwargs)
+    interfaces.get_kv_cache_manager = (
+        lambda *args, **kwargs: types.SimpleNamespace(args=args, kwargs=kwargs)
+    )
+    interfaces.alloc_kv_cache = fake_alloc_kv_cache
+    monkeypatch.setitem(sys.modules, "kvcached.integration.sglang.interfaces", interfaces)
+
+    mem_pool_mod = types.SimpleNamespace(MHATokenToKVPool=MHATokenToKVPool)
+    patch = patches.ElasticMemoryPoolPatch()
+    assert patch.inject_elastic_mem_pool(mem_pool_mod)
+
+    pool = mem_pool_mod.ElasticMHATokenToKVPool(
+        size=128,
+        page_size=16,
+        dtype=logical_dtype,
+        head_num=8,
+        head_dim=64,
+        layer_num=2,
+        device="cuda",
+        enable_memory_saver=False,
+    )
+
+    assert pool.cell_size == 8 * 64 * storage_dtype.itemsize
+    assert calls["init_kvcached"]["device"] == "cuda:0"
+    assert calls["alloc_kv_cache"]["dtype"] is storage_dtype
+    assert calls["alloc_kv_cache"]["device"] == "cuda:0"
+    assert pool.device == "cuda:0"
+
+
+def test_elastic_mha_nonzero_tp_rank_uses_logical_allocator(monkeypatch):
+    patches = _load_sglang_patches(monkeypatch)
+
+    dist_mod = types.ModuleType("sglang.srt.distributed")
+    dist_mod.get_tensor_model_parallel_rank = lambda: 2
+    dist_mod.get_tensor_model_parallel_world_size = lambda: 4
+    dist_mod.get_pipeline_model_parallel_rank = lambda: 0
+    monkeypatch.setitem(sys.modules, "sglang.srt.distributed", dist_mod)
+
+    calls = {}
+
+    class MHATokenToKVPool:
+        def __init__(
+            self,
+            size,
+            page_size,
+            dtype,
+            head_num,
+            head_dim,
+            layer_num,
+            device,
+            enable_memory_saver,
+            start_layer=None,
+            end_layer=None,
+        ):
+            self.size = size
+            self.page_size = page_size
+            self.dtype = dtype
+            self.store_dtype = dtype
+            self.head_num = head_num
+            self.head_dim = head_dim
+            self.layer_num = layer_num
+            self.device = device
+            self.enable_memory_saver = enable_memory_saver
+            self.start_layer = start_layer
+            self.end_layer = end_layer
+            self._create_buffers()
+
+        def get_kv_size_bytes(self):
+            return (self.layer_num * self.size, self.layer_num * self.size)
+
+    interfaces = types.ModuleType("kvcached.integration.sglang.interfaces")
+    interfaces.init_kvcached = lambda **kwargs: calls.setdefault("init_kvcached", kwargs)
+
+    def fake_alloc_kv_cache(**kwargs):
+        calls["alloc_kv_cache"] = kwargs
+        return [object()], [object()]
+
+    interfaces.alloc_kv_cache = fake_alloc_kv_cache
+
+    def fail_get_manager(*_args, **_kwargs):
+        raise AssertionError("nonzero TP rank should not drive physical KV manager")
+
+    interfaces.get_kv_cache_manager = fail_get_manager
+    monkeypatch.setitem(sys.modules, "kvcached.integration.sglang.interfaces", interfaces)
+
+    mem_pool_mod = types.SimpleNamespace(MHATokenToKVPool=MHATokenToKVPool)
+    patch = patches.ElasticMemoryPoolPatch()
+    assert patch.inject_elastic_mem_pool(mem_pool_mod)
+
+    pool = mem_pool_mod.ElasticMHATokenToKVPool(
+        size=128,
+        page_size=16,
+        dtype=types.SimpleNamespace(itemsize=1),
+        head_num=8,
+        head_dim=64,
+        layer_num=2,
+        device="cuda",
+        enable_memory_saver=False,
+    )
+
+    assert pool.device == "cuda:2"
+    assert calls["init_kvcached"]["device"] == "cuda:2"
+    assert calls["alloc_kv_cache"]["device"] == "cuda:2"
+    assert pool.kvcached_allocator.alloc(2) == [1, 2]
+
+
+def test_resolve_tp_device_keeps_explicit_device(monkeypatch):
+    patches = _load_sglang_patches(monkeypatch)
+
+    assert patches._resolve_tp_device("cuda", 2) == "cuda:2"
+    assert patches._resolve_tp_device("hip", 3) == "hip:3"
+    assert patches._resolve_tp_device("cuda:1", 2) == "cuda:1"
+
+
+def test_capped_allocator_reports_logical_available_but_checks_physical(monkeypatch):
+    patches = _load_sglang_patches(monkeypatch)
+
+    class Manager:
+        def __init__(self):
+            self.available = 2
+            self.alloc_calls = []
+
+        def available_size(self):
+            return self.available
+
+        def alloc(self, need_size):
+            self.alloc_calls.append(need_size)
+            return list(range(1, need_size + 1))
+
+        def free(self, _block_ids):
+            return None
+
+    manager = Manager()
+    allocator = patches._CappedKVCachedAllocator(manager, capacity_blocks=5)
+
+    assert allocator.available_size() == 5
+    assert allocator.alloc(3) is None
+    assert manager.alloc_calls == []
+
+    manager.available = 4
+    assert allocator.alloc(3) == [1, 2, 3]
+    assert allocator.available_size() == 2
+
+
+def test_elastic_mamba_pool_uses_rank_local_device_for_spec_buffers(monkeypatch):
+    patches = _load_sglang_patches(monkeypatch)
+
+    torch_mod = sys.modules["torch"]
+    torch_mod.zeros.side_effect = lambda size, **kwargs: types.SimpleNamespace(
+        size=size,
+        kwargs=kwargs,
+        mem_usage_bytes=lambda: 0,
+    )
+
+    calls = {"zeros": []}
+
+    def fake_zeros(*args, **kwargs):
+        calls["zeros"].append(kwargs)
+        return types.SimpleNamespace(
+            args=args,
+            kwargs=kwargs,
+            mem_usage_bytes=lambda: 0,
+        )
+
+    torch_mod.zeros.side_effect = fake_zeros
+
+    dist_mod = types.ModuleType("sglang.srt.distributed")
+    dist_mod.get_tensor_model_parallel_rank = lambda: 2
+    dist_mod.get_tensor_model_parallel_world_size = lambda: 4
+    dist_mod.get_pipeline_model_parallel_rank = lambda: 0
+    monkeypatch.setitem(sys.modules, "sglang.srt.distributed", dist_mod)
+
+    interfaces = types.ModuleType("kvcached.integration.sglang.interfaces")
+    interfaces.init_kvcached = lambda **kwargs: calls.setdefault("init_kvcached", kwargs)
+    interfaces.alloc_mamba_states = lambda **kwargs: (
+        [types.SimpleNamespace(mem_usage_bytes=lambda: 0)],
+        types.SimpleNamespace(mem_usage_bytes=lambda: 0),
+        {"is_contiguous": True, "cell_size": 1},
+    )
+    interfaces.get_kv_cache_manager = lambda *args, **kwargs: types.SimpleNamespace(
+        args=args,
+        kwargs=kwargs,
+        available_size=lambda: 8,
+    )
+    monkeypatch.setitem(sys.modules, "kvcached.integration.sglang.interfaces", interfaces)
+
+    class CacheParams:
+        layers = [0]
+        shape = types.SimpleNamespace(conv=[(2, 2)], temporal=(2, 2, 2))
+        dtype = types.SimpleNamespace(conv="conv-dtype", temporal="temporal-dtype")
+
+    class MambaPool:
+        class State:
+            def __init__(self, *, conv, temporal):
+                self.conv = conv
+                self.temporal = temporal
+
+            def mem_usage_bytes(self):
+                return 0
+
+        class SpeculativeState(State):
+            def __init__(self, *, conv, temporal, intermediate_ssm, intermediate_conv_window):
+                super().__init__(conv=conv, temporal=temporal)
+                self.intermediate_ssm = intermediate_ssm
+                self.intermediate_conv_window = intermediate_conv_window
+
+    mem_pool_mod = types.SimpleNamespace(MambaPool=MambaPool)
+    patch = patches.ElasticMambaPoolPatch()
+    assert patch.inject_elastic_mamba_pool(mem_pool_mod)
+
+    pool = mem_pool_mod.ElasticMambaPool(
+        size=16,
+        spec_state_size=1,
+        cache_params=CacheParams(),
+        device="cuda",
+        speculative_num_draft_tokens=2,
+    )
+
+    assert pool.device == "cuda:2"
+    assert calls["init_kvcached"]["device"] == "cuda:2"
+    assert calls["zeros"]
+    assert {call["device"] for call in calls["zeros"]} == {"cuda:2"}


### PR DESCRIPTION
## Summary

This is the first narrow DeepSeek-V4 integration step for SGLang. It accounts for GPU memory that remains owned by DeepSeek-V4 runtime pools before kvcached sizes its own virtual KV backing.

The patch is automatic when the existing `KVCACHED_AUTOPATCH` entry point is enabled and the DeepSeek-V4 pool module is present. It adds no DeepSeek-V4-specific environment variable.

## Why per-pool accounting

DeepSeek-V4 allocates SWA, compressed-cache, indexer, and compressor-state pools separately. kvcached consumes only the total for budgeting today, but retaining the breakdown lets later PRs transfer one pool at a time to kvcached ownership without double-counting the remaining runtime-owned pools.

## Design

- Wrap `DeepSeekV4TokenToKVPool` construction and measure the buffers that remain runtime-owned.
- Register reservations per device and per pool:
  - unified KV
  - SWA KV
  - C4 KV
  - C128 KV
  - C4 indexer KV
  - compressor state
  - indexer compressor state
- Subtract the reservation sum from the virtual KV backing budget.
- Exclude pools marked as kvcached-managed.
- Treat a zero registration as removal of a stale reservation, so a later ownership transition does not double-count memory.
- Clear reservations during integration shutdown.

## Scope

This PR does not replace any DeepSeek-V4 pool, change allocator lifecycle, or make a performance claim. Pool takeover is intentionally left to follow-up work.

## Validation

Validated on commit `0d78515c8d0b200caa02adb47031221a9ab66f75`:

- CPU pytest manifest on Python 3.9, 3.10, 3.11, 3.12, and 3.13
- GPU-free C++ tests
- `pre-commit run --all-files`
- mypy hooks on Python 3.9 through 3.13
- focused DeepSeek-V4 reservation and test-classification tests

All checks passed and the validation worktree remained clean.

Related: #369
