### PR TITLE
fix(vllm): floor max cached blocks at 1 for sub-block-size budgets (#343)

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Optional
 
 from kvcached.integration.patch_base import BasePatch, enable_kvcached
 from kvcached.integration.version_utils import VersionAwarePatch, VersionRange, version_range
-from kvcached.utils import KVCachedConfigError
+from kvcached.utils import KVCachedConfigError, get_kvcached_logger
 
 if TYPE_CHECKING:
     # These types are imported from vLLM at runtime via getattr()
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
         KVCacheBlock = Any  # type: ignore[misc,assignment]
         KVCacheEvent = Any  # type: ignore[misc,assignment]
         Request = Any  # type: ignore[misc,assignment]
+
+
+logger = get_kvcached_logger()
 
 
 def _is_attention_spec(spec: Any) -> bool:
@@ -249,12 +252,32 @@ def _get_max_cached_blocks(block_size: int) -> int:
 
     Returns -1 (unlimited) when MAX_CACHED_TOKENS < 0.
     Returns 0  (disabled — evict on free) when MAX_CACHED_TOKENS == 0.
-    Otherwise returns MAX_CACHED_TOKENS // block_size.
+    Otherwise returns ``max(1, MAX_CACHED_TOKENS // block_size)``.
+
+    The floor matters: a *positive* ``MAX_CACHED_TOKENS`` smaller than
+    ``block_size`` (e.g. 8 tokens with a 16-token block) integer-divides to
+    ``0``, which is indistinguishable from the ``== 0`` "disabled" sentinel and
+    would silently turn prefix caching off. Flooring at one block keeps caching
+    enabled for the smallest non-zero budget, matching the user's intent; a
+    warning is logged so the effective granularity is not silent.
     """
     from kvcached.utils import MAX_CACHED_TOKENS
     if MAX_CACHED_TOKENS < 0:
         return -1
-    return MAX_CACHED_TOKENS // block_size
+    if MAX_CACHED_TOKENS == 0:
+        return 0
+    max_cached_blocks = MAX_CACHED_TOKENS // block_size
+    if max_cached_blocks == 0:
+        logger.warning(
+            "KVCACHED_MAX_CACHED_TOKENS=%d is smaller than the KV block size "
+            "(%d tokens); flooring max cached blocks to 1 so prefix caching "
+            "stays enabled. Set KVCACHED_MAX_CACHED_TOKENS=0 to disable "
+            "caching explicitly.",
+            MAX_CACHED_TOKENS,
+            block_size,
+        )
+        return 1
+    return max_cached_blocks
 
 
 def _make_cache_key(block_hash: Any, group_id: int) -> bytes:

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Optional
 
 from kvcached.integration.patch_base import BasePatch, enable_kvcached
 from kvcached.integration.version_utils import VersionAwarePatch, VersionRange, version_range
-from kvcached.utils import KVCachedConfigError
+from kvcached.utils import KVCachedConfigError, get_kvcached_logger
 
 if TYPE_CHECKING:
     # These types are imported from vLLM at runtime via getattr()
@@ -28,6 +28,9 @@ if TYPE_CHECKING:
         KVCacheBlock = Any  # type: ignore[misc,assignment]
         KVCacheEvent = Any  # type: ignore[misc,assignment]
         Request = Any  # type: ignore[misc,assignment]
+
+
+logger = get_kvcached_logger()
 
 
 def _is_attention_spec(spec: Any) -> bool:
@@ -307,12 +310,32 @@ def _get_max_cached_blocks(block_size: int) -> int:
 
     Returns -1 (unlimited) when MAX_CACHED_TOKENS < 0.
     Returns 0  (disabled — evict on free) when MAX_CACHED_TOKENS == 0.
-    Otherwise returns MAX_CACHED_TOKENS // block_size.
+    Otherwise returns ``max(1, MAX_CACHED_TOKENS // block_size)``.
+
+    The floor matters: a *positive* ``MAX_CACHED_TOKENS`` smaller than
+    ``block_size`` (e.g. 8 tokens with a 16-token block) integer-divides to
+    ``0``, which is indistinguishable from the ``== 0`` "disabled" sentinel and
+    would silently turn prefix caching off. Flooring at one block keeps caching
+    enabled for the smallest non-zero budget, matching the user's intent; a
+    warning is logged so the effective granularity is not silent.
     """
     from kvcached.utils import MAX_CACHED_TOKENS
     if MAX_CACHED_TOKENS < 0:
         return -1
-    return MAX_CACHED_TOKENS // block_size
+    if MAX_CACHED_TOKENS == 0:
+        return 0
+    max_cached_blocks = MAX_CACHED_TOKENS // block_size
+    if max_cached_blocks == 0:
+        logger.warning(
+            "KVCACHED_MAX_CACHED_TOKENS=%d is smaller than the KV block size "
+            "(%d tokens); flooring max cached blocks to 1 so prefix caching "
+            "stays enabled. Set KVCACHED_MAX_CACHED_TOKENS=0 to disable "
+            "caching explicitly.",
+            MAX_CACHED_TOKENS,
+            block_size,
+        )
+        return 1
+    return max_cached_blocks
 
 
 def _cache_dtype_str(model_runner: Any) -> Optional[str]:

--- a/tests/manifests/cpu.txt
+++ b/tests/manifests/cpu.txt
@@ -1,5 +1,6 @@
 tests/test_alloc_rollback.py
 tests/test_bestfit_page_selection.py
+tests/test_get_max_cached_blocks.py
 tests/test_ipc_name.py
 tests/test_ipc_timeout.py
 tests/test_kv_cache_shape_compat.py

--- a/tests/test_get_max_cached_blocks.py
+++ b/tests/test_get_max_cached_blocks.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``_get_max_cached_blocks`` (MAX_CACHED_TOKENS → block budget).
+
+GPU-free: ``_get_max_cached_blocks`` is a module-level pure function in
+``kvcached.integration.vllm.patches`` and needs neither the ``vmm_ops``
+extension, a GPU, nor an installed vLLM.
+
+It guards the sub-block-size floor fix: a *positive* ``KVCACHED_MAX_CACHED_TOKENS``
+smaller than ``block_size`` used to integer-divide to ``0`` — the same value the
+``== 0`` "disabled" sentinel produces — which silently turned prefix caching off
+(issue #343). The positive branch now floors at one block.
+"""
+import logging
+
+import pytest
+
+from kvcached.integration.vllm import patches
+from kvcached.integration.vllm.patches import _get_max_cached_blocks
+
+
+@pytest.fixture
+def set_max_cached_tokens(monkeypatch):
+    """Set the module-level MAX_CACHED_TOKENS the function reads at call time."""
+
+    def _set(value: int) -> None:
+        monkeypatch.setattr("kvcached.utils.MAX_CACHED_TOKENS", value)
+
+    return _set
+
+
+@pytest.fixture
+def captured_warnings():
+    """Collect records from the module logger.
+
+    ``get_kvcached_logger`` sets ``propagate = False``, so pytest's root-attached
+    ``caplog`` never sees these records; attach a handler to the logger directly.
+    """
+    records: list[logging.LogRecord] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _ListHandler(level=logging.WARNING)
+    old_level = patches.logger.level
+    patches.logger.addHandler(handler)
+    patches.logger.setLevel(logging.WARNING)
+    try:
+        yield records
+    finally:
+        patches.logger.removeHandler(handler)
+        patches.logger.setLevel(old_level)
+
+
+def test_negative_is_unlimited(set_max_cached_tokens):
+    set_max_cached_tokens(-1)
+    assert _get_max_cached_blocks(16) == -1
+    set_max_cached_tokens(-9999)
+    assert _get_max_cached_blocks(16) == -1
+
+
+def test_zero_is_disabled(set_max_cached_tokens):
+    set_max_cached_tokens(0)
+    assert _get_max_cached_blocks(16) == 0
+
+
+def test_small_positive_floors_to_one_block(set_max_cached_tokens):
+    """Regression for #343: 0 < tokens < block_size must not collapse to 0."""
+    set_max_cached_tokens(8)
+    assert _get_max_cached_blocks(16) == 1
+
+
+@pytest.mark.parametrize("tokens", [1, 8, 15])
+def test_below_block_size_never_disables(set_max_cached_tokens, tokens):
+    """Any positive budget below one block stays enabled (>= 1 block)."""
+    set_max_cached_tokens(tokens)
+    assert _get_max_cached_blocks(16) == 1
+
+
+def test_exact_multiple(set_max_cached_tokens):
+    set_max_cached_tokens(32)
+    assert _get_max_cached_blocks(16) == 2
+
+
+def test_non_multiple_rounds_down_but_stays_positive(set_max_cached_tokens):
+    set_max_cached_tokens(40)
+    assert _get_max_cached_blocks(16) == 2  # floor(40 / 16) == 2
+
+
+def test_large_value(set_max_cached_tokens):
+    set_max_cached_tokens(16000)
+    assert _get_max_cached_blocks(16) == 1000
+
+
+def test_positive_result_distinct_from_disabled(set_max_cached_tokens):
+    """A positive budget must never return the 0 'disabled' sentinel."""
+    for tokens in range(1, 17):
+        set_max_cached_tokens(tokens)
+        assert _get_max_cached_blocks(16) >= 1
+
+
+def test_clamp_emits_warning(set_max_cached_tokens, captured_warnings):
+    """The floor must not be silent — a warning explains the effective budget."""
+    set_max_cached_tokens(8)
+    assert _get_max_cached_blocks(16) == 1
+    assert any("flooring max cached blocks to 1" in r.getMessage()
+               for r in captured_warnings)
+
+
+def test_no_warning_when_budget_is_a_full_block(
+        set_max_cached_tokens, captured_warnings):
+    set_max_cached_tokens(16)
+    assert _get_max_cached_blocks(16) == 1
+    assert not captured_warnings


### PR DESCRIPTION
## Summary

Fixes #343.

`_get_max_cached_blocks` (`kvcached/integration/vllm/patches.py`) converts the
unified `KVCACHED_MAX_CACHED_TOKENS` config into a block budget with:

```python
return MAX_CACHED_TOKENS // block_size
```

When `KVCACHED_MAX_CACHED_TOKENS` is a **small positive** value below one KV
block (e.g. `8` with a `16`-token `block_size`), integer division floors to `0`.
That is the exact value the `== 0` **"disabled — evict on free"** sentinel
produces, so a user who asked for a small non-zero cache gets prefix caching
**silently turned off** instead of a small cap.

## Fix

Handle the sentinels explicitly and floor the positive branch at one block:

```python
if MAX_CACHED_TOKENS < 0:
    return -1          # unlimited (unchanged)
if MAX_CACHED_TOKENS == 0:
    return 0           # disabled  (unchanged)
max_cached_blocks = MAX_CACHED_TOKENS // block_size
if max_cached_blocks == 0:
    logger.warning(...)  # no longer silent
    return 1
return max_cached_blocks
```

- A positive-but-sub-block budget now keeps prefix caching **enabled** at the
  smallest viable unit (1 block), which the consumer at
  `ElasticBlockPool` (`max_cached_blocks >= 0 and len(evictable) > max_cached_blocks`)
  treats as a valid cap of one evictable block.
- The clamp is **no longer silent** — a `warning` reports the effective
  granularity and points at `KVCACHED_MAX_CACHED_TOKENS=0` for explicit disable.
- `< 0` (unlimited), `== 0` (disabled), and `>= block_size` budgets are
  **byte-for-byte unchanged**; the only behavioral change is the previously
  broken `0 < tokens < block_size` case.

## Tests

Adds `tests/test_get_max_cached_blocks.py` — GPU-free (no `vmm_ops`, GPU, or
installed vLLM), mirroring the existing `tests/test_make_cache_key.py`. Covers
the `-1 / 0 / sub-block / exact-multiple / non-multiple / large` boundaries, the
`#343` regression (`0 < tokens < block_size` never collapses to the disabled
sentinel), and the warn-on-clamp / no-warn-on-full-block behavior.

```
$ pytest tests/test_get_max_cached_blocks.py -q
12 passed
```
