### PR TITLE
fix: honor explicit IPC names

### DIFF
--- a/kvcached/utils.py
+++ b/kvcached/utils.py
@@ -53,6 +53,14 @@ def _obtain_default_ipc_name() -> str:
     single segment, while separate launches get distinct names.
     """
 
+    explicit = os.getenv("KVCACHED_IPC_NAME")
+    if explicit:
+        # An explicit IPC name is a contract between all processes in one
+        # serving instance.  Treat it as exact after SHM-safe sanitization: do
+        # not probe or auto-suffix it, because late-importing TP workers must
+        # still join the same namespace.
+        return _sanitize_segment(explicit)
+
     engine_tag = _detect_engine_tag()
     try:
         group_id = os.getpgid(0)
@@ -61,24 +69,6 @@ def _obtain_default_ipc_name() -> str:
             group_id = os.getsid(0)
         except Exception:
             group_id = os.getpid()
-
-    explicit = os.getenv("KVCACHED_IPC_NAME")
-    if explicit:
-        preferred = _sanitize_segment(explicit)
-
-        if not _ipc_segment_exists(preferred):
-            return preferred
-
-        base_candidate = f"{preferred}_{engine_tag}_{group_id}"
-        if not _ipc_segment_exists(base_candidate):
-            return base_candidate
-        # As a last resort, append a small numeric suffix until unique
-        for i in range(1, 100):
-            candidate = f"{base_candidate}_{i}"
-            if not _ipc_segment_exists(candidate):
-                return candidate
-        # If everything somehow exists, fall back to PID-specific name
-        return f"{base_candidate}_{os.getpid()}"
 
     # No explicit override: start from conventional base and ensure uniqueness
     base = "kvcached"

--- a/tests/test_ipc_name.py
+++ b/tests/test_ipc_name.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import sys
+import types
+
+
+def test_explicit_ipc_name_is_exact_without_probing(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", types.ModuleType("torch"))
+
+    utils = importlib.import_module("kvcached.utils")
+
+    monkeypatch.setenv("KVCACHED_IPC_NAME", "shared-instance-ipc")
+
+    def fail_if_probed(name):
+        raise AssertionError(f"explicit IPC name should not probe {name}")
+
+    monkeypatch.setattr(utils, "_ipc_segment_exists", fail_if_probed)
+
+    assert utils._obtain_default_ipc_name() == "shared-instance-ipc"


### PR DESCRIPTION
### Summary

Fixes #378.

Treat `KVCACHED_IPC_NAME` as an exact IPC namespace when it is explicitly set. The generated-name path still keeps the existing uniqueness probing.

### Why

The explicit env var is used as a process coordination contract. If kvcached auto-suffixes it after the segment already exists, later workers can join a different namespace than the process that created the segment.

### Tests

```bash
python -m pytest tests/test_ipc_name.py -q
python -m py_compile kvcached/utils.py tests/test_ipc_name.py
```
