### PR TITLE
fix(vllm): evict prefix-cache blocks by page to release memory (#359)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ benchmarks/bench_vmm/*.bin
 benchmarks/bench_latency_benefit/results/
 benchmarks/bench_latency_benefit/plot*
 benchmarks/gsm8k/*.jsonl
+benchmarks/bench_idle_footprint/*.jsonl
 benchmarks/gsm8k/*.txt
 
 # tools

--- a/benchmarks/bench_frag/README.md
+++ b/benchmarks/bench_frag/README.md
@@ -1,0 +1,37 @@
+# bench_frag
+
+Measures how much physical memory stays pinned when retained KV blocks are
+scattered across pages ([#359](https://github.com/ovg-project/kvcached/issues/359)).
+
+kvcached returns memory to the GPU one page at a time, and only once every block
+on that page is free. A cache bound expressed in tokens therefore says nothing
+about how much memory an idle instance actually holds: 1024 retained blocks
+packed together occupy 8 pages, while the same 1024 blocks spread one per page
+occupy 128. The `waste` column is that ratio.
+
+## Run
+
+```bash
+python bench_frag.py
+```
+
+Defaults to 16 layers and 16384 blocks of 16 KiB, i.e. 128 blocks per 2 MB page.
+Each row frees all but `KEEP` blocks at the given stride and reports the memory
+still mapped afterwards.
+
+| column | meaning |
+|---|---|
+| `stride` | spacing between retained blocks; 1 is packed, 16 is one per page |
+| `kept` | blocks retained (constant across rows) |
+| `held GB` | memory the retained blocks themselves need |
+| `pinned GB` | memory still mapped, from `get_mapped_memory_size()` |
+| `waste` | `pinned / held` — 1.0x is ideal, higher means fragmentation |
+
+`stride=1` is the floor: it is what a page-aware policy converges toward. Rows
+above it show what scattering costs.
+
+## Scope
+
+This drives `KVCacheManager` directly, so it measures the allocator's behaviour
+rather than any engine's eviction policy. It reproduces the conditions #359
+describes; it does not by itself exercise `ElasticBlockPool`'s block selection.

--- a/benchmarks/bench_frag/README.md
+++ b/benchmarks/bench_frag/README.md
@@ -35,3 +35,27 @@ above it show what scattering costs.
 This drives `KVCacheManager` directly, so it measures the allocator's behaviour
 rather than any engine's eviction policy. It reproduces the conditions #359
 describes; it does not by itself exercise `ElasticBlockPool`'s block selection.
+
+# bench_evict
+
+Measures how much memory prefix-cache eviction actually returns. Caches 4096
+blocks, touches every stride-th block so an age-only policy spares it, then
+evicts down to 512 and reports the memory released.
+
+```bash
+python bench_evict.py
+```
+
+Measured on an RTX PRO 4000 Blackwell (24GB), 8 layers, 16 KiB blocks, 2 MB
+pages (128 blocks per page). Both columns evict the same 3584 blocks:
+
+| stride | freed before (LRU) | freed after (page-aware) |
+|---|---|---|
+| 1 | 0.84 GB | 0.88 GB |
+| 2 | 0.75 GB | 0.88 GB |
+| 4 | 0.50 GB | 0.88 GB |
+| 8 | 0.03 GB | 0.88 GB |
+
+Age-only eviction degrades as the retained blocks scatter: at stride 8 it evicts
+3584 blocks and frees almost nothing, because each surviving block pins a page.
+Page-aware selection holds flat, evicting the same count.

--- a/benchmarks/bench_frag/bench_evict.py
+++ b/benchmarks/bench_frag/bench_evict.py
@@ -2,14 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 """Measure memory released by prefix-cache eviction (issue #359).
 
-Fills ElasticBlockPool's prefix cache, releases the blocks so they become
-evictable, then evicts down to a cap and reports how much physical memory came
-back. Pages only unmap once every block on them is free, so an eviction policy
-that ignores pages can hit the cap while releasing nothing.
+Pages unmap only once every block on them is free, so an eviction policy that
+picks victims by age alone can hit its block cap while releasing no memory: the
+survivors stay scattered and each one pins a whole page.
 
-Run on each branch and compare the "freed" column:
+This models that. Cache a large run of blocks, then touch every stride-th block
+so it looks recently used. Evicting down to the cap must then choose between the
+cold blocks (scattered around the hot ones) and the pages they sit on. The
+"freed" column is how much physical memory the eviction actually returned.
+
+Run on each branch and compare:
     python bench_evict.py
 """
+import time
 import types
 
 import torch
@@ -27,10 +32,8 @@ DTYPE = torch.float16
 DEVICE = f"cuda:{TP_RANK}"
 KV_SHAPE = (2, NUM_BLOCKS, BLOCK_SIZE, 8, 64)
 
-# Cache this many blocks, then evict down to KEEP. Mirrors an instance going
-# idle with MAX_CACHED_TOKENS worth of prefix cache left over.
-CACHED = 4096
-KEEP = 512
+CACHED = 4096  # blocks cached before eviction
+KEEP = 512  # cap to evict down to; must be well below CACHED
 
 
 class _Block:
@@ -53,7 +56,6 @@ def build_pool():
                   async_sched=False)
     alloc_kv_cache(kvcache_shape=KV_SHAPE, block_size=BLOCK_SIZE, dtype=DTYPE,
                    device=DEVICE, num_layers=NUM_LAYERS)
-    import time
     t0 = time.time()
     while not kv_tensors_created():
         if time.time() - t0 > 10.0:
@@ -70,23 +72,28 @@ def build_pool():
         cell_size=CELL_SIZE,
         num_layers=NUM_LAYERS,
         enable_caching=True,
+        # Cap eviction explicitly: the default (1000) would silently bound the
+        # pool below CACHED and evict before the measurement starts.
+        max_cached_blocks=-1,
     )
 
 
 def fill_cache(pool, n, stride):
-    """Cache n blocks, releasing every stride-th one last.
+    """Cache n blocks, then re-cache every stride-th one so it is newest.
 
-    Interleaving which blocks are cached vs freed spreads the survivors across
-    pages, which is what a real prefix cache looks like after mixed requests.
+    Re-caching under a fresh hash moves those blocks to the end of the LRU
+    order, so an age-only policy spares them. They are spread every stride
+    blocks, so sparing them pins one page per survivor.
     """
     blocks = pool.get_new_blocks(n)
     req = _Request([f"h{b.block_id}" for b in blocks])
     pool.cache_full_blocks(req, blocks, 0, n, BLOCK_SIZE, 0)
     pool.free_blocks(blocks)
-    # Re-activate blocks we do not want cached, so they leave the pool.
-    drop = [b for i, b in enumerate(blocks) if i % stride != 0]
-    if drop:
-        pool.evict_blocks({b.block_id for b in drop})
+
+    hot = blocks[::stride]
+    for block in hot:
+        pool.touch([block])
+    pool.free_blocks(hot)
     return blocks
 
 
@@ -94,17 +101,18 @@ if __name__ == "__main__":
     pool = build_pool()
     mgr = pool.kv_cache_manager
     print(f"cached={CACHED} keep={KEEP} "
-          f"page={mgr.page_size // (1024 * 1024)}MB block={mgr.block_mem_size}B\n")
-    print(f"{'stride':>7} {'evictable':>10} {'before GB':>10} {'after GB':>9} "
-          f"{'freed GB':>9}")
-    for stride in (1, 2, 4):
+          f"page={mgr.page_size // (1024 * 1024)}MB block={mgr.block_mem_size}B")
+    print(f"blocks per page = {mgr.page_size // mgr.block_mem_size}\n")
+    print(f"{'stride':>7} {'evictable':>10} {'evicted':>8} {'before GB':>10} "
+          f"{'after GB':>9} {'freed GB':>9}")
+    for stride in (1, 2, 4, 8):
         fill_cache(pool, CACHED, stride)
         evictable = len(pool._evictable_blocks)
-        before = mgr.get_mapped_memory_size(unit='gb')
         excess = max(0, evictable - KEEP)
-        pool._evict_blocks_from_pool(excess)
+        before = mgr.get_mapped_memory_size(unit='gb')
+        evicted = pool._evict_blocks_from_pool(excess)
         after = mgr.get_mapped_memory_size(unit='gb')
-        print(f"{stride:>7} {evictable:>10} {before:>10.2f} {after:>9.2f} "
-              f"{before - after:>9.2f}")
+        print(f"{stride:>7} {evictable:>10} {evicted:>8} {before:>10.2f} "
+              f"{after:>9.2f} {before - after:>9.2f}")
         pool.reset_prefix_cache()
     shutdown_kvcached()

--- a/benchmarks/bench_frag/bench_evict.py
+++ b/benchmarks/bench_frag/bench_evict.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Measure memory released by prefix-cache eviction (issue #359).
+
+Fills ElasticBlockPool's prefix cache, releases the blocks so they become
+evictable, then evicts down to a cap and reports how much physical memory came
+back. Pages only unmap once every block on them is free, so an eviction policy
+that ignores pages can hit the cap while releasing nothing.
+
+Run on each branch and compare the "freed" column:
+    python bench_evict.py
+"""
+import types
+
+import torch
+
+from kvcached.integration.vllm.interfaces import alloc_kv_cache, init_kvcached, shutdown_kvcached
+from kvcached.integration.vllm.patches import ElasticBlockPoolPatch
+from kvcached.vmm_ops import kv_tensors_created
+
+TP_RANK, TP_SIZE = 0, 1
+NUM_LAYERS = 8
+BLOCK_SIZE = 16
+CELL_SIZE = 1024
+NUM_BLOCKS = 8192
+DTYPE = torch.float16
+DEVICE = f"cuda:{TP_RANK}"
+KV_SHAPE = (2, NUM_BLOCKS, BLOCK_SIZE, 8, 64)
+
+# Cache this many blocks, then evict down to KEEP. Mirrors an instance going
+# idle with MAX_CACHED_TOKENS worth of prefix cache left over.
+CACHED = 4096
+KEEP = 512
+
+
+class _Block:
+
+    def __init__(self, block_id: int):
+        self.block_id = block_id
+        self.ref_cnt = 0
+        self.is_null = False
+
+
+class _Request:
+
+    def __init__(self, block_hashes):
+        self.block_hashes = block_hashes
+
+
+def build_pool():
+    torch.cuda.set_device(TP_RANK)
+    init_kvcached(tp_rank=TP_RANK, world_size=TP_SIZE, is_worker=True,
+                  async_sched=False)
+    alloc_kv_cache(kvcache_shape=KV_SHAPE, block_size=BLOCK_SIZE, dtype=DTYPE,
+                   device=DEVICE, num_layers=NUM_LAYERS)
+    import time
+    t0 = time.time()
+    while not kv_tensors_created():
+        if time.time() - t0 > 10.0:
+            raise RuntimeError("KV tensors not created within 10s")
+        time.sleep(0.05)
+
+    mod = types.ModuleType("bench_block_pool")
+    mod.BlockPool = object
+    mod.KVCacheBlock = _Block
+    ElasticBlockPoolPatch().inject_elastic_block_pool(mod)
+    return mod.ElasticBlockPool(
+        num_gpu_blocks=NUM_BLOCKS,
+        block_size=BLOCK_SIZE,
+        cell_size=CELL_SIZE,
+        num_layers=NUM_LAYERS,
+        enable_caching=True,
+    )
+
+
+def fill_cache(pool, n, stride):
+    """Cache n blocks, releasing every stride-th one last.
+
+    Interleaving which blocks are cached vs freed spreads the survivors across
+    pages, which is what a real prefix cache looks like after mixed requests.
+    """
+    blocks = pool.get_new_blocks(n)
+    req = _Request([f"h{b.block_id}" for b in blocks])
+    pool.cache_full_blocks(req, blocks, 0, n, BLOCK_SIZE, 0)
+    pool.free_blocks(blocks)
+    # Re-activate blocks we do not want cached, so they leave the pool.
+    drop = [b for i, b in enumerate(blocks) if i % stride != 0]
+    if drop:
+        pool.evict_blocks({b.block_id for b in drop})
+    return blocks
+
+
+if __name__ == "__main__":
+    pool = build_pool()
+    mgr = pool.kv_cache_manager
+    print(f"cached={CACHED} keep={KEEP} "
+          f"page={mgr.page_size // (1024 * 1024)}MB block={mgr.block_mem_size}B\n")
+    print(f"{'stride':>7} {'evictable':>10} {'before GB':>10} {'after GB':>9} "
+          f"{'freed GB':>9}")
+    for stride in (1, 2, 4):
+        fill_cache(pool, CACHED, stride)
+        evictable = len(pool._evictable_blocks)
+        before = mgr.get_mapped_memory_size(unit='gb')
+        excess = max(0, evictable - KEEP)
+        pool._evict_blocks_from_pool(excess)
+        after = mgr.get_mapped_memory_size(unit='gb')
+        print(f"{stride:>7} {evictable:>10} {before:>10.2f} {after:>9.2f} "
+              f"{before - after:>9.2f}")
+        pool.reset_prefix_cache()
+    shutdown_kvcached()

--- a/benchmarks/bench_frag/bench_frag.py
+++ b/benchmarks/bench_frag/bench_frag.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Measure physical memory pinned by a scattered cache (issue #359).
+
+An idle instance keeps up to KVCACHED_MAX_CACHED_TOKENS worth of prefix cache,
+but memory only comes back once every block on a 2MB page is freed. When the
+retained blocks are scattered, the pinned set is bounded by pages touched rather
+than blocks kept, and the instance holds far more than the cap implies.
+
+This reproduces that without a model: allocate many blocks, then free all but a
+scattered residue and compare what is pinned against what is held.
+
+Run on each branch and compare:
+    python bench_frag.py
+"""
+import time
+
+import torch
+
+from kvcached.integration.vllm.interfaces import alloc_kv_cache, init_kvcached, shutdown_kvcached
+from kvcached.kv_cache_manager import KVCacheManager
+from kvcached.vmm_ops import kv_tensors_created
+
+TP_RANK, TP_SIZE = 0, 1
+NUM_LAYERS = 16
+BLOCK_SIZE = 16
+NUM_BLOCKS = 65536
+CELL_SIZE = 1024
+DTYPE = torch.float16
+DEVICE = f"cuda:{TP_RANK}"
+KV_SHAPE = (2, NUM_BLOCKS, BLOCK_SIZE, 8, 64)
+
+# Blocks to allocate before thinning, and how many to keep. KEEP is the residue
+# an idle instance would retain as prefix cache.
+ALLOC = 16384
+KEEP = 1024
+
+
+def setup():
+    torch.cuda.set_device(TP_RANK)
+    init_kvcached(tp_rank=TP_RANK, world_size=TP_SIZE, is_worker=True,
+                  async_sched=False)
+    alloc_kv_cache(kvcache_shape=KV_SHAPE, block_size=BLOCK_SIZE, dtype=DTYPE,
+                   device=DEVICE, num_layers=NUM_LAYERS)
+    t0 = time.time()
+    while not kv_tensors_created():
+        if time.time() - t0 > 10.0:
+            raise RuntimeError("KV tensors not created within 10s")
+        time.sleep(0.05)
+    return KVCacheManager(num_blocks=NUM_BLOCKS, block_size=BLOCK_SIZE,
+                          cell_size=CELL_SIZE, num_layers=NUM_LAYERS,
+                          world_size=TP_SIZE)
+
+
+def measure(manager, keep_stride):
+    """Keep every keep_stride-th block, free the rest, report what stays pinned.
+
+    keep_stride=1 keeps a contiguous prefix (the best case: retained blocks pack
+    into as few pages as possible). Larger strides spread the same number of
+    retained blocks over more pages, which is what a real prefix cache looks like
+    after mixed-length requests come and go.
+    """
+    blocks = manager.alloc(ALLOC)
+    assert blocks is not None and len(blocks) == ALLOC
+
+    kept = blocks[::keep_stride][:KEEP]
+    kept_set = set(kept)
+    manager.free([b for b in blocks if b not in kept_set])
+
+    pinned_gb = manager.get_mapped_memory_size(unit='gb')
+    held_bytes = len(kept) * manager.block_mem_size * NUM_LAYERS * 2
+    held_gb = held_bytes / (1024**3)
+
+    manager.free(kept)
+    return len(kept), held_gb, pinned_gb
+
+
+if __name__ == "__main__":
+    manager = setup()
+    print(f"kept={KEEP} blocks of {ALLOC} allocated, "
+          f"page={manager.page_size // (1024 * 1024)}MB, "
+          f"block={manager.block_mem_size}B\n")
+    print(f"{'stride':>7} {'kept':>6} {'held GB':>9} {'pinned GB':>10} {'waste':>7}")
+    for stride in (1, 2, 4, 8, 16):
+        kept, held_gb, pinned_gb = measure(manager, stride)
+        ratio = pinned_gb / held_gb if held_gb else 0.0
+        print(f"{stride:>7} {kept:>6} {held_gb:>9.2f} {pinned_gb:>10.2f} "
+              f"{ratio:>6.1f}x")
+    shutdown_kvcached()

--- a/benchmarks/bench_idle_footprint/README.md
+++ b/benchmarks/bench_idle_footprint/README.md
@@ -1,0 +1,131 @@
+# bench_idle_footprint
+
+How much physical memory does a kvcached instance still hold once it goes idle?
+
+That is the question behind [#359](https://github.com/ovg-project/kvcached/issues/359).
+`KVCACHED_MAX_CACHED_TOKENS` bounds the prefix cache in **blocks**, but memory
+comes back a **page** at a time, and only once every block on that page is free.
+So what an idle instance holds is decided by how many pages its surviving blocks
+are spread over — not by how many blocks it kept.
+
+## Scripts
+
+| | |
+|---|---|
+| `run_idle_footprint.py` | how much memory is still held once the instance is idle — the headline number, plus a per-second timeline |
+| `run_reuse_after_idle.py` | what the eviction policy's victim choice costs in hit rate |
+| `sim_eviction.py` | why a page-aware policy does nothing while traffic is running (CPU only, no GPU or vLLM needed) |
+| `workload.py`, `probe_mem.py` | the load generator and the memory probe the two runners drive |
+
+## Run
+
+```bash
+MODEL=/path/to/Qwen3-4B ./run_idle_footprint.py
+```
+
+Run it once per branch and compare the `idle_gb` line. Useful knobs:
+
+```bash
+./run_idle_footprint.py --workload "--requests 1000 --concurrency 32"
+./run_idle_footprint.py --serve-arg --enforce-eager
+```
+
+## What it measures
+
+`idle_gb` comes from the number kvcached publishes about itself, in its MemInfo
+shared-memory segment:
+
+```
+used_size = num_inuse_pages * num_layers * page_size * num_kv_buffers
+```
+
+`nvidia-smi` is no use here — it also counts weights and activations. Note the
+`num_layers * num_kv_buffers` factor: one page id is mapped in every layer and
+in both the K and V buffers, so on a 36-layer model a 2 MiB page id costs
+**144 MiB** of physical memory.
+
+`idle_prealloc_gb` is reported separately: `free_page()` parks up to
+`KVCACHED_MAX_RESERVED_PAGES` (default 10) pages without unmapping them, and
+only `trim()` returns those.
+
+## The workload shape matters
+
+The reproduction hinges on **staggered decode lengths**, which is easy to miss:
+
+| workload | idle pages |
+|---|---|
+| 4000 requests, concurrency 32, `max_tokens=4` | 27 |
+| 5000 requests, concurrency 96, varied prompts, `max_tokens=4` | 27 |
+| **2500 requests, concurrency 96, varied prompts, `max_tokens` in [16,256]** | **73** |
+
+Prefill asks for many blocks at once and the allocator drains one page before
+moving to the next, so prefill-shaped traffic packs naturally. Decode asks for
+**one block at a time**, and with many requests decoding at different rates and
+finishing at different moments, those single-block allocations land in whatever
+holes exist across many pages. A benchmark that only stresses prefill will
+report kvcached as near-optimal and miss the problem entirely.
+
+`workload.py` therefore mixes hot prefixes (revisited, so an age-only eviction
+policy never drops them) with a long cold tail, and samples both prompt and
+decode lengths. Prompts are sent as token-id lists so prefix sharing is exact.
+
+## Reference numbers
+
+NVIDIA L40, Qwen3-4B (36 layers), vLLM 0.22.1, default
+`KVCACHED_MAX_CACHED_TOKENS=16000`, so the cap is 1000 blocks and one page holds
+64 of them. Two runs per row, same workload and seed:
+
+```
+--requests 2500 --concurrency 96 --hot-prefixes 16 --hot-tokens 128
+--suffix-tokens 64 --cold-tokens-min 192 --cold-tokens-max 1024
+--hot-ratio 0.3 --max-tokens-min 16 --max-tokens-max 256 --seed 1234
+```
+
+| | idle GB | pages | vs packed floor |
+|---|---|---|---|
+| before #390 | 10.27 / 10.55 | 73 / 75 | 4.6x |
+| \+ #390 page-aware eviction | 5.20 / 5.34 | 37 / 38 | 2.3x |
+| \+ page-aware allocation | 3.09 / 3.09 | 22 / 22 | **1.4x** |
+| packed floor | 2.25 | 16 | 1.0x |
+
+The **packed floor** is what the cap would cost with no holes at all:
+`ceil(1000 blocks / 64 per page) = 16 pages = 2.25 GB`. No eviction or
+allocation policy can go below it without caching fewer blocks than the cap
+allows. (It equals the raw KV bytes of 1000 blocks, which is the same statement:
+packed means no holes.)
+
+Prefix-cache hits were identical across all rows (93,952) and throughput was
+11.7–11.9 req/s throughout.
+
+## What eviction costs in hit rate
+
+That last point needs care, which is what `run_reuse_after_idle.py` is for. Two
+eviction policies make **identical** choices while traffic is running: live
+requests hold blocks all over the pool, so hardly any page is fully evictable
+and a page-aware policy has nothing to choose from. `sim_eviction.py` shows this
+directly — with 1000 blocks held by running requests, **0 of 89** pages are
+eligible at any eviction budget:
+
+```
+  active  budget   eligible/total  pages freed
+       0      64            86/87           14
+     200      64             8/89            5
+    1000      64             0/89            0
+```
+
+The policies only diverge once the pool goes quiet. So the measurement is: send
+traffic, let it go idle so the trim runs, then send more — and have that second
+round ask for the **cold** prompts the first round cached. Hot prefixes survive
+under any policy and fresh prompts were never cached, so neither can tell two
+policies apart; `--cold-pool N` gives both rounds one fixed set of prompts to
+draw from, and the hit rate afterwards reads out what the trim kept.
+
+| | memory while idle | hit rate after idle |
+|---|---|---|
+| before #390 | 9.00 / 8.86 GB | 0.4200 / 0.4200 |
+| \+ #390 page-aware eviction | 4.92 / 4.78 GB | 0.4138 / 0.4121 |
+
+Do not carry that ~0.70 pp anywhere: the prompts are random token ids and the
+reuse pattern is uniform sampling from a 200-prompt pool, nothing a real
+deployment produces. It establishes only that the cost is non-zero and small
+here.

--- a/benchmarks/bench_idle_footprint/probe_mem.py
+++ b/benchmarks/bench_idle_footprint/probe_mem.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Read kvcached's published memory usage from its shared-memory segment.
+
+`PageAllocator::update_memory_usage()` publishes, per KV cache group:
+  used_size     = num_inuse_pages       * num_layers * page_size * num_kv_buffers
+  prealloc_size = len(reserved_page_list) * num_layers * page_size * num_kv_buffers
+
+`used_size` is exactly the physical memory pinned by mapped pages -- the
+quantity issue #359 is about. `prealloc_size` is the reserved pool that
+free_page() parks pages in before unmapping them; those are also still mapped.
+"""
+import argparse
+import json
+import os
+import sys
+import time
+
+from kvcached.cli.utils import SHM_DIR, MemInfoStruct, RwLockedShm
+
+GB = 1024**3
+
+
+def detect_segments():
+    """Return every /dev/shm segment that looks like a kvcached MemInfoStruct."""
+    found = []
+    for fname in sorted(os.listdir(SHM_DIR)):
+        path = os.path.join(SHM_DIR, fname)
+        try:
+            if os.stat(path).st_size != MemInfoStruct.SHM_SIZE:
+                continue
+            with RwLockedShm(fname, MemInfoStruct.SHM_SIZE,
+                             RwLockedShm.RLOCK) as mm:
+                if MemInfoStruct.from_buffer(mm).total_size <= 0:
+                    continue
+        except Exception:  # noqa: BLE001 -- unreadable segments are not ours
+            continue
+        found.append(fname)
+    return found
+
+
+def read_mem(name):
+    with RwLockedShm(name, MemInfoStruct.SHM_SIZE, RwLockedShm.RLOCK) as mm:
+        info = MemInfoStruct.from_buffer(mm)
+    return {
+        "seg": name,
+        "total_gb": info.total_size / GB,
+        "used_gb": info.used_size / GB,
+        "prealloc_gb": info.prealloc_size / GB,
+        "pinned_gb": (info.used_size + info.prealloc_size) / GB,
+        "used_bytes": info.used_size,
+        "prealloc_bytes": info.prealloc_size,
+    }
+
+
+def read_all(names=None):
+    names = names or detect_segments()
+    out = []
+    for n in names:
+        try:
+            out.append(read_mem(n))
+        except Exception as e:  # noqa: BLE001
+            out.append({"seg": n, "error": f"{type(e).__name__}: {e}"})
+    return out
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--seg", default=None)
+    ap.add_argument("--watch", type=float, default=0.0)
+    ap.add_argument("--duration", type=float, default=0.0)
+    ap.add_argument("--jsonl", default=None)
+    args = ap.parse_args()
+
+    names = [args.seg] if args.seg else None
+    if args.watch <= 0:
+        print(json.dumps(read_all(names), indent=1))
+        sys.exit(0)
+
+    out = open(args.jsonl, "w") if args.jsonl else None
+    t0 = time.time()
+    pinned_names = names
+    while True:
+        if not pinned_names:
+            detected = detect_segments()
+            if detected:
+                pinned_names = detected
+        recs = read_all(pinned_names) if pinned_names else []
+        line = json.dumps({"t": time.time() - t0, "segs": recs})
+        if out:
+            out.write(line + "\n")
+            out.flush()
+        else:
+            print(line, flush=True)
+        if args.duration and time.time() - t0 >= args.duration:
+            break
+        time.sleep(args.watch)
+    if out:
+        out.close()

--- a/benchmarks/bench_idle_footprint/run_idle_footprint.py
+++ b/benchmarks/bench_idle_footprint/run_idle_footprint.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Measure the physical memory a kvcached instance still holds once it is idle.
+
+Issue #359: with prefix caching on, an idle instance keeps far more physical
+memory than KVCACHED_MAX_CACHED_TOKENS implies. The cap counts blocks, but
+memory comes back a page at a time, and only once every block on that page is
+free -- so what an idle instance holds is decided by how many pages its
+surviving blocks are spread over, not by how many blocks it kept.
+
+This drives a real vLLM server, then reads the number kvcached itself
+publishes: `used_size` in its MemInfo shared-memory segment, which is
+`num_inuse_pages * num_layers * page_size * num_kv_buffers`. (nvidia-smi would
+be no good here -- it also counts weights and activations.)
+
+Usage:
+    MODEL=/path/to/Qwen3-4B ./run_idle_footprint.py
+    ./run_idle_footprint.py --workload "--requests 1000 --concurrency 32"
+
+Run it once per branch and compare the "idle" line.
+"""
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import urllib.request
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GB = 1024**3
+
+sys.path.insert(0, HERE)
+from probe_mem import detect_segments, read_all  # noqa: E402
+
+
+def http_text(url, timeout=10):
+    with urllib.request.urlopen(url, timeout=timeout) as r:
+        return r.read().decode()
+
+
+def metric(text, name):
+    m = re.search(rf'^{re.escape(name)}\{{[^}}]*\}}\s+([0-9.e+-]+)$', text,
+                  re.MULTILINE)
+    return float(m.group(1)) if m else None
+
+
+def _vllm_bin():
+    """Find the `vllm` console script, preferring the one next to this
+    interpreter so `venv/bin/python run_idle_footprint.py` works without
+    activating the venv first."""
+    local = os.path.join(os.path.dirname(sys.executable), "vllm")
+    if os.path.exists(local):
+        return local
+    found = shutil.which("vllm")
+    if not found:
+        raise RuntimeError("cannot find the `vllm` executable; activate the "
+                           "environment vLLM is installed in")
+    return found
+
+
+def launch(model, port, log, extra):
+    env = dict(os.environ)
+    env.setdefault("ENABLE_KVCACHED", "true")
+    env.setdefault("KVCACHED_AUTOPATCH", "1")
+    env.setdefault("VLLM_USE_V1", "1")
+    # kvcached patches the V1 GPUModelRunner. vLLM picks the V2 runner by
+    # default for some models, and then kvcached's worker-side init hook never
+    # fires and KV init dies; keep it on the path kvcached supports.
+    env.setdefault("VLLM_USE_V2_MODEL_RUNNER", "0")
+    cmd = [_vllm_bin(), "serve", model, "--port", str(port),
+           "--served-model-name", "bench", "--max-model-len",
+           os.environ.get("MAX_MODEL_LEN", "8192")] + extra
+    with open(log, "w") as f:
+        return subprocess.Popen(cmd, stdout=f, stderr=subprocess.STDOUT,
+                                env=env)
+
+
+def wait_ready(port, log, proc, timeout=900):
+    t0 = time.time()
+    while time.time() - t0 < timeout:
+        if proc.poll() is not None:
+            return False
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/health", timeout=5)
+            return True
+        except Exception:  # noqa: BLE001
+            pass
+        time.sleep(3)
+    return False
+
+
+def geometry(log):
+    """Recover the page geometry the server chose, from its own startup log."""
+    with open(log, errors="ignore") as f:
+        text = f.read()
+    m = re.search(r"num_layers=(\d+).*?page_size=(\d+)MB.*?num_kv_buffers=(\d+)",
+                  text)
+    if not m:
+        return {}
+    layers, page_mb, buffers = (int(m.group(1)), int(m.group(2)),
+                                int(m.group(3)))
+    return {"num_layers": layers, "page_size_mb": page_mb,
+            "num_kv_buffers": buffers,
+            "bytes_per_page": page_mb * 1024**2 * layers * buffers}
+
+
+def our_segments(before):
+    """The MemInfo segments this run's server created.
+
+    Reading every segment in /dev/shm would fold in any co-located kvcached
+    instance -- which is the whole point of kvcached, so it is not hypothetical
+    -- and any segment a previously killed server left behind. Deleting them is
+    not an option for the same reason, so diff against what existed at launch.
+    """
+    ours = [n for n in detect_segments() if n not in before]
+    if not ours:
+        print("warning: no new MemInfo segment appeared; is kvcached enabled?",
+              file=sys.stderr)
+    return ours
+
+
+def snapshot(names):
+    live = [s for s in read_all(names) if "error" not in s]
+    return {"used_gb": sum(s["used_gb"] for s in live),
+            "prealloc_gb": sum(s["prealloc_gb"] for s in live)}
+
+
+def wait_idle(port, settle, timeout=600):
+    t0 = time.time()
+    while time.time() - t0 < timeout:
+        try:
+            text = http_text(f"http://127.0.0.1:{port}/metrics")
+            if (metric(text, "vllm:num_requests_running") or 0) == 0 and \
+               (metric(text, "vllm:num_requests_waiting") or 0) == 0:
+                break
+        except Exception:  # noqa: BLE001
+            pass
+        time.sleep(2)
+    time.sleep(settle)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default=os.environ.get("MODEL"))
+    ap.add_argument("--port", type=int, default=8100)
+    ap.add_argument("--idle-settle", type=float, default=25.0)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--tag", default="",
+                    help="suffix for the timeline file, to keep runs apart")
+    ap.add_argument("--workload", default="",
+                    help="extra args forwarded to workload.py")
+    ap.add_argument("--serve-arg", action="append", default=[],
+                    help="extra args forwarded to `vllm serve`")
+    args = ap.parse_args()
+    if not args.model:
+        ap.error("pass --model or set MODEL")
+
+    log = os.path.join(HERE, "server.log")
+    before = set(detect_segments())
+    proc = launch(args.model, args.port, log, args.serve_arg)
+    try:
+        if not wait_ready(args.port, log, proc):
+            print(f"server failed to start; see {log}")
+            return 1
+        segs = our_segments(before)
+        geo = geometry(log)
+        print(f"geometry: {geo}", flush=True)
+
+        # Sample throughout, not just at the end: the shape matters. Page-aware
+        # eviction cannot free anything while requests are in flight (nearly
+        # every page holds a live block), so its whole effect appears as a step
+        # at the moment the last request drains.
+        timeline = os.path.join(HERE, f"timeline{args.tag}.jsonl")
+        sampler = subprocess.Popen(
+            [sys.executable, os.path.join(HERE, "probe_mem.py"),
+             "--watch", "1", "--jsonl", timeline]
+            + (["--seg", segs[0]] if segs else []),
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        subprocess.run([sys.executable, os.path.join(HERE, "workload.py"),
+                        "--port", str(args.port), "--model", "bench"]
+                       + args.workload.split(), check=False)
+        after = snapshot(segs)
+        wait_idle(args.port, args.idle_settle)
+        idle = snapshot(segs)
+
+        sampler.terminate()
+        text = http_text(f"http://127.0.0.1:{args.port}/metrics")
+        q = metric(text, "vllm:prefix_cache_queries_total") or 0
+        h = metric(text, "vllm:prefix_cache_hits_total") or 0
+
+        bpp = geo.get("bytes_per_page")
+        result = {
+            "after_workload_gb": round(after["used_gb"], 2),
+            "idle_gb": round(idle["used_gb"], 2),
+            "idle_prealloc_gb": round(idle["prealloc_gb"], 2),
+            "idle_pages": round(idle["used_gb"] * GB / bpp) if bpp else None,
+            "prefix_cache_hits": int(h),
+            "prefix_cache_hit_rate": round(h / q, 4) if q else None,
+            "geometry": geo,
+            "timeline": timeline,
+        }
+        print(json.dumps(result, indent=1), flush=True)
+        if args.out:
+            with open(args.out, "w") as f:
+                json.dump(result, f, indent=1)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=60)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/bench_idle_footprint/run_reuse_after_idle.py
+++ b/benchmarks/bench_idle_footprint/run_reuse_after_idle.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""What an eviction policy's victim choice costs in prefix-cache hit rate.
+
+Two eviction policies make identical choices while traffic is running: live
+requests hold blocks all over the pool, so hardly any page is fully evictable
+and a page-aware policy has nothing to choose from. They only diverge once the
+pool goes quiet and every cached block becomes a candidate.
+
+So the measurement needs three things in order: send traffic, let it go idle
+long enough for the trim to run, then send more traffic. And that second round
+has to ask for the *cold* prompts the first round cached -- hot prefixes survive
+under any policy, and fresh prompts were never cached at all, so neither can
+tell two policies apart. `--cold-pool` gives both rounds one fixed set of
+prompts to draw from, so the second round re-requests what the first one cached
+and its hit rate reads out directly what the trim kept.
+
+    MODEL=/path/to/Qwen3-4B ./run_reuse_after_idle.py
+
+Run it once per branch and compare `hit_rate_after_idle` alongside `idle_gb`.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+from probe_mem import detect_segments  # noqa: E402
+from run_idle_footprint import (  # noqa: E402
+    geometry,
+    http_text,
+    launch,
+    metric,
+    our_segments,
+    snapshot,
+    wait_idle,
+    wait_ready,
+)
+
+GB = 1024**3
+
+
+def counters(port):
+    text = http_text(f"http://127.0.0.1:{port}/metrics")
+    return (metric(text, "vllm:prefix_cache_queries_total") or 0.0,
+            metric(text, "vllm:prefix_cache_hits_total") or 0.0)
+
+
+def send_traffic(port, workload, seed, hot_seed):
+    cmd = [sys.executable, os.path.join(HERE, "workload.py"),
+           "--port", str(port), "--model", "bench",
+           "--seed", str(seed), "--hot-seed", str(hot_seed)]
+    subprocess.run(cmd + workload.split(), check=False)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default=os.environ.get("MODEL"))
+    ap.add_argument("--port", type=int, default=8100)
+    ap.add_argument("--gap", type=float, default=45.0,
+                    help="idle seconds between the two rounds of traffic")
+    ap.add_argument("--idle-settle", type=float, default=20.0)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--workload", default=(
+        "--requests 1400 --concurrency 96 --hot-prefixes 8 --hot-tokens 128 "
+        "--suffix-tokens 64 --cold-tokens-min 192 --cold-tokens-max 1024 "
+        "--hot-ratio 0.2 --max-tokens-min 16 --max-tokens-max 192 "
+        "--cold-pool 200"),
+        help="args for workload.py; keep --cold-pool or the second round "
+             "measures nothing")
+    ap.add_argument("--serve-arg", action="append", default=[])
+    args = ap.parse_args()
+    if not args.model:
+        ap.error("pass --model or set MODEL")
+    if "--cold-pool" not in args.workload:
+        print("warning: without --cold-pool the second round only revisits hot "
+              "prefixes, which every policy keeps, and hit rate will not move",
+              file=sys.stderr)
+
+    log = os.path.join(HERE, "server.log")
+    before = set(detect_segments())
+    proc = launch(args.model, args.port, log, args.serve_arg)
+    result = {"gap_s": args.gap, "workload": args.workload}
+    try:
+        if not wait_ready(args.port, log, proc):
+            print(f"server failed to start; see {log}")
+            return 1
+        segs = our_segments(before)
+        result["geometry"] = geometry(log)
+        bpp = result["geometry"].get("bytes_per_page")
+
+        # First round fills the cache from the pool.
+        q0, h0 = counters(args.port)
+        send_traffic(args.port, args.workload, seed=1234, hot_seed=99)
+        wait_idle(args.port, args.idle_settle)
+        q1, h1 = counters(args.port)
+        result["hit_rate_before_idle"] = round((h1 - h0) / (q1 - q0), 4) \
+            if q1 > q0 else None
+
+        # Going quiet is when the trim finally has pages to choose from, and
+        # when memory comes back.
+        print(f"idle gap {args.gap}s ...", flush=True)
+        time.sleep(args.gap)
+        gap = snapshot(segs)
+        result["idle_gb"] = round(gap["used_gb"], 2)
+        result["idle_pages"] = round(gap["used_gb"] * GB / bpp) if bpp else None
+
+        # Second round re-requests the same pool: whatever the trim kept, hits.
+        send_traffic(args.port, args.workload, seed=5678, hot_seed=99)
+        wait_idle(args.port, args.idle_settle)
+        q2, h2 = counters(args.port)
+        result["hit_rate_after_idle"] = round((h2 - h1) / (q2 - q1), 4) \
+            if q2 > q1 else None
+        result["hits_after_idle"] = int(h2 - h1)
+
+        print(json.dumps(result, indent=1), flush=True)
+        if args.out:
+            with open(args.out, "w") as f:
+                json.dump(result, f, indent=1)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=60)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/bench_idle_footprint/sim_eviction.py
+++ b/benchmarks/bench_idle_footprint/sim_eviction.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Why page-aware eviction does nothing while traffic is running (CPU only).
+
+A page can only be emptied if *every* allocated block on it is evictable. While
+requests are in flight they hold blocks all over the pool, so most pages are
+disqualified and the policy quietly falls back to LRU. That is invisible in a
+serving run -- you just see memory not moving -- so this measures it directly.
+
+It drives a real ElasticBlockPool with torch and the C extension mocked out (the
+same trick tests/test_prefix_cache.py uses), builds a scattered prefix cache,
+adds a controllable number of blocks held by "running requests", and reports for
+each eviction budget: how many pages were eligible at all, how many came free,
+and how many victims pure LRU would have kept.
+
+    python sim_eviction.py                 # sweep active blocks
+    python sim_eviction.py --active 1000   # one point
+"""
+import argparse
+import json
+import random
+import sys
+import types
+from unittest import mock
+
+BLOCKS_PER_PAGE = 64  # 2MiB page / 32KiB block, i.e. Qwen3-4B geometry
+
+_torch = mock.MagicMock()
+_torch.__version__ = "2.6.0"
+_torch.cuda.mem_get_info.return_value = (8 * 1024**3, 16 * 1024**3)
+sys.modules.setdefault("torch", _torch)
+sys.modules.setdefault("torch.cuda", _torch.cuda)
+sys.modules.setdefault("torch.utils", _torch.utils)
+sys.modules.setdefault("torch.utils.cpp_extension", _torch.utils.cpp_extension)
+sys.modules.setdefault("posix_ipc", mock.MagicMock())
+sys.modules.setdefault("kvcached.vmm_ops", mock.MagicMock())
+sys.modules.setdefault("kvcached.integration.vllm.interfaces", mock.MagicMock())
+
+
+class Block:
+
+    def __init__(self, block_id):
+        self.block_id = block_id
+        self.ref_cnt = 0
+        self.is_null = False
+
+
+class Request:
+
+    def __init__(self, block_hashes):
+        self.block_hashes = block_hashes
+
+
+class PageAllocator:
+    """Groups block ids by page the way the C++ allocator does."""
+
+    def group_indices_by_page(self, indices, block_mem_size):
+        by_page = {}
+        for idx in indices:
+            by_page.setdefault(idx // BLOCKS_PER_PAGE, []).append(idx)
+        return by_page
+
+
+class Manager:
+    """Tracks which blocks are live on which page; that is all eviction reads."""
+
+    def __init__(self, num_blocks):
+        self._free = list(range(1, num_blocks))
+        self._allocated = {0}  # block 0 is the reserved null block
+        self._page_count = {0: 1}
+        self.page_allocator = PageAllocator()
+        self.block_mem_size = 32 * 1024
+        self.page_size = BLOCKS_PER_PAGE * self.block_mem_size
+
+    def _note_alloc(self, ids):
+        self._allocated.update(ids)
+        for i in ids:
+            p = i // BLOCKS_PER_PAGE
+            self._page_count[p] = self._page_count.get(p, 0) + 1
+
+    def alloc(self, n, rng=None, spread_pages=None):
+        """Hand out random free slots, as a churned pool would."""
+        if len(self._free) < n:
+            return None
+        if rng is None:
+            ids, self._free = self._free[:n], self._free[n:]
+        else:
+            limit = len(self._free)
+            if spread_pages:
+                limit = min(limit, spread_pages * BLOCKS_PER_PAGE)
+            picks = set(rng.sample(range(limit), n))
+            ids = [self._free[i] for i in picks]
+            self._free = [b for i, b in enumerate(self._free) if i not in picks]
+        self._note_alloc(ids)
+        return ids
+
+    def free(self, ids):
+        for i in ids:
+            if i in self._allocated:
+                p = i // BLOCKS_PER_PAGE
+                self._page_count[p] -= 1
+                if not self._page_count[p]:
+                    del self._page_count[p]
+            self._allocated.discard(i)
+            self._free.append(i)
+
+    def available_size(self):
+        return len(self._free)
+
+    def get_page_occupancy(self, page_ids):
+        return {p: self._page_count.get(p, 0) for p in page_ids}
+
+    def pages_pinned(self):
+        return len(self._page_count)
+
+
+def make_pool(num_blocks, rng, spread_pages):
+    mgr = Manager(num_blocks)
+    mgr.alloc = lambda n: Manager.alloc(mgr, n, rng, spread_pages)
+
+    mod = types.ModuleType("sim_block_pool")
+    mod.BlockPool = object
+    mod.KVCacheBlock = Block
+    with mock.patch(
+            "kvcached.integration.vllm.interfaces.get_kv_cache_manager",
+            return_value=mgr):
+        from kvcached.integration.vllm.patches import ElasticBlockPoolPatch
+        ElasticBlockPoolPatch().inject_elastic_block_pool(mod)
+        pool = mod.ElasticBlockPool(num_gpu_blocks=num_blocks, block_size=16,
+                                    cell_size=2048, num_layers=36,
+                                    enable_caching=True)
+    pool.max_cached_blocks = -1  # keep the setup out of the way
+    return pool, mgr
+
+
+def build_cache(pool, cached, rng):
+    got = []
+    while len(got) < cached:
+        n = min(rng.randint(8, 64), cached - len(got))
+        blocks = pool.get_new_blocks(n)
+        pool.cache_full_blocks(Request([f"h{b.block_id}" for b in blocks]),
+                               blocks, 0, n, 16, 0)
+        pool.free_blocks(blocks)
+        got.extend(blocks)
+    return got
+
+
+def measure(budget, cached, active, num_blocks, spread_pages, seed):
+    rng = random.Random(seed)
+    pool, mgr = make_pool(num_blocks, rng, spread_pages)
+    build_cache(pool, cached, rng)
+    if active:
+        # Blocks of requests that are still running: they never enter the
+        # evictable pool, and a page holding one can never be emptied.
+        pool.get_new_blocks(active)
+
+    by_page = {}
+    for bid in pool._evictable_blocks:
+        by_page[bid // BLOCKS_PER_PAGE] = by_page.get(
+            bid // BLOCKS_PER_PAGE, 0) + 1
+    occ = mgr.get_page_occupancy(list(by_page))
+    eligible = sum(1 for p, c in by_page.items() if c >= occ.get(p, 0))
+
+    lru_window = set(list(pool._evictable_blocks)[:budget])
+    before_pages = mgr.pages_pinned()
+    before_ids = set(pool._evictable_blocks)
+    evicted = pool._evict_blocks_from_pool(budget)
+    victims = before_ids - set(pool._evictable_blocks)
+
+    return {"budget": budget, "active": active, "evicted": evicted,
+            "pages_total": before_pages, "pages_eligible": eligible,
+            "pages_freed": before_pages - mgr.pages_pinned(),
+            "victims_lru_would_have_kept": len(victims - lru_window)}
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cached", type=int, default=1000)
+    ap.add_argument("--active", type=int, nargs="+", default=[0, 200, 1000])
+    ap.add_argument("--budgets", type=int, nargs="+", default=[4, 16, 64, 128])
+    ap.add_argument("--spread-pages", type=int, default=73,
+                    help="confine the cache to this many pages, as a real "
+                         "churned cache is")
+    ap.add_argument("--num-blocks", type=int, default=14000)
+    ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    rows = [measure(b, args.cached, a, args.num_blocks, args.spread_pages,
+                    args.seed)
+            for a in args.active for b in args.budgets]
+    if args.json:
+        print(json.dumps(rows, indent=1))
+    else:
+        print(f"{'active':>8} {'budget':>7} {'eligible/total':>16} "
+              f"{'pages freed':>12} {'LRU would keep':>15}")
+        for r in rows:
+            print(f"{r['active']:>8} {r['budget']:>7} "
+                  f"{str(r['pages_eligible']) + '/' + str(r['pages_total']):>16} "
+                  f"{r['pages_freed']:>12} "
+                  f"{r['victims_lru_would_have_kept']:>15}")

--- a/benchmarks/bench_idle_footprint/workload.py
+++ b/benchmarks/bench_idle_footprint/workload.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Issue #359 workload: make an idle instance's prefix cache scatter across pages.
+
+Two kinds of traffic mixed together:
+
+  * HOT prefixes revisited throughout the run. Every revisit is a cache hit,
+    which moves those blocks back to the most-recently-used end, so an age-only
+    eviction policy never drops them. They keep the block ids they were first
+    allocated at, spread over whatever pages were filling at that moment.
+  * a long tail of COLD prompts seen once. They churn through the cache and get
+    evicted, but a page they shared with a surviving block cannot be unmapped.
+
+Decode length matters as much as prompt length: prefill allocates a run of
+blocks in one go and packs, while decode grows a request one block at a time
+into whatever hole is free. Staggered decodes are what interleaves live
+requests across pages in the first place -- without them the cache stays packed
+and #359 does not reproduce.
+
+Prompts are lists of token ids so prefix sharing is exact.
+"""
+import argparse
+import asyncio
+import json
+import random
+import time
+
+import aiohttp
+
+# Well inside any modern vocab, above the special-token range.
+TOKEN_LO, TOKEN_HI = 1000, 100000
+
+
+def build_requests(args):
+    """Deterministically build the full request list for a run."""
+    rng = random.Random(args.seed)
+
+    def toks(n, r=None):
+        r = r or rng
+        return [r.randint(TOKEN_LO, TOKEN_HI) for _ in range(n)]
+
+    # The hot prefixes get their own seed so a second burst can reuse exactly
+    # the same ones while its cold tail is all new.
+    hot_rng = random.Random(args.hot_seed if args.hot_seed is not None
+                            else args.seed)
+    hot = [toks(args.hot_tokens, hot_rng) for _ in range(args.hot_prefixes)]
+
+    # Optional shared pool of cold prompts so two bursts can draw from the same
+    # set: hot prefixes always survive eviction, so a second burst that only
+    # revisits them cannot tell one eviction policy from another.
+    cold_pool = None
+    if args.cold_pool:
+        pool_rng = random.Random(args.cold_pool_seed)
+        cold_pool = [
+            [pool_rng.randint(TOKEN_LO, TOKEN_HI)
+             for _ in range(pool_rng.randint(args.cold_tokens_min,
+                                             args.cold_tokens_max))]
+            for _ in range(args.cold_pool)
+        ]
+
+    requests = []
+    for i in range(args.requests):
+        # Introduce hot prefixes gradually so they are first allocated at
+        # widely separated times, i.e. on different pages.
+        introduced = min(len(hot),
+                         1 + int(len(hot) * (i / max(1, args.requests - 1))))
+        if rng.random() < args.hot_ratio:
+            prefix = hot[rng.randrange(introduced)]
+            prompt = prefix + toks(args.suffix_tokens)
+            kind = "hot"
+        else:
+            if cold_pool is not None:
+                prompt = cold_pool[rng.randrange(len(cold_pool))]
+            else:
+                n = rng.randint(args.cold_tokens_min, args.cold_tokens_max)
+                prompt = toks(n)
+            kind = "cold"
+        decode = rng.randint(args.max_tokens_min, args.max_tokens_max)
+        requests.append((kind, prompt, decode))
+    return requests
+
+
+async def one_request(session, url, model, prompt, max_tokens, results):
+    t0 = time.time()
+    try:
+        async with session.post(
+                url,
+                json={"model": model, "prompt": prompt,
+                      "max_tokens": max_tokens, "temperature": 0.0},
+                timeout=aiohttp.ClientTimeout(total=600)) as resp:
+            body = await resp.json()
+            ok = resp.status == 200
+    except Exception as e:  # noqa: BLE001
+        ok, body = False, {"error": str(e)}
+    results.append({"ok": ok, "latency": time.time() - t0,
+                    "err": None if ok else str(body)[:200]})
+
+
+async def run(args):
+    requests = build_requests(args)
+    url = f"http://127.0.0.1:{args.port}/v1/completions"
+    sem = asyncio.Semaphore(args.concurrency)
+    results = []
+
+    async def guarded(session, prompt, decode):
+        async with sem:
+            await one_request(session, url, args.model, prompt, decode, results)
+
+    t0 = time.time()
+    connector = aiohttp.TCPConnector(limit=args.concurrency * 2)
+    async with aiohttp.ClientSession(connector=connector) as session:
+        tasks = [asyncio.create_task(guarded(session, p, d))
+                 for _kind, p, d in requests]
+        done = 0
+        for coro in asyncio.as_completed(tasks):
+            await coro
+            done += 1
+            if done % max(1, len(tasks) // 20) == 0:
+                print(f"  {done}/{len(tasks)} done "
+                      f"({time.time() - t0:.0f}s)", flush=True)
+    elapsed = time.time() - t0
+
+    okc = sum(1 for r in results if r["ok"])
+    lats = sorted(r["latency"] for r in results if r["ok"])
+    summary = {
+        "requests": len(results), "ok": okc, "failed": len(results) - okc,
+        "elapsed_s": elapsed,
+        "throughput_rps": okc / elapsed if elapsed else 0.0,
+        "latency_p50": lats[len(lats) // 2] if lats else None,
+        "latency_p99": lats[int(len(lats) * 0.99)] if lats else None,
+        "sample_errors": [r["err"] for r in results if not r["ok"]][:3],
+    }
+    print(json.dumps(summary, indent=1), flush=True)
+    if args.out:
+        with open(args.out, "w") as f:
+            json.dump(summary, f, indent=1)
+    return summary
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=8100)
+    ap.add_argument("--model", default="qwen3-4b")
+    ap.add_argument("--requests", type=int, default=600)
+    ap.add_argument("--concurrency", type=int, default=16)
+    ap.add_argument("--hot-prefixes", type=int, default=24)
+    ap.add_argument("--hot-tokens", type=int, default=256)
+    ap.add_argument("--suffix-tokens", type=int, default=64)
+    ap.add_argument("--cold-tokens-min", type=int, default=192)
+    ap.add_argument("--cold-tokens-max", type=int, default=1024)
+    ap.add_argument("--hot-ratio", type=float, default=0.5)
+    ap.add_argument("--max-tokens-min", type=int, default=16)
+    ap.add_argument("--max-tokens-max", type=int, default=256)
+    ap.add_argument("--seed", type=int, default=1234)
+    ap.add_argument("--hot-seed", type=int, default=None)
+    ap.add_argument("--cold-pool", type=int, default=0)
+    ap.add_argument("--cold-pool-seed", type=int, default=4242)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+    asyncio.run(run(args))

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -464,14 +464,60 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                     self._cached_blocks[key] = block
                     self._block_id_to_key[block.block_id] = key
 
+            def _page_aligned_victims(self, num_to_evict: int) -> list[int]:
+                """Order evictable blocks so whole pages come free.
+
+                kvcached only returns physical memory once every block on a page
+                is freed, so evicting in LRU order can free no memory at all when
+                the survivors stay scattered across pages. Prefer pages this pool
+                can empty outright, cheapest first; draining a page only part of
+                the way costs hit rate and frees nothing.
+                """
+                mgr = self.kv_cache_manager
+                allocator = getattr(mgr, "page_allocator", None)
+                if allocator is None:
+                    return []
+
+                bids = list(self._evictable_blocks)
+                by_page = allocator.group_indices_by_page(
+                    bids, mgr.block_mem_size)
+                # Blocks held by running requests are absent from
+                # _evictable_blocks, so a page whose occupancy exceeds its
+                # evictable count cannot be emptied here -- skip it.
+                occupancy = mgr.get_page_occupancy(list(by_page))
+                lru_rank = {bid: i for i, bid in enumerate(bids)}
+
+                pages = [(len(ids), max(lru_rank[b] for b in ids), ids)
+                         for page_id, ids in by_page.items()
+                         if len(ids) >= occupancy.get(page_id, 0)]
+                pages.sort()
+
+                victims: list[int] = []
+                for cost, _rank, ids in pages:
+                    if len(victims) + cost > num_to_evict:
+                        break
+                    victims.extend(ids)
+                return victims
+
             def _evict_blocks_from_pool(self, num_to_evict: int) -> int:
-                """Evict oldest blocks from evictable pool, free to kvcached.
+                """Evict blocks from evictable pool, free to kvcached.
+
+                Prefers victims that empty whole pages so freeing them returns
+                physical memory, then falls back to LRU order for the remainder.
 
                 Returns the number of blocks actually evicted.
                 """
+                num_to_evict = min(num_to_evict, len(self._evictable_blocks))
+                if num_to_evict <= 0:
+                    return 0
+
+                ordered = self._page_aligned_victims(num_to_evict)
+                ordered.extend(bid for bid in self._evictable_blocks
+                               if bid not in set(ordered))
+
                 ids_to_free: list[int] = []
-                for _ in range(min(num_to_evict, len(self._evictable_blocks))):
-                    bid, _block = self._evictable_blocks.popitem(last=False)
+                for bid in ordered[:num_to_evict]:
+                    self._evictable_blocks.pop(bid, None)
                     key = self._block_id_to_key.pop(bid, None)
                     if key is not None:
                         self._cached_blocks.pop(key, None)

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -501,11 +501,23 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                     victims.extend(ids)
                 return victims
 
-            def _evict_blocks_from_pool(self, num_to_evict: int) -> int:
+            def _evict_blocks_from_pool(self,
+                                        num_to_evict: int,
+                                        page_aware: bool = True) -> int:
                 """Evict blocks from evictable pool, free to kvcached.
 
-                Prefers victims that empty whole pages so freeing them returns
-                physical memory, then falls back to LRU order for the remainder.
+                With page_aware set, prefers victims that empty whole pages so
+                freeing them returns physical memory, then falls back to LRU
+                order for the remainder. Use it only when the goal is physical
+                release (cap trimming): a page returns memory only once every
+                block on it is free.
+
+                With page_aware clear, evicts in pure LRU order. Callers that
+                reuse the freed logical slot immediately (allocation shortage)
+                get no page benefit -- the page is neither unmapped nor
+                remapped -- so reordering victims by page only trades away a
+                newer prefix for an older one and pays for the full evictable
+                scan and page sort.
 
                 Returns the number of blocks actually evicted.
                 """
@@ -513,12 +525,15 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 if num_to_evict <= 0:
                     return 0
 
-                ordered = self._page_aligned_victims(num_to_evict)
-                chosen = set(ordered)
-                # Top up in LRU order: page alignment is best-effort, but the
-                # caller still needs the count it asked for.
-                ordered.extend(bid for bid in self._evictable_blocks
-                               if bid not in chosen)
+                if page_aware:
+                    ordered = self._page_aligned_victims(num_to_evict)
+                    chosen = set(ordered)
+                    # Top up in LRU order: page alignment is best-effort, but
+                    # the caller still needs the count it asked for.
+                    ordered.extend(bid for bid in self._evictable_blocks
+                                   if bid not in chosen)
+                else:
+                    ordered = list(self._evictable_blocks)
 
                 ids_to_free: list[int] = []
                 for bid in ordered[:num_to_evict]:
@@ -543,7 +558,12 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                     if self.enable_prefix_cache:
                         kvcached_free = self.kv_cache_manager.available_size()
                         if kvcached_free < num_blocks and self._evictable_blocks:
-                            self._evict_blocks_from_pool(num_blocks - kvcached_free)
+                            # Allocation shortage: the freed slot is reused
+                            # immediately, so page-aware selection buys no
+                            # memory and would evict a newer prefix over the
+                            # LRU victim. Keep pure LRU here.
+                            self._evict_blocks_from_pool(
+                                num_blocks - kvcached_free, page_aware=False)
                     block_ids = self.kv_cache_manager.alloc(num_blocks)
                     if block_ids is not None:
                         break

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -490,7 +490,9 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 pages = [(len(ids), max(lru_rank[b] for b in ids), ids)
                          for page_id, ids in by_page.items()
                          if len(ids) >= occupancy.get(page_id, 0)]
-                pages.sort()
+                # Cheapest page first; break ties on the page whose most
+                # recently used block is oldest, so hot pages are kept.
+                pages.sort(key=lambda page: (page[0], page[1]))
 
                 victims: list[int] = []
                 for cost, _rank, ids in pages:
@@ -512,8 +514,11 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                     return 0
 
                 ordered = self._page_aligned_victims(num_to_evict)
+                chosen = set(ordered)
+                # Top up in LRU order: page alignment is best-effort, but the
+                # caller still needs the count it asked for.
                 ordered.extend(bid for bid in self._evictable_blocks
-                               if bid not in set(ordered))
+                               if bid not in chosen)
 
                 ids_to_free: list[int] = []
                 for bid in ordered[:num_to_evict]:

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -430,8 +430,6 @@ class KVCacheManager:
         callers choosing which blocks to evict need to know how many blocks a
         page still holds. Page ids the manager does not track report 0.
         """
-        blocks_per_page = InternalPage.get_num_blocks(self.page_size,
-                                                      self.block_mem_size)
         occupancy: Dict[int, int] = {}
         for page_id in page_ids:
             if page_id in self.full_pages:
@@ -441,7 +439,12 @@ class KVCacheManager:
             else:
                 occupancy[page_id] = 0
                 continue
-            occupancy[page_id] = blocks_per_page - page.num_free_blocks()
+            # Blocks straddling a page boundary belong to neither page, so a
+            # page's capacity comes from its own block range rather than from
+            # page_size // block_mem_size.
+            start, end = InternalPage.get_block_range(page_id, self.page_size,
+                                                      self.block_mem_size)
+            occupancy[page_id] = (end - start) - page.num_free_blocks()
         return occupancy
 
     @synchronized

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -289,7 +289,7 @@ class KVCacheManager:
                     continue
                 self.num_avail_blocks += page.num_free_blocks()
             else:
-                _, page = self.avail_pages.popitem()
+                page = self._pick_avail_page(remaining_need)
             num_from_page = min(page.num_free_blocks(), remaining_need)
             alloced_index = page.alloc(num_from_page)
             ret_index.extend(alloced_index)
@@ -302,6 +302,42 @@ class KVCacheManager:
             remaining_need -= num_from_page
 
         return ret_index
+
+    def _pick_avail_page(self, remaining_need: int) -> InternalPage:
+        """Pick the available page this allocation fits into best.
+
+        `avail_pages.popitem()` hands back the most recently touched page, and
+        a partially consumed page is re-inserted at the tail, so allocation
+        drains one page dry before moving on. That is fine for a single block,
+        but a long prefill run then walks whatever partly-filled pages happen
+        to sit at the tail and smears itself over many of them. Since a page
+        only returns physical memory once every block on it is free, a request
+        whose blocks are spread over a dozen pages pins all twelve for as long
+        as any one of those blocks survives in the prefix cache.
+
+        Choosing the smallest page that still holds the whole remaining run
+        (and the emptiest page when none does, so the next bite is as big as
+        possible) keeps a request's blocks together instead.
+
+        This is O(len(avail_pages)) and runs once per page consumed, not per
+        block; measured at ~7us for 100 available pages, with no throughput
+        change on a 96-way serving workload. Bucketing pages by free-block
+        count would make it independent of pool size if that ever matters.
+        """
+        best_id: Optional[int] = None
+        best_free: Optional[int] = None
+        fallback_id: Optional[int] = None
+        fallback_free = -1
+        for page_id, page in self.avail_pages.items():
+            free = page.num_free_blocks()
+            if free >= remaining_need:
+                if best_free is None or free < best_free:
+                    best_id, best_free = page_id, free
+            elif free > fallback_free:
+                fallback_id, fallback_free = page_id, free
+        chosen = best_id if best_id is not None else fallback_id
+        assert chosen is not None, "caller guarantees avail_pages is non-empty"
+        return self.avail_pages.pop(chosen)
 
     @synchronized
     def free(self, indices: List[int]):

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -423,6 +423,28 @@ class KVCacheManager:
         return avail_blocks + blocks_from_free_pages
 
     @synchronized
+    def get_page_occupancy(self, page_ids: List[int]) -> Dict[int, int]:
+        """Return the number of allocated blocks on each of `page_ids`.
+
+        A page only returns physical memory once every block on it is freed, so
+        callers choosing which blocks to evict need to know how many blocks a
+        page still holds. Page ids the manager does not track report 0.
+        """
+        blocks_per_page = InternalPage.get_num_blocks(self.page_size,
+                                                      self.block_mem_size)
+        occupancy: Dict[int, int] = {}
+        for page_id in page_ids:
+            if page_id in self.full_pages:
+                page = self.full_pages[page_id]
+            elif page_id in self.avail_pages:
+                page = self.avail_pages[page_id]
+            else:
+                occupancy[page_id] = 0
+                continue
+            occupancy[page_id] = blocks_per_page - page.num_free_blocks()
+        return occupancy
+
+    @synchronized
     def get_mapped_memory_size(self, unit='bytes') -> float:
         """Get memory usage in specified unit (bytes, kb, mb, gb)."""
         memory_bytes = (self.page_allocator.get_num_inuse_pages() *

--- a/tests/test_bestfit_page_selection.py
+++ b/tests/test_bestfit_page_selection.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Allocation picks the page an allocation fits into best (issue #359).
+
+kvcached returns physical memory one page at a time, and only once every block
+on that page is free. So it matters a great deal *which* page a request's
+blocks come from: a request smeared over a dozen partly-filled pages pins all
+twelve for as long as any one of its blocks survives in the prefix cache.
+
+`avail_pages.popitem()` hands back the most recently touched page, which walks
+whatever small holes sit at the tail of the dict. These tests pin down the
+replacement rule: take the smallest page that still holds the whole remaining
+run, or the emptiest page when none does.
+
+The compiled kvcached.vmm_ops extension is stubbed out (as in
+test_resize_reserved_order.py) so this runs on CPU-only hardware.
+"""
+
+import sys
+import threading
+import types
+
+import pytest
+
+
+def _install_fake_vmm_ops():
+    """Stand in for the compiled extension so this runs without a GPU build.
+
+    Installed only when the real one cannot be imported: it is a partial stub,
+    and leaving it in sys.modules would break the tests that need the genuine
+    module (test_kvcache_manager, test_paged_allocator_aliasing) whenever this
+    file is collected before them.
+    """
+
+    class FakeInternalPage:
+        pass
+
+    class FakePageAllocator:
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+    fake = types.ModuleType("kvcached.vmm_ops")
+    fake.PageAllocator = FakePageAllocator  # type: ignore[attr-defined]
+    fake.InternalPage = FakeInternalPage  # type: ignore[attr-defined]
+    fake.kv_tensors_created = lambda *a, **kw: True  # type: ignore[attr-defined]
+    fake.map_to_kv_tensors = lambda *a, **kw: None  # type: ignore[attr-defined]
+    fake.unmap_from_kv_tensors = lambda *a, **kw: None  # type: ignore[attr-defined]
+    sys.modules["kvcached.vmm_ops"] = fake
+
+
+try:
+    import kvcached.vmm_ops  # noqa: F401
+except Exception:  # noqa: BLE001 - any import failure means no GPU build
+    _install_fake_vmm_ops()
+
+from kvcached.kv_cache_manager import KVCacheManager  # noqa: E402
+from kvcached.locks import NoOpLock  # noqa: E402
+
+BLOCKS_PER_PAGE = 64
+
+
+class FakePage:
+    """A page that hands out its own block ids, so victims trace back to it."""
+
+    def __init__(self, page_id: int, num_free: int):
+        self.page_id = page_id
+        base = page_id * BLOCKS_PER_PAGE
+        # The free slots sit at the end of the page, as they would after the
+        # earlier blocks were handed out.
+        self.free_list = list(range(base + BLOCKS_PER_PAGE - num_free,
+                                    base + BLOCKS_PER_PAGE))
+
+    def num_free_blocks(self) -> int:
+        return len(self.free_list)
+
+    def alloc(self, n: int):
+        got, self.free_list = self.free_list[:n], self.free_list[n:]
+        return got
+
+    def full(self) -> bool:
+        return not self.free_list
+
+
+def _make_manager(pages):
+    """A manager with only what _alloc / _pick_avail_page read.
+
+    __init__ is skipped: it starts a background thread and talks to the real
+    page allocator.
+    """
+    mgr = object.__new__(KVCacheManager)
+    mgr._lock = NoOpLock()
+    mgr.block_mem_size = 32 * 1024
+    mgr.reserved_blocks = []
+    mgr.avail_pages = {p.page_id: p for p in pages}
+    mgr.full_pages = {}
+    mgr.num_avail_blocks = sum(p.num_free_blocks() for p in pages)
+    mgr._post_init_done = threading.Event()
+    mgr._post_init_done.set()
+
+    class StubPageAllocator:
+
+        def get_resize_target(self):
+            return -1
+
+        def alloc_page(self):  # pragma: no cover - the tests never run dry
+            raise AssertionError("test should not need a fresh page")
+
+    mgr.page_allocator = StubPageAllocator()
+    mgr.available_size = lambda: mgr.num_avail_blocks
+    return mgr
+
+
+def _pages_touched(block_ids):
+    return {bid // BLOCKS_PER_PAGE for bid in block_ids}
+
+
+class TestPickAvailPage:
+
+    def test_takes_the_smallest_page_that_fits_the_whole_run(self):
+        mgr = _make_manager([FakePage(10, 5), FakePage(11, 20),
+                             FakePage(12, 40)])
+        assert mgr._pick_avail_page(10).page_id == 11, (
+            "20 free is the tightest fit for 10 blocks; 40 wastes a big hole")
+
+    def test_falls_back_to_the_emptiest_page_when_none_fits(self):
+        mgr = _make_manager([FakePage(10, 5), FakePage(11, 20),
+                             FakePage(12, 40)])
+        assert mgr._pick_avail_page(50).page_id == 12, (
+            "no page holds 50, so take the biggest bite available")
+
+    def test_exact_fit_wins(self):
+        mgr = _make_manager([FakePage(10, 16), FakePage(11, 17)])
+        assert mgr._pick_avail_page(16).page_id == 10
+
+    def test_removes_the_page_it_returns(self):
+        mgr = _make_manager([FakePage(10, 5), FakePage(11, 20)])
+        page = mgr._pick_avail_page(4)
+        assert page.page_id not in mgr.avail_pages, (
+            "the caller re-inserts the page itself, as with popitem()")
+
+
+class TestAllocationKeepsARunTogether:
+
+    def test_a_run_lands_on_one_page_instead_of_walking_the_small_holes(self):
+        """The regression this exists for.
+
+        The 40-free page is inserted first, so it sits at the head of the dict
+        and the small holes sit at the tail -- exactly where `popitem()` looks.
+        Draining those first spreads a 40-block request over six pages, and
+        every one of them stays pinned while any of those blocks is cached.
+        """
+        pages = [FakePage(12, 40)] + [FakePage(pid, n) for pid, n in
+                                      ((13, 2), (14, 3), (15, 2), (16, 1),
+                                       (17, 2))]
+        mgr = _make_manager(pages)
+
+        block_ids = mgr._alloc(40)
+
+        assert block_ids is not None and len(block_ids) == 40
+        assert _pages_touched(block_ids) == {12}, (
+            "a run that fits in one page must not be smeared across the holes")
+
+    def test_a_run_too_big_for_any_page_still_allocates_everything(self):
+        """Falling back must stay correct, not just tidy."""
+        mgr = _make_manager([FakePage(20, 10), FakePage(21, 30),
+                             FakePage(22, 20)])
+
+        block_ids = mgr._alloc(55)
+
+        assert block_ids is not None
+        assert len(block_ids) == 55
+        assert len(set(block_ids)) == 55, "no block may be handed out twice"
+        # Biggest bite first, so the emptiest page is drained before the rest.
+        assert _pages_touched(block_ids) == {20, 21, 22}
+
+    def test_single_block_allocations_are_unaffected_in_count(self):
+        """Decode asks for one block at a time; it must still get exactly one."""
+        mgr = _make_manager([FakePage(30, 4), FakePage(31, 64)])
+        for _ in range(4):
+            got = mgr._alloc(1)
+            assert got is not None and len(got) == 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_page_aware_eviction.py
+++ b/tests/test_page_aware_eviction.py
@@ -201,3 +201,27 @@ class TestPageAwareEviction:
         for block in blocks[:3]:
             assert pool.get_cached_block(f"h{block.block_id}", [0]) is None
         assert pool.get_cached_block(f"h{blocks[3].block_id}", [0]) is not None
+
+    def test_lru_eviction_ignores_page_layout(self, pool_factory):
+        """page_aware=False evicts the LRU victim even off a fuller page.
+
+        The allocation-shortage path reuses the freed slot immediately, so no
+        page is unmapped and page-aware selection would only swap a newer
+        prefix for an older one. Lay out the oldest cached block on a full page
+        and the newest alone on a nearly-empty page: page-aware would take the
+        newest to empty its page, so LRU must instead take the oldest.
+        """
+        pool, mgr = pool_factory(64)
+        blocks = _cache_n(pool, 8)
+        oldest, newest = blocks[0], blocks[-1]
+        # The lone newest block sits on a page by itself; the oldest shares a
+        # full page. Page-aware selection would prefer the newest here.
+        assert (sum(1 for b in mgr._allocated
+                    if b // BLOCKS_PER_PAGE
+                    == newest.block_id // BLOCKS_PER_PAGE) == 1)
+
+        pool._evict_blocks_from_pool(1, page_aware=False)
+
+        # LRU dropped the oldest; the newest prefix survives.
+        assert pool.get_cached_block(f"h{oldest.block_id}", [0]) is None
+        assert pool.get_cached_block(f"h{newest.block_id}", [0]) is not None

--- a/tests/test_page_aware_eviction.py
+++ b/tests/test_page_aware_eviction.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for page-aware eviction in ElasticBlockPool (issue #359).
+
+kvcached only unmaps a page once every block on it is free, so evicting blocks
+in pure LRU order can return no memory at all when the retained blocks stay
+scattered. These tests mock KVCacheManager's page bookkeeping to assert that
+eviction prefers victims that empty whole pages.
+
+No GPU or vLLM dependency: torch and the C extension are mocked, as in
+test_prefix_cache.py.
+"""
+
+import sys
+import types
+from unittest import mock
+
+_torch_mock = mock.MagicMock()
+_torch_mock.__version__ = "2.6.0"
+_torch_mock.cuda.mem_get_info.return_value = (8 * 1024**3, 16 * 1024**3)
+sys.modules.setdefault("torch", _torch_mock)
+sys.modules.setdefault("torch.cuda", _torch_mock.cuda)
+sys.modules.setdefault("torch.utils", _torch_mock.utils)
+sys.modules.setdefault("torch.utils.cpp_extension", _torch_mock.utils.cpp_extension)
+sys.modules.setdefault("posix_ipc", mock.MagicMock())
+sys.modules.setdefault("kvcached.vmm_ops", mock.MagicMock())
+sys.modules.setdefault("kvcached.integration.vllm.interfaces", mock.MagicMock())
+
+import pytest  # noqa: E402
+
+BLOCKS_PER_PAGE = 4
+
+
+class MockBlockPool:
+    pass
+
+
+class MockKVCacheBlock:
+
+    def __init__(self, block_id: int, ref_cnt: int = 0):
+        self.block_id = block_id
+        self.ref_cnt = ref_cnt
+        self.is_null = False
+
+
+class MockRequest:
+
+    def __init__(self, block_hashes: list):
+        self.block_hashes = block_hashes
+
+
+class MockPageAllocator:
+    """Groups block ids by page the same way the C++ allocator does."""
+
+    def group_indices_by_page(self, indices, block_mem_size):
+        by_page: dict = {}
+        for idx in indices:
+            by_page.setdefault(idx // BLOCKS_PER_PAGE, []).append(idx)
+        return by_page
+
+
+class MockPagedKVCacheManager:
+    """Allocator that tracks which blocks are live on each page.
+
+    Mirrors the real manager closely enough for eviction: alloc/free move ids,
+    and get_page_occupancy reports how many blocks a page still holds.
+    """
+
+    def __init__(self, num_blocks: int):
+        self._free: list[int] = list(range(num_blocks))
+        self._allocated: set[int] = set()
+        self.page_allocator = MockPageAllocator()
+        self.block_mem_size = 16 * 1024
+        self.page_size = BLOCKS_PER_PAGE * self.block_mem_size
+
+    def alloc(self, n: int):
+        if len(self._free) < n:
+            return None
+        ids = self._free[:n]
+        self._free = self._free[n:]
+        self._allocated.update(ids)
+        return ids
+
+    def free(self, ids: list):
+        for i in ids:
+            self._allocated.discard(i)
+            self._free.append(i)
+
+    def available_size(self) -> int:
+        return len(self._free)
+
+    def get_page_occupancy(self, page_ids: list) -> dict:
+        occupancy = {pid: 0 for pid in page_ids}
+        for bid in self._allocated:
+            pid = bid // BLOCKS_PER_PAGE
+            if pid in occupancy:
+                occupancy[pid] += 1
+        return occupancy
+
+    def pages_pinned(self) -> int:
+        """Pages holding at least one live block -- what stays mapped."""
+        return len({bid // BLOCKS_PER_PAGE for bid in self._allocated})
+
+
+@pytest.fixture
+def pool_factory():
+
+    def _make(num_blocks: int = 64):
+        manager = MockPagedKVCacheManager(num_blocks)
+
+        mock_mod = types.ModuleType("mock_block_pool")
+        mock_mod.BlockPool = MockBlockPool  # type: ignore[attr-defined]
+        mock_mod.KVCacheBlock = MockKVCacheBlock  # type: ignore[attr-defined]
+
+        with mock.patch(
+                "kvcached.integration.vllm.interfaces.get_kv_cache_manager",
+                return_value=manager,
+        ):
+            from kvcached.integration.vllm.patches import ElasticBlockPoolPatch
+
+            ElasticBlockPoolPatch().inject_elastic_block_pool(mock_mod)
+            ElasticBlockPool = mock_mod.ElasticBlockPool  # type: ignore[attr-defined]
+            pool = ElasticBlockPool(
+                num_gpu_blocks=num_blocks,
+                block_size=16,
+                cell_size=1024,
+                num_layers=1,
+                enable_caching=True,
+            )
+        return pool, manager
+
+    return _make
+
+
+def _cache_n(pool, n: int) -> list:
+    """Allocate, cache and release `n` blocks so they become evictable.
+
+    Ids come from the pool itself, so the null block the constructor holds is
+    accounted for rather than overwritten.
+    """
+    blocks = pool.get_new_blocks(n)
+    req = MockRequest([f"h{b.block_id}" for b in blocks])
+    pool.cache_full_blocks(req, blocks, 0, n, 16, 0)
+    pool.free_blocks(blocks)
+    return blocks
+
+
+class TestPageAwareEviction:
+
+    def test_evicting_a_pages_worth_frees_a_page(self, pool_factory):
+        """Evicting BLOCKS_PER_PAGE blocks should empty one page outright.
+
+        The null block the pool allocates at construction occupies page 0, so
+        caching 8 more blocks spans pages 0..2. Evicting 4 must concentrate on
+        one page rather than take blocks from each and free nothing.
+        """
+        pool, mgr = pool_factory(64)
+        _cache_n(pool, 8)
+
+        before = mgr.pages_pinned()
+        pool._evict_blocks_from_pool(BLOCKS_PER_PAGE)
+        assert mgr.pages_pinned() == before - 1, (
+            "evicting one page's worth of blocks should free exactly one page")
+
+    def test_skips_pages_pinned_by_active_blocks(self, pool_factory):
+        """A page holding a running request's block cannot be emptied.
+
+        One block is left active (ref_cnt>0) so its page can never be freed by
+        eviction; the pages that are fully evictable should be chosen instead.
+        """
+        pool, mgr = pool_factory(64)
+        blocks = _cache_n(pool, 8)
+
+        # Re-activate one block: it leaves the evictable pool but keeps its page.
+        pool.touch([blocks[0]])
+        pinned_page = blocks[0].block_id // BLOCKS_PER_PAGE
+
+        pool._evict_blocks_from_pool(BLOCKS_PER_PAGE)
+        assert blocks[0].block_id in mgr._allocated
+        assert pinned_page in {b // BLOCKS_PER_PAGE for b in mgr._allocated}
+
+    def test_evicts_requested_count(self, pool_factory):
+        """Page preference must not change how many blocks get evicted."""
+        pool, mgr = pool_factory(64)
+        _cache_n(pool, 8)
+        assert len(pool._evictable_blocks) == 8
+
+        evicted = pool._evict_blocks_from_pool(6)
+        assert evicted == 6
+        assert len(pool._evictable_blocks) == 2
+
+    def test_falls_back_to_lru_without_page_allocator(self, pool_factory):
+        """A manager without page bookkeeping still evicts in LRU order."""
+        pool, mgr = pool_factory(64)
+        blocks = _cache_n(pool, 8)
+        del mgr.page_allocator
+
+        evicted = pool._evict_blocks_from_pool(3)
+        assert evicted == 3
+        # The three oldest cached blocks go first.
+        for block in blocks[:3]:
+            assert pool.get_cached_block(f"h{block.block_id}", [0]) is None
+        assert pool.get_cached_block(f"h{blocks[3].block_id}", [0]) is not None


### PR DESCRIPTION
## Problem

With prefix caching enabled, an idle instance retains far more physical memory
than `KVCACHED_MAX_CACHED_TOKENS` implies — #359 measures ~8.9 GiB pinned
against a nominal ~2.2 GiB on Qwen3-4B.

The cap is counted in blocks, but memory is returned in pages: `free_pages()`
can only unmap a page once *every* block on it is free. `_evict_blocks_from_pool`
picks victims in pure LRU order, so the surviving blocks stay scattered across
the pages they were originally allocated from and each one pins a whole 2 MB
page. The pinned set ends up bounded by pages touched rather than blocks kept,
and a co-located instance is starved of memory the cap says was released.

## Root Cause

`ElasticBlockPool._evict_blocks_from_pool()` (`kvcached/integration/vllm/patches.py`)
evicts `len(_evictable_blocks) - max_cached_blocks` blocks oldest-first, with no
knowledge of which page each block sits on. Evicting N scattered blocks satisfies
the cap while freeing zero pages.

## What Changed

- **`kvcached/kv_cache_manager.py`** — new `get_page_occupancy(page_ids)`
  reporting how many blocks each page still holds, derived from
  `InternalPage.get_block_range()` so blocks straddling a page boundary are
  accounted for the same way the C++ allocator accounts for them.
- **`kvcached/integration/vllm/patches.py`** — `_evict_blocks_from_pool()` now
  orders victims by page: prefer pages the pool can empty outright, cheapest
  first, breaking ties toward the page whose most recently used block is oldest.
  Pages holding blocks from running requests can never be emptied by eviction
  and are skipped. Falls back to LRU order for any remaining budget, and when
  page information is unavailable.

The eviction *count* is unchanged — only the choice of victims. No additional
blocks are dropped, so prefix-cache hit rate is not traded for memory.

## Verification

Measured on an RTX PRO 4000 Blackwell (24 GB), 8 layers, 16 KiB blocks, 2 MB
pages (128 blocks/page). 4096 blocks cached, every stride-th touched so an
age-only policy spares it, then evicted down to 512. **Both columns evict the
same 3584 blocks:**

| stride | freed before | freed after |
|---|---|---|
| 1 | 0.84 GB | 0.88 GB |
| 2 | 0.75 GB | 0.88 GB |
| 4 | 0.50 GB | 0.88 GB |
| 8 | 0.03 GB | 0.88 GB |

Age-only eviction collapses as the survivors scatter: at stride 8 it evicts 3584
blocks and frees essentially nothing. Page-aware selection holds flat.

`benchmarks/bench_frag/` contains both harnesses: `bench_frag.py` measures the
allocator's pinned-to-held ratio directly (reproducing #359's premise at
1.0x/2.0x/4.0x as blocks scatter), and `bench_evict.py` produces the table above.

## Tests

Added `tests/test_page_aware_eviction.py` (mocks torch and the C extension, no
GPU needed, following `tests/test_prefix_cache.py`):

- `test_evicting_a_pages_worth_frees_a_page` — **fails on main**, passes here
- `test_skips_pages_pinned_by_active_blocks`
- `test_evicts_requested_count`
- `test_falls_back_to_lru_without_page_allocator`

All 28 existing `tests/test_prefix_cache.py` tests still pass (32 total).

## Scope

Numbers above come from driving `ElasticBlockPool` directly rather than a live
vLLM server, so the issue's ~8.9 GiB → ~2.2 GiB figure on Qwen3-4B is not
independently confirmed here. They were collected on a PyTorch build that
predates this GPU's `sm_120` architecture (warns at startup); memory-mapping
behaviour should be unaffected.

## Issue

Closes #359
