### PR TITLE
fix: make FTensor page map operations idempotent

### DIFF
--- a/csrc/ftensor.cpp
+++ b/csrc/ftensor.cpp
@@ -102,8 +102,7 @@ bool FTensor::map(offset_t offset) {
 
   page_id_t page_id = offset / page_size_;
   if (mapping_.find(page_id) != mapping_.end()) {
-    LOGGER(ERROR, "Page %ld is already mapped.", page_id);
-    return false;
+    return true;
   }
 
   auto vaddr = reinterpret_cast<generic_ptr_t>(
@@ -122,8 +121,7 @@ bool FTensor::unmap(offset_t offset) {
 
   page_id_t page_id = offset / page_size_;
   if (mapping_.find(page_id) == mapping_.end()) {
-    LOGGER(ERROR, "Page %ld is not mapped.", page_id);
-    return false;
+    return true;
   }
 
   auto vaddr = reinterpret_cast<generic_ptr_t>(


### PR DESCRIPTION
### Summary  Fixes #381.  Make `FTensor::map()` and `FTensor::unmap()` tolerate idempotent page operations:  - mapping an already-mapped page returns success - unmapping an already-unmapped page returns success - real VMM map/unmap failures still propagate through the existing `CHECK_GPU` paths  This avoids treating duplicate runtime page-map coordination messages as hard failures.  ### Status

Withdrawn after maintainer and internal review. This was a preventive DFX finding from code inspection, not a reproduced runtime failure. We could not establish a legitimate duplicate map/unmap path, and silently accepting duplicates could hide an upper-layer bookkeeping error. The separate partial-transaction problem remains tracked by #412/#418.