### PR TITLE
Add read-only observability snapshots

### DIFF
--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -7,6 +7,15 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import torch
 
 from kvcached.kv_cache_manager import KVCacheManager
+from kvcached.observability import (
+    build_runtime_snapshot,
+    get_registered_kv_cache_pool_snapshot_dicts,
+    get_registered_kv_cache_pool_snapshots,
+)
+from kvcached.pool_registry import (
+    clear_registered_kv_cache_pools,
+    register_kv_cache_pool,
+)
 from kvcached.tp_ipc_util import start_worker_listener_thread
 from kvcached.utils import CONTIGUOUS_LAYOUT, PAGE_SIZE, get_kvcached_logger, normalize_gpu_device
 from kvcached.vmm_ops import (
@@ -55,12 +64,42 @@ def init_kvcached(
 def shutdown_kvcached() -> None:
     global _kvcached_initialized, _kvcached_device, _async_sched
     if not _kvcached_initialized:
+        clear_registered_kv_cache_pools(integration="sglang")
         return
 
     _shutdown_kvcached_impl()
+    clear_registered_kv_cache_pools(integration="sglang")
     _kvcached_initialized = False
     _kvcached_device = None
     _async_sched = False
+
+
+def observability_snapshot():
+    """Return a read-only snapshot of the SGLang integration state."""
+    return build_runtime_snapshot(
+        engine="sglang",
+        initialized=_kvcached_initialized,
+        device=_kvcached_device,
+        world_size=_world_size,
+        pp_rank=_pp_rank,
+        async_sched=_async_sched,
+        contiguous_layout=_contiguous_layout,
+    )
+
+
+def observability_snapshot_dict() -> Dict[str, Any]:
+    """Return a JSON-serializable snapshot of the SGLang integration state."""
+    return observability_snapshot().to_dict()
+
+
+def kv_cache_pool_snapshots():
+    """Return read-only snapshots for all live SGLang KV pools."""
+    return get_registered_kv_cache_pool_snapshots(integration="sglang")
+
+
+def kv_cache_pool_snapshot_dicts() -> List[Dict[str, Any]]:
+    """Return JSON-serializable snapshots for all live SGLang KV pools."""
+    return get_registered_kv_cache_pool_snapshot_dicts(integration="sglang")
 
 
 def alloc_kv_cache(
@@ -409,11 +448,12 @@ def get_kv_cache_manager(
     reserve_null_block: bool = True,
     num_kv_buffers: int = 2,
     group_id: int = 0,
+    pool_name: Optional[str] = None,
 ) -> KVCacheManager:
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
 
-    return KVCacheManager(
+    manager = KVCacheManager(
         num_blocks,
         block_size,
         cell_size,
@@ -424,4 +464,10 @@ def get_kv_cache_manager(
         reserve_null_block=reserve_null_block,
         num_kv_buffers=num_kv_buffers,
         group_id=group_id,
+        pool_name=pool_name,
     )
+    register_kv_cache_pool(
+        manager,
+        integration="sglang",
+    )
+    return manager

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -412,6 +412,7 @@ class ElasticMemoryPoolPatch(VersionAwarePatch, BasePatch):
                     self.kvcached_allocator = kvi.get_kv_cache_manager(
                         math.ceil(size / page_size) + 1, page_size, self.cell_size, layer_num,
                         group_id=self._group_id,
+                        pool_name="mha",
                     )
 
                     k_size, v_size = self.get_kv_size_bytes()
@@ -653,6 +654,7 @@ class ElasticMLAMemoryPoolPatch(VersionAwarePatch, BasePatch):
                     self.kvcached_allocator = kvi.get_kv_cache_manager(
                         size + page_size, page_size, self.cell_size, layer_num,
                         num_kv_buffers=1,
+                        pool_name="mla",
                     )
 
                     kv_size = self.get_kv_size_bytes()
@@ -982,6 +984,7 @@ class ElasticMambaPoolPatch(VersionAwarePatch, BasePatch):
                         reserve_null_block=True,
                         num_kv_buffers=1,
                         group_id=self._group_id,
+                        pool_name="mamba",
                     )
 
                     # Placeholder so code that touches self.free_slots in

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -2,11 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 
 from kvcached.kv_cache_manager import KVCacheManager
+from kvcached.observability import (
+    build_runtime_snapshot,
+    get_registered_kv_cache_pool_snapshot_dicts,
+    get_registered_kv_cache_pool_snapshots,
+)
+from kvcached.pool_registry import (
+    clear_registered_kv_cache_pools,
+    register_kv_cache_pool,
+)
 from kvcached.tp_ipc_util import start_worker_listener_thread
 from kvcached.utils import CONTIGUOUS_LAYOUT, PAGE_SIZE, get_kvcached_logger, normalize_gpu_device
 from kvcached.vmm_ops import (
@@ -77,9 +86,11 @@ def init_kvcached(
 def shutdown_kvcached() -> None:
     global _kvcached_initialized, _kvcached_device, _async_sched
     if not _kvcached_initialized:
+        clear_registered_kv_cache_pools(integration="vllm")
         return
 
     _shutdown_kvcached_impl()
+    clear_registered_kv_cache_pools(integration="vllm")
     _kvcached_initialized = False
     _kvcached_device = None
     _async_sched = False
@@ -190,6 +201,35 @@ def build_kv_views(
         ]
 
     return kv_tensors, page_size_bytes
+
+
+def observability_snapshot():
+    """Return a read-only snapshot of the vLLM integration state."""
+    return build_runtime_snapshot(
+        engine="vllm",
+        initialized=_kvcached_initialized,
+        device=_kvcached_device,
+        world_size=_world_size,
+        pp_rank=_pp_rank,
+        async_sched=_async_sched,
+        contiguous_layout=_contiguous_layout,
+        is_worker=_is_worker,
+    )
+
+
+def observability_snapshot_dict() -> Dict[str, Any]:
+    """Return a JSON-serializable snapshot of the vLLM integration state."""
+    return observability_snapshot().to_dict()
+
+
+def kv_cache_pool_snapshots():
+    """Return read-only snapshots for all live vLLM KV pools."""
+    return get_registered_kv_cache_pool_snapshots(integration="vllm")
+
+
+def kv_cache_pool_snapshot_dicts() -> List[Dict[str, Any]]:
+    """Return JSON-serializable snapshots for all live vLLM KV pools."""
+    return get_registered_kv_cache_pool_snapshot_dicts(integration="vllm")
 
 
 def alloc_kv_cache(
@@ -506,11 +546,12 @@ def get_kv_cache_manager(
     num_layers: int,
     num_kv_buffers: int = 2,
     group_id: int = 0,
+    pool_name: Optional[str] = None,
 ) -> KVCacheManager:
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
 
-    return KVCacheManager(
+    manager = KVCacheManager(
         num_blocks,
         block_size,
         cell_size,
@@ -521,4 +562,10 @@ def get_kv_cache_manager(
         num_kv_buffers=num_kv_buffers,
         group_id=group_id,
         reserve_null_block=True,
+        pool_name=pool_name,
     )
+    register_kv_cache_pool(
+        manager,
+        integration="vllm",
+    )
+    return manager

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -420,7 +420,8 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
 
                 self.kv_cache_manager = get_kv_cache_manager(
                     num_gpu_blocks, block_size, cell_size, num_layers,
-                    num_kv_buffers=num_kv_buffers)
+                    num_kv_buffers=num_kv_buffers,
+                    pool_name="block_pool")
 
                 # Allocate a dedicated null block – a placeholder for skipped
                 # positions (e.g. sliding-window / chunked-local attention).

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -582,6 +582,12 @@ class KVCacheManager:
     # Private methods
     @synchronized
     def _get_num_alloced_blocks(self) -> int:
+        """Return how many blocks are currently handed out of their pages.
+
+        Reserved blocks (``self.reserved_blocks``) are part of this count:
+        try_to_reserve() obtains them via alloc(), so they have already left
+        their pages. They are deliberately NOT added a second time below.
+        """
         # Blocks from fully allocated pages
         blocks_from_full_pages = len(self.full_pages) * InternalPage.get_num_blocks(
             self.page_size, self.block_mem_size)
@@ -591,7 +597,4 @@ class KVCacheManager:
         # allocated pages minus the number of free blocks.
         blocks_from_avail_pages = len(self.avail_pages) * InternalPage.get_num_blocks(
             self.page_size, self.block_mem_size) - self.num_avail_blocks
-        # Blocks from reserved blocks
-        blocks_from_reserved_blocks = len(self.reserved_blocks)
-        return (blocks_from_full_pages + blocks_from_avail_pages +
-                blocks_from_reserved_blocks)
+        return blocks_from_full_pages + blocks_from_avail_pages

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -69,6 +69,7 @@ class KVCacheManager:
         reserve_null_block: bool = False,
         num_kv_buffers: int = 2,
         group_id: int = 0,
+        pool_name: Optional[str] = None,
     ):
         """
         Args:
@@ -85,6 +86,8 @@ class KVCacheManager:
                 1 for MLA combined KV).
             group_id: KV cache group identifier for hybrid attention models.
                 Different groups have independent FTensors and page spaces.
+            pool_name: Stable, low-cardinality name assigned by the engine
+                integration when this pool is created.
         """
         self.num_blocks = num_blocks
         self.block_mem_size = block_size * cell_size
@@ -92,6 +95,7 @@ class KVCacheManager:
         self.num_kv_buffers = num_kv_buffers
         self.reserve_null_block = reserve_null_block
         self.group_id = group_id
+        self._pool_name = pool_name
 
         # The physical page size used by kvcached page allocator.
         self.page_size = PAGE_SIZE
@@ -505,6 +509,27 @@ class KVCacheManager:
             return memory_bytes / (1024**3)
         else:
             raise ValueError(f"Unknown unit: {unit}")
+
+    @property
+    def pool_name(self) -> Optional[str]:
+        """Return the stable name assigned when this pool was created."""
+        return self._pool_name
+
+    @synchronized
+    def observability_snapshot(self, *, integration=None):
+        """Return a read-only snapshot of this KV cache pool."""
+        from kvcached.observability import build_kv_cache_pool_snapshot
+        return build_kv_cache_pool_snapshot(
+            self,
+            integration=integration,
+        )
+
+    @synchronized
+    def observability_snapshot_dict(self, *, integration=None):
+        """Return a JSON-serializable read-only snapshot of this KV cache pool."""
+        return self.observability_snapshot(
+            integration=integration,
+        ).to_dict()
 
     @synchronized
     def clear(self):

--- a/kvcached/observability.py
+++ b/kvcached/observability.py
@@ -68,6 +68,14 @@ class KVCachePoolSnapshot:
     ``reserved_pages``, which counts *physical pages* held by the background
     pre-allocation thread.
 
+    Virtual reservation:
+
+    * ``virtual_per_layer_bytes`` -- virtual bytes reserved for one layer,
+      across all of its KV buffers (K and V for MHA, the single combined
+      buffer for MLA).
+    * ``virtual_total_bytes`` -- the whole pool, i.e.
+      ``virtual_per_layer_bytes * num_layers``.
+
     Values are best-effort rather than a consistent point-in-time cut: the
     C++ pre-allocation thread mutates page counters without taking the
     manager lock, so fields may come from marginally different instants.
@@ -165,9 +173,15 @@ def build_kv_cache_pool_snapshot(
         effective_free_pages = min(free_pages, available_physical_pages + reserved_pages)
 
     mapped_bytes = int(manager.get_mapped_memory_size("bytes"))
-    virtual_per_layer_bytes = _int_attr(manager, "mem_size") or 0
     num_layers = _int_attr(manager, "num_layers") or 0
     num_kv_buffers = _int_attr(manager, "num_kv_buffers") or 0
+    # manager.mem_size is the virtual reservation for ONE KV buffer of ONE
+    # layer -- K (or V) for MHA, the single combined buffer for MLA -- which
+    # is why the total scales by both num_layers and num_kv_buffers. Scale by
+    # num_kv_buffers here so the exported field means what its name says: all
+    # KV buffers of one layer.
+    virtual_bytes_per_buffer = _int_attr(manager, "mem_size") or 0
+    virtual_per_layer_bytes = virtual_bytes_per_buffer * num_kv_buffers
     block_size_bytes = _int_attr(manager, "block_mem_size") or 0
     bytes_per_block = block_size_bytes * num_layers * num_kv_buffers
     # available_size() can transiently go negative: it derives from
@@ -198,7 +212,7 @@ def build_kv_cache_pool_snapshot(
         reserved_bytes=reserved_blocks * bytes_per_block,
         null_block_reserved=getattr(manager, "null_block", None) is not None,
         virtual_per_layer_bytes=virtual_per_layer_bytes,
-        virtual_total_bytes=virtual_per_layer_bytes * num_layers * num_kv_buffers,
+        virtual_total_bytes=virtual_per_layer_bytes * num_layers,
         mapped_bytes=mapped_bytes,
         total_pages=_call_int(allocator, "get_num_total_pages"),
         free_pages=free_pages,

--- a/kvcached/observability.py
+++ b/kvcached/observability.py
@@ -51,7 +51,27 @@ class RuntimeSnapshot:
 
 @dataclass(frozen=True)
 class KVCachePoolSnapshot:
-    """Read-only state of one kvcached-backed KV pool."""
+    """Read-only state of one kvcached-backed KV pool.
+
+    Block accounting (these fields are NOT mutually exclusive -- do not sum
+    them):
+
+    * ``allocated_blocks`` -- blocks currently handed out of their pages.
+      Includes ``reserved_blocks``.
+    * ``reserved_blocks`` -- the subset of ``allocated_blocks`` held on the
+      pool's reserve ledger. ``alloc()`` drains this ledger first.
+    * ``available_blocks`` -- what the next request could obtain. Because
+      ``alloc()`` drains the reserve ledger first, this also includes
+      ``reserved_blocks``.
+
+    ``reserved_blocks`` counts *blocks* on that ledger and is unrelated to
+    ``reserved_pages``, which counts *physical pages* held by the background
+    pre-allocation thread.
+
+    Values are best-effort rather than a consistent point-in-time cut: the
+    C++ pre-allocation thread mutates page counters without taking the
+    manager lock, so fields may come from marginally different instants.
+    """
 
     schema_version: str
     pool_type: str
@@ -150,8 +170,13 @@ def build_kv_cache_pool_snapshot(
     num_kv_buffers = _int_attr(manager, "num_kv_buffers") or 0
     block_size_bytes = _int_attr(manager, "block_mem_size") or 0
     bytes_per_block = block_size_bytes * num_layers * num_kv_buffers
-    available_blocks = int(manager.available_size())
-    allocated_blocks = int(manager._get_num_alloced_blocks())
+    # available_size() can transiently go negative: it derives from
+    # PageAllocator::get_num_free_pages(), which reads a mutable counter
+    # without holding the allocator mutex, so a concurrent snapshot may
+    # observe an intermediate value. A negative gauge is never meaningful to
+    # an exporter, so clamp at zero.
+    available_blocks = max(int(manager.available_size()), 0)
+    allocated_blocks = max(int(manager._get_num_alloced_blocks()), 0)
     reserved_blocks = len(getattr(manager, "reserved_blocks", []))
 
     return KVCachePoolSnapshot(

--- a/kvcached/observability.py
+++ b/kvcached/observability.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-only observability snapshots for kvcached integrations.
+
+The structures in this module are intentionally policy-free.  They expose
+allocator and runtime state so monitoring systems or external control planes
+can consume kvcached status without depending on private patch details.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional
+
+from kvcached.pool_registry import get_registered_kv_cache_pools
+
+SCHEMA_VERSION = "kvcached.observability.v1"
+
+def _call_int(obj: Any, name: str) -> Optional[int]:
+    method = getattr(obj, name, None)
+    if method is None:
+        return None
+    return int(method())
+
+
+def _int_attr(obj: Any, name: str) -> Optional[int]:
+    value = getattr(obj, name, None)
+    if value is None:
+        return None
+    return int(value)
+
+
+@dataclass(frozen=True)
+class RuntimeSnapshot:
+    """Runtime integration state for an engine shim."""
+
+    schema_version: str
+    engine: str
+    initialized: bool
+    device: Optional[str]
+    world_size: int
+    pp_rank: int
+    async_sched: bool
+    contiguous_layout: bool
+    is_worker: Optional[bool] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class KVCachePoolSnapshot:
+    """Read-only state of one kvcached-backed KV pool."""
+
+    schema_version: str
+    pool_type: str
+    integration: Optional[str]
+    pool_name: Optional[str]
+    group_id: int
+    num_layers: int
+    num_kv_buffers: int
+    page_size_bytes: int
+    block_size_bytes: int
+    total_blocks: int
+    available_blocks: int
+    allocated_blocks: int
+    reserved_blocks: int
+    available_bytes: int
+    allocated_bytes: int
+    reserved_bytes: int
+    null_block_reserved: bool
+    virtual_per_layer_bytes: int
+    virtual_total_bytes: int
+    mapped_bytes: int
+    total_pages: Optional[int]
+    free_pages: Optional[int]
+    inuse_pages: Optional[int]
+    reserved_pages: Optional[int]
+    available_physical_pages: Optional[int]
+    effective_free_pages: Optional[int]
+    in_shrink: bool
+    shrink_target_blocks: Optional[int]
+    resize_target_bytes: Optional[int]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def get_capabilities() -> Dict[str, Any]:
+    """Return the stable observability surface currently exposed by kvcached."""
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "features": {
+            "runtime_snapshot": True,
+            "kv_cache_pool_snapshot": True,
+            "registered_kv_cache_pool_snapshots": True,
+            "read_only": True,
+            "policy_control": False,
+        },
+        "pool_snapshot_fields": list(KVCachePoolSnapshot.__dataclass_fields__.keys()),
+        "runtime_snapshot_fields": list(RuntimeSnapshot.__dataclass_fields__.keys()),
+    }
+
+
+def build_runtime_snapshot(
+    *,
+    engine: str,
+    initialized: bool,
+    device: Optional[str],
+    world_size: int,
+    pp_rank: int,
+    async_sched: bool,
+    contiguous_layout: bool,
+    is_worker: Optional[bool] = None,
+) -> RuntimeSnapshot:
+    return RuntimeSnapshot(
+        schema_version=SCHEMA_VERSION,
+        engine=engine,
+        initialized=initialized,
+        device=device,
+        world_size=world_size,
+        pp_rank=pp_rank,
+        async_sched=async_sched,
+        contiguous_layout=contiguous_layout,
+        is_worker=is_worker,
+    )
+
+
+def build_kv_cache_pool_snapshot(
+    manager: Any,
+    *,
+    integration: Optional[str] = None,
+) -> KVCachePoolSnapshot:
+    """Build a read-only snapshot from a ``KVCacheManager``-like object."""
+
+    allocator = manager.page_allocator
+    free_pages = _call_int(allocator, "get_num_free_pages")
+    reserved_pages = _call_int(allocator, "get_num_reserved_pages")
+    available_physical_pages = _call_int(allocator, "get_avail_physical_pages")
+    if free_pages is None or reserved_pages is None or available_physical_pages is None:
+        effective_free_pages = None
+    else:
+        effective_free_pages = min(free_pages, available_physical_pages + reserved_pages)
+
+    mapped_bytes = int(manager.get_mapped_memory_size("bytes"))
+    virtual_per_layer_bytes = _int_attr(manager, "mem_size") or 0
+    num_layers = _int_attr(manager, "num_layers") or 0
+    num_kv_buffers = _int_attr(manager, "num_kv_buffers") or 0
+    block_size_bytes = _int_attr(manager, "block_mem_size") or 0
+    bytes_per_block = block_size_bytes * num_layers * num_kv_buffers
+    available_blocks = int(manager.available_size())
+    allocated_blocks = int(manager._get_num_alloced_blocks())
+    reserved_blocks = len(getattr(manager, "reserved_blocks", []))
+
+    return KVCachePoolSnapshot(
+        schema_version=SCHEMA_VERSION,
+        pool_type="kv_cache",
+        integration=integration,
+        pool_name=getattr(manager, "pool_name", None),
+        group_id=_int_attr(manager, "group_id") or 0,
+        num_layers=num_layers,
+        num_kv_buffers=num_kv_buffers,
+        page_size_bytes=_int_attr(manager, "page_size") or 0,
+        block_size_bytes=block_size_bytes,
+        total_blocks=_int_attr(manager, "num_blocks") or 0,
+        available_blocks=available_blocks,
+        allocated_blocks=allocated_blocks,
+        reserved_blocks=reserved_blocks,
+        available_bytes=available_blocks * bytes_per_block,
+        allocated_bytes=allocated_blocks * bytes_per_block,
+        reserved_bytes=reserved_blocks * bytes_per_block,
+        null_block_reserved=getattr(manager, "null_block", None) is not None,
+        virtual_per_layer_bytes=virtual_per_layer_bytes,
+        virtual_total_bytes=virtual_per_layer_bytes * num_layers * num_kv_buffers,
+        mapped_bytes=mapped_bytes,
+        total_pages=_call_int(allocator, "get_num_total_pages"),
+        free_pages=free_pages,
+        inuse_pages=_call_int(allocator, "get_num_inuse_pages"),
+        reserved_pages=reserved_pages,
+        available_physical_pages=available_physical_pages,
+        effective_free_pages=effective_free_pages,
+        in_shrink=bool(getattr(manager, "in_shrink", False)),
+        shrink_target_blocks=getattr(manager, "target_num_blocks", None),
+        resize_target_bytes=_call_int(allocator, "get_resize_target"),
+    )
+
+
+def get_registered_kv_cache_pool_snapshots(
+    *,
+    integration: Optional[str] = None,
+) -> List[KVCachePoolSnapshot]:
+    """Return snapshots of currently live registered KV pools."""
+
+    snapshots = []
+    for manager, registered_integration in get_registered_kv_cache_pools(
+        integration=integration
+    ):
+        snapshots.append(
+            build_kv_cache_pool_snapshot(
+                manager,
+                integration=registered_integration,
+            )
+        )
+    return sorted(
+        snapshots,
+        key=lambda snapshot: (
+            snapshot.integration or "",
+            snapshot.pool_name or "",
+            snapshot.group_id,
+        ),
+    )
+
+
+def get_registered_kv_cache_pool_snapshot_dicts(
+    *,
+    integration: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Return JSON-serializable snapshots of currently live registered KV pools."""
+
+    return [
+        snapshot.to_dict()
+        for snapshot in get_registered_kv_cache_pool_snapshots(integration=integration)
+    ]

--- a/kvcached/observability.py
+++ b/kvcached/observability.py
@@ -212,6 +212,28 @@ def build_kv_cache_pool_snapshot(
     )
 
 
+def _snapshot_one_pool(
+    manager: Any,
+    integration: Optional[str],
+) -> KVCachePoolSnapshot:
+    """Snapshot one pool through its own synchronized entry point.
+
+    ``KVCacheManager.observability_snapshot()`` is ``@synchronized``, so the
+    whole snapshot is taken under a single hold of the manager lock (the
+    nested per-accessor acquisitions are reentrant). Calling
+    ``build_kv_cache_pool_snapshot()`` directly instead takes the lock once
+    per accessor, which lets a writer commit in the gaps and stitches the
+    result together from several different instants.
+
+    Fall back to the module-level builder for the duck-typed manager-likes
+    that ``build_kv_cache_pool_snapshot`` is documented to accept.
+    """
+    take_snapshot = getattr(manager, "observability_snapshot", None)
+    if take_snapshot is None:
+        return build_kv_cache_pool_snapshot(manager, integration=integration)
+    return take_snapshot(integration=integration)
+
+
 def get_registered_kv_cache_pool_snapshots(
     *,
     integration: Optional[str] = None,
@@ -223,10 +245,7 @@ def get_registered_kv_cache_pool_snapshots(
         integration=integration
     ):
         snapshots.append(
-            build_kv_cache_pool_snapshot(
-                manager,
-                integration=registered_integration,
-            )
+            _snapshot_one_pool(manager, registered_integration)
         )
     return sorted(
         snapshots,

--- a/kvcached/pool_registry.py
+++ b/kvcached/pool_registry.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-local registry for live kvcached-backed KV pools."""
+
+from __future__ import annotations
+
+import threading
+import weakref
+from typing import Any, Dict, List, Optional, Tuple
+
+_registered_pools: Dict[int, Tuple[Any, Optional[str]]] = {}
+_registered_pools_lock = threading.RLock()
+
+
+def register_kv_cache_pool(
+    manager: Any,
+    *,
+    integration: Optional[str] = None,
+) -> None:
+    """Register a live KV pool without extending its lifetime."""
+
+    manager_id = id(manager)
+
+    def _remove(reference: Any) -> None:
+        with _registered_pools_lock:
+            current = _registered_pools.get(manager_id)
+            if current is not None and current[0] is reference:
+                _registered_pools.pop(manager_id, None)
+
+    reference = weakref.ref(manager, _remove)
+    with _registered_pools_lock:
+        _registered_pools[manager_id] = (reference, integration)
+
+
+def clear_registered_kv_cache_pools(*, integration: Optional[str] = None) -> None:
+    """Forget registered pools, optionally for one engine integration."""
+
+    with _registered_pools_lock:
+        if integration is None:
+            _registered_pools.clear()
+            return
+        stale_ids = [
+            manager_id
+            for manager_id, (_, registered_integration) in _registered_pools.items()
+            if registered_integration == integration
+        ]
+        for manager_id in stale_ids:
+            _registered_pools.pop(manager_id, None)
+
+
+def get_registered_kv_cache_pools(
+    *,
+    integration: Optional[str] = None,
+) -> List[Tuple[Any, Optional[str]]]:
+    """Return live KV managers and their engine integration metadata."""
+
+    with _registered_pools_lock:
+        entries = list(_registered_pools.values())
+
+    pools = []
+    for reference, registered_integration in entries:
+        if integration is not None and registered_integration != integration:
+            continue
+        manager = reference()
+        if manager is not None:
+            pools.append((manager, registered_integration))
+    return pools

--- a/tests/test_kvcache_manager.py
+++ b/tests/test_kvcache_manager.py
@@ -181,14 +181,17 @@ def test_reserve_and_free_blocks(setup_kvcache):
 
     # initial reserved blocks
     initial_reserved_blocks = len(manager.reserved_blocks)
+    initial_allocated_blocks = manager._get_num_alloced_blocks()
 
     # reserve some blocks
     n_blocks = 512
     manager.try_to_reserve(n_blocks)
     after_reserve_blocks = len(manager.reserved_blocks)
     assert after_reserve_blocks == initial_reserved_blocks + n_blocks
+    assert manager._get_num_alloced_blocks() == initial_allocated_blocks + n_blocks
 
     # free the reserved blocks
     manager.free_reserved()
     after_free_blocks = len(manager.reserved_blocks)
     assert after_free_blocks == 0
+    assert manager._get_num_alloced_blocks() == initial_allocated_blocks

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -122,6 +122,7 @@ def test_kv_cache_pool_snapshot_from_manager_like_object():
     assert data["allocated_bytes"] == 16 * bytes_per_block
     assert data["reserved_bytes"] == 2 * bytes_per_block
     assert data["null_block_reserved"] is True
+    assert data["virtual_per_layer_bytes"] == 128 * 4096 * 2
     assert data["virtual_total_bytes"] == 128 * 4096 * 8 * 2
     assert data["mapped_bytes"] == 6 * 8 * (2 * 1024 * 1024) * 2
     assert data["total_pages"] == 20
@@ -132,6 +133,42 @@ def test_kv_cache_pool_snapshot_from_manager_like_object():
     assert data["effective_free_pages"] == 6
     assert data["resize_target_bytes"] == 0
     json.dumps(data)
+
+
+def test_pool_snapshot_clamps_negative_block_gauges():
+    class NegativeBlockManager(FakeManager):
+        def available_size(self):
+            return -127
+
+        def _get_num_alloced_blocks(self):
+            return -1
+
+    data = build_kv_cache_pool_snapshot(NegativeBlockManager()).to_dict()
+
+    assert data["available_blocks"] == 0
+    assert data["available_bytes"] == 0
+    assert data["allocated_blocks"] == 0
+    assert data["allocated_bytes"] == 0
+
+
+def test_registered_pool_snapshot_uses_manager_snapshot_entrypoint():
+    clear_registered_kv_cache_pools()
+
+    class SynchronizedManager(FakeManager):
+        snapshot_calls = 0
+
+        def observability_snapshot(self, *, integration=None):
+            self.snapshot_calls += 1
+            return build_kv_cache_pool_snapshot(self, integration=integration)
+
+    manager = SynchronizedManager()
+    register_kv_cache_pool(manager, integration="vllm")
+
+    snapshots = get_registered_kv_cache_pool_snapshot_dicts(integration="vllm")
+
+    assert len(snapshots) == 1
+    assert manager.snapshot_calls == 1
+    clear_registered_kv_cache_pools()
 
 
 def test_registered_pool_snapshots_are_filtered_and_do_not_keep_managers_alive():

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+if "torch" not in sys.modules and importlib.util.find_spec("torch") is None:
+    sys.modules.setdefault("torch", types.ModuleType("torch"))
+
+from kvcached.observability import (  # noqa: E402
+    build_kv_cache_pool_snapshot,
+    build_runtime_snapshot,
+    get_capabilities,
+    get_registered_kv_cache_pool_snapshot_dicts,
+)
+from kvcached.pool_registry import (  # noqa: E402
+    clear_registered_kv_cache_pools,
+    register_kv_cache_pool,
+)
+
+
+class FakePageAllocator:
+    def get_num_free_pages(self):
+        return 10
+
+    def get_num_inuse_pages(self):
+        return 6
+
+    def get_num_total_pages(self):
+        return 20
+
+    def get_num_reserved_pages(self):
+        return 2
+
+    def get_avail_physical_pages(self):
+        return 4
+
+    def get_resize_target(self):
+        return 0
+
+
+class FakeManager:
+    num_blocks = 128
+    block_mem_size = 4096
+    num_layers = 8
+    num_kv_buffers = 2
+    group_id = 3
+    pool_name = "full_attention"
+    page_size = 2 * 1024 * 1024
+    mem_size = num_blocks * block_mem_size
+    reserved_blocks = [0, 7]
+    null_block = [0]
+    in_shrink = False
+    target_num_blocks = None
+    page_allocator = FakePageAllocator()
+
+    def available_size(self):
+        return 64
+
+    def _get_num_alloced_blocks(self):
+        return 16
+
+    def get_mapped_memory_size(self, unit="bytes"):
+        assert unit == "bytes"
+        return 6 * self.num_layers * self.page_size * self.num_kv_buffers
+
+
+def test_capabilities_are_json_serializable():
+    capabilities = get_capabilities()
+
+    assert capabilities["schema_version"] == "kvcached.observability.v1"
+    assert capabilities["features"]["read_only"] is True
+    assert capabilities["features"]["policy_control"] is False
+    json.dumps(capabilities)
+
+
+def test_runtime_snapshot_dict():
+    snapshot = build_runtime_snapshot(
+        engine="vllm",
+        initialized=True,
+        device="cuda:0",
+        world_size=2,
+        pp_rank=1,
+        async_sched=True,
+        contiguous_layout=False,
+        is_worker=True,
+    )
+
+    assert snapshot.to_dict() == {
+        "schema_version": "kvcached.observability.v1",
+        "engine": "vllm",
+        "initialized": True,
+        "device": "cuda:0",
+        "world_size": 2,
+        "pp_rank": 1,
+        "async_sched": True,
+        "contiguous_layout": False,
+        "is_worker": True,
+    }
+
+
+def test_kv_cache_pool_snapshot_from_manager_like_object():
+    snapshot = build_kv_cache_pool_snapshot(
+        FakeManager(),
+        integration="sglang",
+    )
+    data = snapshot.to_dict()
+
+    assert data["pool_type"] == "kv_cache"
+    assert data["integration"] == "sglang"
+    assert data["pool_name"] == "full_attention"
+    assert data["group_id"] == 3
+    assert data["available_blocks"] == 64
+    assert data["allocated_blocks"] == 16
+    assert data["reserved_blocks"] == 2
+    bytes_per_block = 4096 * 8 * 2
+    assert data["available_bytes"] == 64 * bytes_per_block
+    assert data["allocated_bytes"] == 16 * bytes_per_block
+    assert data["reserved_bytes"] == 2 * bytes_per_block
+    assert data["null_block_reserved"] is True
+    assert data["virtual_total_bytes"] == 128 * 4096 * 8 * 2
+    assert data["mapped_bytes"] == 6 * 8 * (2 * 1024 * 1024) * 2
+    assert data["total_pages"] == 20
+    assert data["free_pages"] == 10
+    assert data["inuse_pages"] == 6
+    assert data["reserved_pages"] == 2
+    assert data["available_physical_pages"] == 4
+    assert data["effective_free_pages"] == 6
+    assert data["resize_target_bytes"] == 0
+    json.dumps(data)
+
+
+def test_registered_pool_snapshots_are_filtered_and_do_not_keep_managers_alive():
+    clear_registered_kv_cache_pools()
+    sglang_manager = FakeManager()
+    other_manager = FakeManager()
+    sglang_manager.pool_name = "mha"
+    other_manager.pool_name = "unified"
+    register_kv_cache_pool(
+        sglang_manager,
+        integration="sglang",
+    )
+    register_kv_cache_pool(
+        other_manager,
+        integration="vllm",
+    )
+
+    snapshots = get_registered_kv_cache_pool_snapshot_dicts(integration="sglang")
+
+    assert len(snapshots) == 1
+    assert snapshots[0]["integration"] == "sglang"
+    assert snapshots[0]["pool_name"] == "mha"
+
+    del sglang_manager
+    gc.collect()
+    assert get_registered_kv_cache_pool_snapshot_dicts(integration="sglang") == []
+    assert len(get_registered_kv_cache_pool_snapshot_dicts(integration="vllm")) == 1
+    clear_registered_kv_cache_pools()
+
+
+def test_sglang_manager_factory_registers_and_shutdown_clears_pool(monkeypatch):
+    clear_registered_kv_cache_pools()
+
+    torch = types.ModuleType("torch")
+    setattr(torch, "dtype", object)
+    setattr(torch, "Tensor", object)
+    setattr(torch, "cuda", types.SimpleNamespace(current_device=lambda: 0))
+
+    manager_module = types.ModuleType("kvcached.kv_cache_manager")
+
+    class FakeKVCacheManager(FakeManager):
+        def __init__(self, num_blocks, block_size, cell_size, num_layers, **kwargs):
+            self.num_blocks = num_blocks
+            self.block_mem_size = block_size * cell_size
+            self.num_layers = num_layers
+            self.num_kv_buffers = kwargs["num_kv_buffers"]
+            self.group_id = kwargs["group_id"]
+            self.pool_name = kwargs["pool_name"]
+            self.mem_size = num_blocks * self.block_mem_size
+            self.reserved_blocks = []
+            self.page_allocator = FakePageAllocator()
+
+    setattr(manager_module, "KVCacheManager", FakeKVCacheManager)
+
+    tp_ipc_module = types.ModuleType("kvcached.tp_ipc_util")
+    setattr(tp_ipc_module, "start_worker_listener_thread", lambda *args: None)
+
+    utils_module = types.ModuleType("kvcached.utils")
+    setattr(utils_module, "CONTIGUOUS_LAYOUT", False)
+    setattr(utils_module, "PAGE_SIZE", 2 * 1024 * 1024)
+    setattr(utils_module, "get_kvcached_logger", lambda: types.SimpleNamespace())
+    setattr(utils_module, "normalize_gpu_device", lambda device: device)
+
+    vmm_ops_module = types.ModuleType("kvcached.vmm_ops")
+    setattr(vmm_ops_module, "create_kv_tensors", lambda *args, **kwargs: [])
+    setattr(vmm_ops_module, "init_kvcached", lambda *args, **kwargs: None)
+    setattr(vmm_ops_module, "shutdown_kvcached", lambda: None)
+
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "kvcached.kv_cache_manager", manager_module)
+    monkeypatch.setitem(sys.modules, "kvcached.tp_ipc_util", tp_ipc_module)
+    monkeypatch.setitem(sys.modules, "kvcached.utils", utils_module)
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", vmm_ops_module)
+
+    module_path = (
+        Path(__file__).parents[1]
+        / "kvcached"
+        / "integration"
+        / "sglang"
+        / "interfaces.py"
+    )
+    spec = importlib.util.spec_from_file_location("_test_sglang_interfaces", module_path)
+    assert spec is not None and spec.loader is not None
+    interfaces = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(interfaces)
+    setattr(interfaces, "_kvcached_initialized", True)
+
+    manager = interfaces.get_kv_cache_manager(
+        128,
+        16,
+        256,
+        8,
+        group_id=4,
+        pool_name="mha",
+    )
+    snapshots = interfaces.kv_cache_pool_snapshot_dicts()
+
+    assert manager.group_id == 4
+    assert manager.pool_name == "mha"
+    assert len(snapshots) == 1
+    assert snapshots[0]["integration"] == "sglang"
+    assert snapshots[0]["pool_name"] == "mha"
+    assert snapshots[0]["group_id"] == 4
+
+    interfaces.shutdown_kvcached()
+    assert interfaces.kv_cache_pool_snapshot_dicts() == []
+def test_vllm_manager_factory_registers_and_shutdown_clears_pool(monkeypatch):
+    clear_registered_kv_cache_pools()
+
+    torch = types.ModuleType("torch")
+    setattr(torch, "dtype", object)
+    setattr(torch, "Tensor", object)
+    setattr(torch, "cuda", types.SimpleNamespace(current_device=lambda: 0))
+
+    manager_module = types.ModuleType("kvcached.kv_cache_manager")
+
+    class FakeKVCacheManager(FakeManager):
+        def __init__(
+            self,
+            num_blocks,
+            block_size,
+            cell_size,
+            num_layers,
+            world_size,
+            **kwargs,
+        ):
+            self.num_blocks = num_blocks
+            self.block_mem_size = block_size * cell_size
+            self.num_layers = num_layers
+            self.num_kv_buffers = kwargs["num_kv_buffers"]
+            self.group_id = kwargs["group_id"]
+            self.pool_name = kwargs["pool_name"]
+            self.mem_size = num_blocks * self.block_mem_size
+            self.reserved_blocks = []
+            self.page_allocator = FakePageAllocator()
+            self.world_size = world_size
+
+    setattr(manager_module, "KVCacheManager", FakeKVCacheManager)
+
+    tp_ipc_module = types.ModuleType("kvcached.tp_ipc_util")
+    setattr(tp_ipc_module, "start_worker_listener_thread", lambda *args: None)
+
+    utils_module = types.ModuleType("kvcached.utils")
+    setattr(utils_module, "CONTIGUOUS_LAYOUT", False)
+    setattr(utils_module, "PAGE_SIZE", 2 * 1024 * 1024)
+    setattr(utils_module, "get_kvcached_logger", lambda: types.SimpleNamespace())
+    setattr(utils_module, "normalize_gpu_device", lambda device: device)
+
+    vmm_ops_module = types.ModuleType("kvcached.vmm_ops")
+    setattr(vmm_ops_module, "create_kv_tensors", lambda *args, **kwargs: [])
+    setattr(vmm_ops_module, "init_kvcached", lambda *args, **kwargs: None)
+    setattr(vmm_ops_module, "shutdown_kvcached", lambda: None)
+
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "kvcached.kv_cache_manager", manager_module)
+    monkeypatch.setitem(sys.modules, "kvcached.tp_ipc_util", tp_ipc_module)
+    monkeypatch.setitem(sys.modules, "kvcached.utils", utils_module)
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", vmm_ops_module)
+
+    module_path = (
+        Path(__file__).parents[1]
+        / "kvcached"
+        / "integration"
+        / "vllm"
+        / "interfaces.py"
+    )
+    spec = importlib.util.spec_from_file_location("_test_vllm_interfaces", module_path)
+    assert spec is not None and spec.loader is not None
+    interfaces = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(interfaces)
+    setattr(interfaces, "_kvcached_initialized", True)
+
+    manager = interfaces.get_kv_cache_manager(
+        128,
+        16,
+        256,
+        8,
+        group_id=5,
+        pool_name="unified",
+    )
+    snapshots = interfaces.kv_cache_pool_snapshot_dicts()
+
+    assert manager.group_id == 5
+    assert manager.pool_name == "unified"
+    assert manager.world_size == 1
+    assert len(snapshots) == 1
+    assert snapshots[0]["integration"] == "vllm"
+    assert snapshots[0]["pool_name"] == "unified"
+    assert snapshots[0]["group_id"] == 5
+
+    interfaces.shutdown_kvcached()
+    assert interfaces.kv_cache_pool_snapshot_dicts() == []


### PR DESCRIPTION
## Summary

Adds a read-only observability surface for kvcached runtime integrations and KV cache pools.

kvcached owns the allocator measurements and byte accounting. External monitoring systems can periodically collect and forward structured snapshots without depending on private allocator or engine-patch details.

## What is included

- `kvcached.observability` dataclasses for runtime state, KV pool state, and capability discovery
- block and byte measurements for available, allocated, reserved, virtual, and mapped KV memory
- a thread-safe weak pool registry that does not extend `KVCacheManager` lifetime
- `KVCacheManager.observability_snapshot()` and `observability_snapshot_dict()`
- vLLM and SGLang runtime snapshot helpers
- automatic registration of vLLM and SGLang KV pools, with cleanup on shutdown
- integration helpers that return snapshots for every live registered pool
- unit tests with no CUDA/GPU dependency

## Design boundaries

- Read-only: no allocation, admission, GC, or scheduling policy is added.
- Pull-based: kvcached measures current state on demand; collectors decide polling and transport.
- Engine-neutral schema: consumers do not need to inspect SGLang or vLLM patch internals.
- Related to #375, but this PR only provides the observability/accounting surface.

## Validation

Local validation:

```text
pytest tests/test_observability.py -q
# 6 passed

ruff, codespell, isort, clang-format, PyMarkdown, actionlint,
and trailing-whitespace pre-commit hooks
# all passed

mypy 1.11.1, Python targets 3.9 / 3.10 / 3.11 / 3.12 / 3.13
# 24 kvcached files + 15 test files passed for every target
```

GitHub Actions is green for pre-commit and all five MyPy jobs.

GPU validation used the SGLang v0.5.13 image on one explicitly isolated RTX 4090. A real CUDA VMM-backed MHA pool was created, sampled, allocated by 32 blocks, sampled again, freed, and sampled a third time:

```text
visible GPUs:             1 x NVIDIA GeForce RTX 4090
allocated blocks:        1 -> 33 -> 1
allocated bytes:         512 -> 16896 -> 512
virtual total bytes:     33554432
mapped bytes:            8388608
identity:                integration=sglang, pool_name=mha, group_id=7
```