### PR TITLE
fix(sglang): bound paged free-index reduction cost

### DIFF
--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -17,6 +17,7 @@ from kvcached.utils import MAX_CACHED_TOKENS, get_kvcached_logger
 
 BYTES_PER_GB = 1024**3
 _CAPACITY_QUERY_FAILED = -(1 << 63)
+PAGED_FREE_CPU_UNIQUE_MAX_INDICES = 4096
 
 # Version ranges for SGLang support
 SGLANG_ALL_RANGE = ">=0.4.9"  # All supported versions
@@ -423,11 +424,13 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
                         return
 
                     if self.is_not_in_free_group:
+                        free_index = free_index.detach()
+                        if free_index.numel() <= PAGED_FREE_CPU_UNIQUE_MAX_INDICES:
+                            free_index = free_index.to(
+                                device="cpu", non_blocking=False
+                            )
                         page_ids = torch.unique(free_index // self.page_size)
-                        try:
-                            indices: list[int] = page_ids.cpu().numpy().tolist()
-                        except Exception:
-                            indices = list(page_ids)
+                        indices: list[int] = page_ids.tolist()
                         return self.kvcached_allocator.free(indices)
                     else:
                         self.free_group.append(free_index)
@@ -774,7 +777,7 @@ class ElasticMLAMemoryPoolPatch(VersionAwarePatch, BasePatch):
                             kvcache_shape=(
                                 size + page_size,
                                 1,
-                                self.kv_cache_dim,
+                                cast(int, self.kv_cache_dim),
                             ),
                             dtype=dtype,
                             device=device,

--- a/tests/manifests/cpu.txt
+++ b/tests/manifests/cpu.txt
@@ -10,6 +10,7 @@ tests/test_observability.py
 tests/test_page_aware_eviction.py
 tests/test_prefix_cache.py
 tests/test_resize_reserved_order.py
+tests/test_sglang_allocator_free_cpu.py
 tests/test_sglang_allocator_patch.py
 tests/test_sglang_autopatch_order.py
 tests/test_sglang_virtual_kv_capacity.py

--- a/tests/test_sglang_allocator_free_cpu.py
+++ b/tests/test_sglang_allocator_free_cpu.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib
+import importlib.machinery
+import sys
+import types
+from typing import Any
+from unittest import mock
+
+
+class FakeTensor(list):
+    def numel(self):
+        return len(self)
+
+    def detach(self):
+        return self
+
+    def __floordiv__(self, value):
+        return FakeTensor([item // value for item in self])
+
+    def numpy(self):
+        raise AssertionError("free page ids should use tolist() directly")
+
+    def tolist(self):
+        return list(self)
+
+
+class TrackingTensor(FakeTensor):
+    def __init__(self, values, reported_numel=None):
+        super().__init__(values)
+        self.to_calls = []
+        self.reported_numel = reported_numel
+
+    def numel(self):
+        if self.reported_numel is not None:
+            return self.reported_numel
+        return super().numel()
+
+    def to(self, *args, **kwargs):
+        self.to_calls.append((args, kwargs))
+        return self
+
+
+def _load_sglang_patches(monkeypatch):
+    torch_mock = mock.MagicMock()
+    torch_mock.__version__ = "2.6.0"
+    torch_mock.int64 = "int64"
+    torch_mock.empty.side_effect = lambda shape, **_kwargs: FakeTensor(
+        [0] * (shape if isinstance(shape, int) else shape[0])
+    )
+    torch_mock.unique.side_effect = lambda values: FakeTensor(sorted(set(values)))
+    monkeypatch.setitem(sys.modules, "torch", torch_mock)
+
+    utils_mod: Any = types.ModuleType("sglang.srt.utils")
+    utils_mod.next_power_of_2 = lambda value: 1 << (int(value) - 1).bit_length()
+    utils_mod.get_num_new_pages = lambda **_kwargs: 0
+
+    for name in ("sglang", "sglang.srt"):
+        module = types.ModuleType(name)
+        module.__spec__ = importlib.machinery.ModuleSpec(name, loader=None)
+        monkeypatch.setitem(sys.modules, name, module)
+    monkeypatch.setitem(sys.modules, "sglang.srt.utils", utils_mod)
+
+    from kvcached.integration.sglang import patches
+
+    importlib.reload(patches)
+    return patches
+
+
+def _make_paged_allocator(patches):
+    class BaseTokenToKVPoolAllocator:
+        def __init__(self, size, page_size, _dtype, device, _kvcache):
+            self.size = size
+            self.page_size = page_size
+            self.device = device
+            self.free_group = []
+            self.is_not_in_free_group = True
+
+    class Kernel:
+        def __call__(self, **_kwargs):
+            return None
+
+        def __getitem__(self, _grid):
+            def run(**_kwargs):
+                return None
+
+            return run
+
+    alloc_mod = types.SimpleNamespace(
+        BaseTokenToKVPoolAllocator=BaseTokenToKVPoolAllocator,
+        alloc_extend_kernel=Kernel(),
+        alloc_decode_kernel=Kernel(),
+    )
+
+    assert patches.ElasticAllocatorPatch().inject_elastic_paged_allocator(alloc_mod)
+
+    freed = []
+    allocator = types.SimpleNamespace(
+        alloc=lambda need_size: list(range(need_size)),
+        free=lambda indices: freed.append(indices),
+    )
+    kvcache = types.SimpleNamespace(kvcached_allocator=allocator)
+    paged = alloc_mod.ElasticPagedTokenToKVPoolAllocator(
+        128,
+        16,
+        object(),
+        "cuda:0",
+        kvcache,
+    )
+
+    return paged, freed
+
+
+def test_elastic_paged_allocator_moves_small_free_to_cpu(monkeypatch):
+    patches = _load_sglang_patches(monkeypatch)
+    paged, freed = _make_paged_allocator(patches)
+
+    free_index = TrackingTensor([0, 16, 32, 48, 48])
+    paged.free(free_index)
+
+    assert free_index.to_calls == [((), {"device": "cpu", "non_blocking": False})]
+    assert freed == [[0, 1, 2, 3]]
+
+
+def test_elastic_paged_allocator_reduces_large_free_before_cpu_copy(monkeypatch):
+    patches = _load_sglang_patches(monkeypatch)
+    paged, freed = _make_paged_allocator(patches)
+
+    free_index = TrackingTensor(
+        [0, 16, 32, 48, 48],
+        reported_numel=patches.PAGED_FREE_CPU_UNIQUE_MAX_INDICES + 1,
+    )
+    paged.free(free_index)
+
+    assert free_index.to_calls == []
+    assert freed == [[0, 1, 2, 3]]


### PR DESCRIPTION
## Summary

Fixes #382.

Bound the cost of page-ID derivation in `ElasticPagedTokenToKVPoolAllocator.free()` by using two paths:

- for at most 4,096 released token indices, copy to CPU first and run `torch.unique()` there, avoiding a small CUDA reduction launch;
- for larger releases, reduce to unique page IDs on GPU first, then copy only the reduced page-ID list to Python, avoiding a full-index D2H copy.

## Why two paths

The kvcached allocator ultimately consumes ordinary CPU page IDs. The previous implementation always ran `torch.unique()` on CUDA and immediately synchronized the result back to Python. Moving all indices to CPU first improves small completion/cancellation releases, but scales poorly when radix-cache eviction or grouped frees release many pages at once.

SGLang call sites can pass slices and concatenated free groups, so it is not safe to assume indices are sorted or that one index can simply be sampled per page. The adaptive path preserves exact `torch.unique()` semantics on both sides of the threshold.

## Changes

1. Detach the incoming free-index tensor once.
2. Use CPU reduction for up to `PAGED_FREE_CPU_UNIQUE_MAX_INDICES` (4,096) indices.
3. Preserve GPU reduction for larger batches.
4. Test both threshold sides and verify the same page IDs are released.

## Validation

### Automated

- `python -m pytest tests/test_sglang_allocator_free_cpu.py -q` -> 2 passed
- `python -m compileall -q kvcached/integration/sglang tests/test_sglang_allocator_free_cpu.py`
- `git diff --check`
- repository pre-commit checks passed across Windows and Linux; the Linux retry covered the bash-based SPDX hooks and `mypy-local`. A full Linux pre-commit bootstrap was also attempted, but `actionlint` dependency installation timed out against the Go proxy before checks began; `actionlint` itself passed in the Windows run.

### RTX 4090 GPU A/B

Environment: SGLang 0.5.13, PyTorch 2.11.0+cu130, CUDA 13.0, MPS active-thread percentage 100, page size 256. Each cell is P50 over 200 measured calls after 20 warmups.

| Released pages | Token indices | Original GPU unique (ms) | All-CPU unique (ms) | Adaptive path (ms) |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 256 | 0.060 | 0.029 | 0.029 |
| 4 | 1,024 | 0.060 | 0.039 | 0.039 |
| 16 | 4,096 | 0.118 | 0.082 | 0.083 |
| 32 | 8,192 | 0.116 | 0.143 | 0.114 |
| 64 | 16,384 | 0.110 | 0.265 | 0.103 |
| 128 | 32,768 | 0.111 | 0.851 | 0.105 |
| 256 | 65,536 | 0.113 | 1.047 | 0.112 |

Instrumentation confirmed that the adaptive implementation calls `torch.unique()` on CPU for 1/4/16-page cases and on `cuda:0` from 32 pages onward. All cases released the expected unique page IDs.

The harness used a partial `DeepseekV4ForCausalLM` artifact and loaded an attention weight onto the GPU, while exercising the real SGLang paged allocator class. The available partial weights were generated for the Transformers/vLLM parameter layout and cannot load as a complete SGLang 0.5.13 serving model, so this is focused allocator-path evidence rather than a replacement for an end-to-end H20 DeepSeek-V4 benchmark.
