### PR TITLE
Fix unsigned underflow in available physical page calculation

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Run GPU-free C++ unit tests
+        run: bash tests/cpp/run_tests.sh
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'  # or match your local Python version

--- a/csrc/inc/math_utils.hpp
+++ b/csrc/inc/math_utils.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+
+namespace kvcached {
+
+constexpr size_t saturating_subtract(size_t value, size_t amount) {
+  return value > amount ? value - amount : size_t{0};
+}
+
+} // namespace kvcached

--- a/csrc/page_allocator.cpp
+++ b/csrc/page_allocator.cpp
@@ -443,12 +443,14 @@ int64_t PageAllocator::get_avail_physical_pages() const {
   size_t avail_phy_mem_size = 0, total_phy_mem_size = 0;
   CHECK_GPU(gpu_vmm::mem_get_info(&avail_phy_mem_size, &total_phy_mem_size));
 
-  size_t headroom = total_phy_mem_size * (1.0 - gpu_utilization_);
-  avail_phy_mem_size =
-      std::max(avail_phy_mem_size - headroom, static_cast<size_t>(0));
+  const size_t headroom =
+      static_cast<size_t>(total_phy_mem_size * (1.0 - gpu_utilization_));
+  const size_t usable_phy_mem_size =
+      avail_phy_mem_size > headroom ? avail_phy_mem_size - headroom
+                                    : static_cast<size_t>(0);
 
   // Calculate available pages considering layers and KV buffers
-  int64_t avail_phy_pages = avail_phy_mem_size / page_size_;
+  int64_t avail_phy_pages = usable_phy_mem_size / page_size_;
   int64_t avail_pages_per_layer =
       avail_phy_pages / num_layers_ / num_kv_buffers_;
   return avail_pages_per_layer;

--- a/csrc/page_allocator.cpp
+++ b/csrc/page_allocator.cpp
@@ -13,6 +13,7 @@
 
 #include "allocator.hpp"
 #include "gpu_utils.hpp"
+#include "math_utils.hpp"
 #include "mem_info_tracker.hpp"
 
 namespace kvcached {
@@ -445,9 +446,8 @@ int64_t PageAllocator::get_avail_physical_pages() const {
 
   const size_t headroom =
       static_cast<size_t>(total_phy_mem_size * (1.0 - gpu_utilization_));
-  const size_t usable_phy_mem_size = avail_phy_mem_size > headroom
-                                         ? avail_phy_mem_size - headroom
-                                         : static_cast<size_t>(0);
+  const size_t usable_phy_mem_size =
+      saturating_subtract(avail_phy_mem_size, headroom);
 
   // Calculate available pages considering layers and KV buffers
   int64_t avail_phy_pages = usable_phy_mem_size / page_size_;

--- a/csrc/page_allocator.cpp
+++ b/csrc/page_allocator.cpp
@@ -445,9 +445,9 @@ int64_t PageAllocator::get_avail_physical_pages() const {
 
   const size_t headroom =
       static_cast<size_t>(total_phy_mem_size * (1.0 - gpu_utilization_));
-  const size_t usable_phy_mem_size =
-      avail_phy_mem_size > headroom ? avail_phy_mem_size - headroom
-                                    : static_cast<size_t>(0);
+  const size_t usable_phy_mem_size = avail_phy_mem_size > headroom
+                                         ? avail_phy_mem_size - headroom
+                                         : static_cast<size_t>(0);
 
   // Calculate available pages considering layers and KV buffers
   int64_t avail_phy_pages = usable_phy_mem_size / page_size_;

--- a/tests/cpp/run_tests.sh
+++ b/tests/cpp/run_tests.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+test_build_dir="$(mktemp -d "${TMPDIR:-/tmp}/kvcached-cpp-tests.XXXXXX")"
+trap 'rm -rf "${test_build_dir}"' EXIT
+
+"${CXX:-c++}" -std=c++17 -Wall -Wextra -Werror \
+  -I"${repo_root}/csrc/inc" \
+  "${script_dir}/test_math_utils.cpp" \
+  -o "${test_build_dir}/test_math_utils"
+
+"${test_build_dir}/test_math_utils"

--- a/tests/cpp/test_math_utils.cpp
+++ b/tests/cpp/test_math_utils.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstddef>
+
+#include "math_utils.hpp"
+
+namespace {
+
+constexpr size_t kHeadroom = 4;
+
+static_assert(kvcached::saturating_subtract(10, kHeadroom) == 6,
+              "available memory above headroom must return the difference");
+static_assert(kvcached::saturating_subtract(kHeadroom, kHeadroom) == 0,
+              "available memory equal to headroom must return zero");
+static_assert(kvcached::saturating_subtract(2, kHeadroom) == 0,
+              "available memory below headroom must return zero");
+
+} // namespace
+
+int main() { return 0; }


### PR DESCRIPTION
Partially addresses #371.

Summary:
- Avoid unsigned underflow when subtracting GPU utilization headroom from available physical memory.
- Return 0 usable physical memory when available memory is below the configured headroom.
- Prevent the prealloc path from seeing an artificially huge available-page count under memory pressure.

Tests:
- git diff --check