### PR TITLE
fix(vllm): preserve hybrid KV pool mapping

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -7,6 +7,7 @@ vLLM-specific patches using unified patch infrastructure.
 
 from __future__ import annotations
 
+import inspect
 import types
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Iterable, Optional
@@ -56,6 +57,29 @@ def _is_mamba_spec(spec: Any) -> bool:
         return isinstance(spec, MambaSpec)
     except ImportError:
         return False
+
+
+def _call_hybrid_layout_update(
+    update_hybrid_layout: Any,
+    kv_caches: dict[str, Any],
+    kernel_block_sizes: Any,
+) -> None:
+    """Call the native vLLM hybrid-layout helper across signature changes."""
+    parameters = inspect.signature(update_hybrid_layout).parameters.values()
+    positional = tuple(
+        parameter
+        for parameter in parameters
+        if parameter.kind
+        in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    )
+    accepts_varargs = any(
+        parameter.kind == inspect.Parameter.VAR_POSITIONAL
+        for parameter in parameters
+    )
+    if accepts_varargs or len(positional) >= 2:
+        update_hybrid_layout(kv_caches, kernel_block_sizes)
+    else:
+        update_hybrid_layout(kv_caches)
 
 
 def _get_first_attention_group(kv_cache_config: Any) -> Any:
@@ -1409,12 +1433,26 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 from vllm.utils import get_dtype_size  # type: ignore[attr-defined]
 
             kv_caches: dict[str, torch.Tensor] = {}
+            has_attn, has_mamba = False, False
 
             mamba_info = getattr(self, "_kvcached_mamba_raw_info", None)
             # Per-group attention views for heterogeneous hybrids (Gemma). None
             # for homogeneous / single-group models, which use the raw-tensor
             # index mapping below unchanged.
             attn_layer_views = getattr(self, "_kvcached_attn_layer_views", None)
+            layer_to_pool_idx: dict[str, int] = {}
+            for pool_idx, tensor_cfg in enumerate(kv_cache_config.kv_cache_tensors):
+                for layer_name in tensor_cfg.shared_by:
+                    layer_to_pool_idx[layer_name] = pool_idx
+
+            def _pool_index_for_layer(layer_name: str) -> int:
+                try:
+                    return layer_to_pool_idx[layer_name]
+                except KeyError as exc:
+                    raise RuntimeError(
+                        "kvcached reshape: KV cache layer "
+                        f"{layer_name!r} is not owned by any physical pool."
+                    ) from exc
 
             for kv_cache_group in kv_cache_config.kv_cache_groups:
                 kv_cache_spec = kv_cache_group.kv_cache_spec
@@ -1425,7 +1463,11 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                             "Mamba layers found but no raw buffer info "
                             "available from kvcached"
                         )
-                    for pool_idx, layer_name in enumerate(kv_cache_group.layer_names):
+                    for layer_name in kv_cache_group.layer_names:
+                        if layer_name in getattr(self, "runner_only_attn_layers", ()):
+                            continue
+                        has_mamba = True
+                        pool_idx = _pool_index_for_layer(layer_name)
                         if mamba_info.get("is_contiguous"):
                             state_tensors = _reshape_mamba_contiguous(
                                 mamba_info, kv_cache_spec, pool_idx,
@@ -1438,11 +1480,29 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                             )
                         kv_caches[layer_name] = state_tensors  # type: ignore[assignment]
                 else:
-                    for pool_idx, layer_name in enumerate(kv_cache_group.layer_names):
+                    for layer_name in kv_cache_group.layer_names:
+                        if layer_name in getattr(self, "runner_only_attn_layers", ()):
+                            continue
+                        has_attn = True
+                        pool_idx = _pool_index_for_layer(layer_name)
                         if attn_layer_views is not None and layer_name in attn_layer_views:
                             kv_caches[layer_name] = attn_layer_views[layer_name]
                         else:
                             kv_caches[layer_name] = kv_cache_raw_tensors[pool_idx]
+
+            update_hybrid_layout = getattr(
+                self, "_update_hybrid_attention_mamba_layout", None
+            )
+            if has_attn and has_mamba and update_hybrid_layout is not None:
+                kernel_block_sizes = args[0] if args else kwargs.get("kernel_block_sizes")
+                if kernel_block_sizes is None:
+                    raise RuntimeError(
+                        "kvcached reshape: hybrid attention+mamba layout requires "
+                        "kernel_block_sizes from vLLM."
+                    )
+                _call_hybrid_layout_update(
+                    update_hybrid_layout, kv_caches, kernel_block_sizes
+                )
 
             return kv_caches
 
@@ -1468,13 +1528,35 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 # vLLM <0.20:  _reshape_kv_cache_tensors(self, kv_cache_config, kv_cache_raw_tensors, ...)
                 # vLLM >=0.20: _reshape_kv_cache_tensors(self, kv_cache_raw_tensors, kernel_block_sizes)
                 #   -> the kv_cache_config arg was dropped; pull it from self.kv_cache_config.
-                if args and hasattr(args[0], "kv_cache_groups"):
-                    kv_cache_config, kv_cache_raw_tensors = args[0], args[1]
+                call_kwargs = dict(kwargs)
+                first = args[0] if args else call_kwargs.get("kv_cache_config")
+                if hasattr(first, "kv_cache_groups"):
+                    kv_cache_config = first
+                    call_kwargs.pop("kv_cache_config", None)
+                    kv_cache_raw_tensors = (
+                        args[1]
+                        if len(args) > 1
+                        else call_kwargs.pop("kv_cache_raw_tensors")
+                    )
+                    rest = args[2:]
                 else:
                     kv_cache_config = getattr(self, "kv_cache_config", None)
-                    kv_cache_raw_tensors = args[0]
+                    if not hasattr(kv_cache_config, "kv_cache_groups"):
+                        raise RuntimeError(
+                            "kvcached reshape: cannot resolve KVCacheConfig. The "
+                            "vLLM _reshape_kv_cache_tensors signature dropped "
+                            "kv_cache_config and self.kv_cache_config is unavailable."
+                        )
+                    kv_cache_raw_tensors = (
+                        args[0]
+                        if args
+                        else call_kwargs.pop("kv_cache_raw_tensors")
+                    )
+                    rest = args[1:]
+                call_kwargs.pop("kv_cache_raw_tensors", None)
                 return self._reshape_kv_cache_tensors_from_kvcached(
-                    kv_cache_config, kv_cache_raw_tensors
+                    kv_cache_config, kv_cache_raw_tensors,
+                    *rest, **call_kwargs
                 )
             return original_method(self, *args, **kwargs)
 

--- a/tests/test_vllm_fp8_hybrid_layout.py
+++ b/tests/test_vllm_fp8_hybrid_layout.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+
+def test_native_hybrid_layout_update_supports_old_and_new_signatures():
+    from kvcached.integration.vllm.patches import _call_hybrid_layout_update
+
+    kv_caches = {"attn.0": object()}
+    kernel_block_sizes = (16,)
+    calls = []
+
+    def legacy_update(caches):
+        calls.append(("legacy", caches, None))
+
+    def current_update(caches, block_sizes):
+        calls.append(("current", caches, block_sizes))
+
+    _call_hybrid_layout_update(legacy_update, kv_caches, kernel_block_sizes)
+    _call_hybrid_layout_update(current_update, kv_caches, kernel_block_sizes)
+
+    assert calls == [
+        ("legacy", kv_caches, None),
+        ("current", kv_caches, kernel_block_sizes),
+    ]
+
+
+def _assert_fp8_hybrid_flashinfer_layout():
+    fp8_dtype = getattr(torch, "float8_e4m3fn", None)
+    assert fp8_dtype is not None
+
+    vmm_ops = ModuleType("kvcached.vmm_ops")
+    setattr(vmm_ops, "PageAllocator", type("PageAllocator", (), {}))
+    setattr(vmm_ops, "InternalPage", type("InternalPage", (), {}))
+    for name in (
+        "create_kv_tensors",
+        "init_kvcached",
+        "kv_tensors_created",
+        "map_to_kv_tensors",
+        "shutdown_kvcached",
+        "unmap_from_kv_tensors",
+    ):
+        setattr(vmm_ops, name, lambda *args, **kwargs: None)
+    sys.modules["kvcached.vmm_ops"] = vmm_ops
+
+    from kvcached.integration.vllm import interfaces
+
+    interfaces._contiguous_layout = False
+    interfaces._kvcached_initialized = True
+    interfaces.normalize_gpu_device = lambda device: device
+    interfaces.torch.cuda.is_available = lambda: True
+    interfaces.torch.cuda.get_device_properties = lambda device: SimpleNamespace(
+        total_memory=4 * interfaces.PAGE_SIZE
+    )
+
+    def create_cpu_kv_tensors(
+        ftensor_bytes_per_layer,
+        dtype_itemsize,
+        device,
+        num_layers,
+        **kwargs,
+    ):
+        assert kwargs["unified_pool"] is True
+        return [
+            torch.zeros(
+                ftensor_bytes_per_layer // dtype_itemsize,
+                dtype=torch.uint8,
+            )
+            for _ in range(num_layers)
+        ]
+
+    interfaces.create_kv_tensors = create_cpu_kv_tensors
+
+    num_blocks = 3
+    block_size = 2
+    num_heads = 1
+    head_size = 4
+    hidden_size = block_size * num_heads * head_size
+    elements_per_block = 2 * hidden_size
+    views, raw_info = interfaces.alloc_kv_cache(
+        (num_blocks, 2, block_size, num_heads, head_size),
+        block_size,
+        fp8_dtype,
+        "cuda:0",
+        num_layers=1,
+        attention_type="HYBRID_LINEAR",
+        kv_layout="NHD",
+    )
+    page_size_bytes = raw_info["page_size_bytes"]
+
+    view = views[0]
+    assert view.dtype == fp8_dtype
+    assert view.shape[0] >= num_blocks
+    assert view.shape[1:] == (2, block_size, num_heads, head_size)
+    assert view.stride() == (elements_per_block, hidden_size, head_size, head_size, 1)
+    assert page_size_bytes == elements_per_block * fp8_dtype.itemsize
+
+    for block_idx in range(num_blocks):
+        k_byte_offset = (
+            view[block_idx, 0].storage_offset() * fp8_dtype.itemsize
+        )
+        v_byte_offset = (
+            view[block_idx, 1].storage_offset() * fp8_dtype.itemsize
+        )
+        assert k_byte_offset == block_idx * page_size_bytes
+        assert v_byte_offset == k_byte_offset + hidden_size * fp8_dtype.itemsize
+
+
+def test_fp8_hybrid_flashinfer_view_interleaves_kv_per_block():
+    """FP8 hybrid K/V must share each physical block, not split the pool."""
+    if getattr(torch, "float8_e4m3fn", None) is None:
+        pytest.skip("torch does not provide float8_e4m3fn")
+
+    test_file = Path(__file__).resolve()
+    repo_root = test_file.parent.parent
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(repo_root), env.get("PYTHONPATH")))
+    )
+    result = subprocess.run(
+        [sys.executable, str(test_file)],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_vllm_022_hybrid_reshape_uses_shared_pools_and_native_layout(monkeypatch):
+    from kvcached.integration.vllm import patches
+
+    torch_utils = ModuleType("vllm.utils.torch_utils")
+    setattr(torch_utils, "get_dtype_size", lambda dtype: 1)
+    vllm_utils = ModuleType("vllm.utils")
+    setattr(vllm_utils, "torch_utils", torch_utils)
+    vllm = ModuleType("vllm")
+    setattr(vllm, "utils", vllm_utils)
+    monkeypatch.setitem(sys.modules, "vllm", vllm)
+    monkeypatch.setitem(sys.modules, "vllm.utils", vllm_utils)
+    monkeypatch.setitem(sys.modules, "vllm.utils.torch_utils", torch_utils)
+
+    attention_spec = object()
+    mamba_spec = object()
+    monkeypatch.setattr(patches, "_is_mamba_spec", lambda spec: spec is mamba_spec)
+    monkeypatch.setattr(
+        patches,
+        "_reshape_mamba_non_contiguous",
+        lambda raw, spec, get_dtype_size: f"state:{raw}",
+    )
+    monkeypatch.setattr(patches, "enable_kvcached", lambda: True)
+
+    kv_cache_config = SimpleNamespace(
+        kv_cache_tensors=[
+            SimpleNamespace(shared_by=("attn.1", "mamba.1")),
+            SimpleNamespace(shared_by=("attn.0", "mamba.0")),
+        ],
+        kv_cache_groups=[
+            SimpleNamespace(
+                kv_cache_spec=attention_spec,
+                layer_names=("attn.0", "attn.1"),
+            ),
+            SimpleNamespace(
+                kv_cache_spec=mamba_spec,
+                layer_names=("mamba.0", "mamba.1"),
+            ),
+        ],
+    )
+
+    class FakeGPUModelRunner:
+        kv_cache_config = None
+        _kvcached_mamba_raw_info = None
+
+        def _reshape_kv_cache_tensors(self, *args, **kwargs):
+            raise AssertionError("native reshape should be patched")
+
+        def _update_hybrid_attention_mamba_layout(self, kv_caches, block_sizes):
+            self.native_layout_call = (dict(kv_caches), block_sizes)
+
+    patch = patches.GPUModelRunnerPatch()
+    assert patch.add_reshape_methods(FakeGPUModelRunner) is True
+    assert patch.patch_reshape_methods(FakeGPUModelRunner) is True
+
+    runner = FakeGPUModelRunner()
+    runner.kv_cache_config = kv_cache_config
+    runner._kvcached_mamba_raw_info = {
+        "buffers": ("pool-0", "pool-1"),
+        "is_contiguous": False,
+    }
+    raw_attention_pools = ("attn-pool-0", "attn-pool-1")
+    kernel_block_sizes = (16, 16)
+
+    kv_caches = runner._reshape_kv_cache_tensors(
+        raw_attention_pools,
+        kernel_block_sizes,
+    )
+
+    assert kv_caches == {
+        "attn.0": "attn-pool-1",
+        "attn.1": "attn-pool-0",
+        "mamba.0": "state:pool-1",
+        "mamba.1": "state:pool-0",
+    }
+    assert runner.native_layout_call == (kv_caches, kernel_block_sizes)
+
+
+def test_legacy_hybrid_reshape_keeps_config_signature(monkeypatch):
+    from kvcached.integration.vllm import patches
+
+    vllm_utils = ModuleType("vllm.utils")
+    setattr(vllm_utils, "get_dtype_size", lambda dtype: 1)
+    vllm = ModuleType("vllm")
+    setattr(vllm, "utils", vllm_utils)
+    monkeypatch.setitem(sys.modules, "vllm", vllm)
+    monkeypatch.setitem(sys.modules, "vllm.utils", vllm_utils)
+
+    attention_spec = object()
+    monkeypatch.setattr(patches, "_is_mamba_spec", lambda spec: False)
+    monkeypatch.setattr(patches, "enable_kvcached", lambda: True)
+    kv_cache_config = SimpleNamespace(
+        kv_cache_tensors=[SimpleNamespace(shared_by=("attn.0",))],
+        kv_cache_groups=[
+            SimpleNamespace(
+                kv_cache_spec=attention_spec,
+                layer_names=("attn.0",),
+            )
+        ],
+    )
+
+    class FakeGPUModelRunner:
+        def _reshape_kv_cache_tensors(self, *args, **kwargs):
+            raise AssertionError("native reshape should be patched")
+
+    patch = patches.GPUModelRunnerPatch()
+    assert patch.add_reshape_methods(FakeGPUModelRunner) is True
+    assert patch.patch_reshape_methods(FakeGPUModelRunner) is True
+
+    runner = FakeGPUModelRunner()
+    assert runner._reshape_kv_cache_tensors(
+        kv_cache_config=kv_cache_config,
+        kv_cache_raw_tensors=("attn-pool-0",),
+    ) == {"attn.0": "attn-pool-0"}
+
+
+if __name__ == "__main__":
+    _assert_fp8_hybrid_flashinfer_layout()


### PR DESCRIPTION
## Summary

- map attention and Mamba layers to physical KV pools through `kv_cache_config.kv_cache_tensors[*].shared_by` instead of group-local list positions
- forward `kernel_block_sizes` and run vLLM's native hybrid attention/Mamba layout update after constructing kvcached views
- retain the legacy reshape call signature and call vLLM's native hybrid-layout helper across its v0.19 and v0.20+ signatures
- cover the FP8 FlashInfer block-interleaved K/V layout and the vLLM 0.22 hybrid mapping path

## Problem

vLLM's KV cache groups describe logical layer groupings, while `KVCacheTensor.shared_by` defines ownership of the physical pools. For hybrid models, the group-local layer order is not guaranteed to match physical pool order. Mapping by position can therefore bind attention or Mamba layers to the wrong pool.

vLLM 0.20+ also removed `kv_cache_config` from `_reshape_kv_cache_tensors` and passes `kernel_block_sizes` instead. The kvcached wrapper recovered the config but discarded the remaining argument and did not invoke vLLM's native hybrid layout update. On the vLLM 0.22.1 FP8 hybrid path this can allow startup but produce corrupted output.

## Validation

- `python3 -m pytest -q tests/test_vllm_fp8_hybrid_layout.py`: 4 passed
- pre-commit hooks for both changed files: passed
- mypy manual hooks for Python 3.9, 3.10, 3.11, 3.12, and 3.13: passed
- full `pre-commit run --all-files` reproduces only the target branch's existing license finding in `benchmarks/bench_gemma_hetero/correctness_check.py` and Markdown formatting finding in `benchmarks/bench_gemma_hetero/README.md`