### PR TITLE
fix(nixl): transfer kvcached KV as split K/V regions on vLLM >=0.23

### DIFF
--- a/kvcached/integration/vllm/nixl_compat.py
+++ b/kvcached/integration/vllm/nixl_compat.py
@@ -23,6 +23,14 @@ class NixlConnectorPatch(BasePatch):
     target_module = "vllm"
     patch_name = "nixl_connector_compat"
 
+    # Class-level signal from the register wrapper (_reconcile_blocks_first_layout)
+    # to the TransferTopology.__init__ hook: True iff the wrapper just transposed a
+    # split-half tensor and the topology should force split_k_and_v. Kept at class
+    # scope (not per-instance) because patch_nixl_connector() may be called multiple
+    # times, so the wrapper and the topology hook can close over different
+    # NixlConnectorPatch instances; a shared class attribute keeps them in lockstep.
+    _pending_force_split: bool = False
+
     # vLLM moved NixlConnectorWorker from the single nixl_connector module into
     # a split nixl.connector / nixl.worker package layout. Try both so this
     # eager patch keeps working across the supported open-ended vLLM range.
@@ -96,13 +104,25 @@ class NixlConnectorPatch(BasePatch):
                 "version; skipping layout override (NHD already in use)"
             )
 
-        if not hasattr(NixlConnectorWorker, "_kvcached_original_register_kv_caches"):
-            NixlConnectorWorker._kvcached_original_register_kv_caches = (
-                NixlConnectorWorker.register_kv_caches
+        # NixlConnectorWorker resolves to NixlPullConnectorWorker, which inherits
+        # register_kv_caches from the base worker. NixlPushConnectorWorker overrides
+        # it but delegates to the base via super().register_kv_caches(). Patch the
+        # class that actually *defines* register_kv_caches so BOTH pull and push
+        # modes are covered -- patching the pull subclass alone would leave push
+        # silently unpatched (and thus silently corrupting).
+        register_owner = NixlConnectorWorker
+        for _cls in NixlConnectorWorker.__mro__:
+            if "register_kv_caches" in _cls.__dict__:
+                register_owner = _cls
+                break
+
+        if not hasattr(register_owner, "_kvcached_original_register_kv_caches"):
+            register_owner._kvcached_original_register_kv_caches = (
+                register_owner.register_kv_caches
             )
 
         def _patched_register(worker, kv_caches, *args, **kwargs):
-            _original_register = NixlConnectorWorker._kvcached_original_register_kv_caches
+            _original_register = register_owner._kvcached_original_register_kv_caches
             if not enable_kvcached():
                 return _original_register(worker, kv_caches, *args, **kwargs)
             patch._ensure_supported_kvcached_layout()
@@ -118,11 +138,73 @@ class NixlConnectorPatch(BasePatch):
                 )
                 worker.num_blocks = kvcached_num_blocks
 
+            # Reconcile kvcached's split-half KV memory with vLLM >=0.23's
+            # blocks-first NIXL descriptor assumptions (see method docstring).
+            kv_caches = patch._reconcile_blocks_first_layout(worker, kv_caches)
+
             return _original_register(worker, kv_caches, *args, **kwargs)
 
-        NixlConnectorWorker.register_kv_caches = _patched_register
+        # Install the register wrapper only once. Re-wrapping on every
+        # patch_nixl_connector() call is redundant (the wrapper always calls the
+        # once-saved original) and would churn the closure for no benefit.
+        if not getattr(register_owner, "_kvcached_register_patched", False):
+            register_owner.register_kv_caches = _patched_register
+            register_owner._kvcached_register_patched = True
+
+        self._patch_transfer_topology()
         self.logger.info("Patched NixlConnector for kvcached PD disagg compatibility")
         return True
+
+    def _patch_transfer_topology(self) -> None:
+        """Force NIXL's split_k_and_v path for kvcached's split-half KV layout.
+
+        vLLM >=0.23 blocks-first backends make TransferTopology report
+        is_kv_layout_blocks_first=True (K/V interleaved within a block), but
+        kvcached lays K and V out as two separate block-contiguous regions. Paired
+        with the tensor transpose in _reconcile_blocks_first_layout, we clear that
+        flag (-> split_k_and_v=True, virtually_split=False) so NIXL registers K and
+        V as separate regions matching kvcached's real memory. See
+        _reconcile_blocks_first_layout for the full rationale.
+
+        The topology is rebuilt inside register_kv_caches, so this patches the
+        class __init__ rather than a per-worker instance. The flip is layout-driven,
+        NOT unconditional: it only fires when _reconcile_blocks_first_layout actually
+        transposed a split-half tensor for this registration (signalled via
+        ``_pending_force_split``). If kvcached's layout ever matches NIXL natively
+        (interleaved / K-V-first), the wrapper leaves the tensors alone and does not
+        set the flag, so NIXL's native path is kept. MLA / mamba topologies and
+        non-kvcached runs are untouched.
+        """
+        try:
+            from vllm.distributed.kv_transfer.kv_connector import utils as _kv_utils
+        except ImportError:
+            return
+        TransferTopology = getattr(_kv_utils, "TransferTopology", None)
+        if TransferTopology is None:
+            return
+        if getattr(TransferTopology, "_kvcached_topology_patched", False):
+            return
+
+        _orig_init = TransferTopology.__init__
+
+        def _patched_init(topo_self, *args, **kwargs):
+            _orig_init(topo_self, *args, **kwargs)
+            if not enable_kvcached():
+                return
+            # Only flip when the paired register wrapper transposed a split-half
+            # tensor for this registration (it runs first and sets the signal on
+            # `patch`). Consume it so it can't leak into an unrelated topology.
+            if not NixlConnectorPatch._pending_force_split:
+                return
+            NixlConnectorPatch._pending_force_split = False
+            # MLA / mamba topologies use different split logic; never flip them.
+            if getattr(topo_self, "is_mla", False) or getattr(topo_self, "is_mamba", False):
+                return
+            if getattr(topo_self, "_is_kv_layout_blocks_first", False):
+                topo_self._is_kv_layout_blocks_first = False
+
+        TransferTopology.__init__ = _patched_init
+        TransferTopology._kvcached_topology_patched = True
 
     def _import_nixl_connector_classes(self) -> Optional[Tuple[Any, Any]]:
         for connector_module_name, worker_module_name in self._CONNECTOR_MODULES:
@@ -138,6 +220,99 @@ class NixlConnectorPatch(BasePatch):
                 return NixlConnector, NixlConnectorWorker
 
         return None
+
+    def _reconcile_blocks_first_layout(self, worker: Any, kv_caches: Any) -> Any:
+        """Match kvcached's split-half KV memory to vLLM >=0.23 blocks-first NIXL.
+
+        vLLM >=0.23 FlashAttention/FlashInfer/Triton/Flex use a *blocks-first* KV
+        shape ``(num_blocks, 2, block_size, H, D)`` (vLLM PR #42095, RFC #42082).
+        NIXL's TransferTopology then sets ``is_kv_layout_blocks_first=True`` and
+        assumes K and V are *interleaved within each block*: per-block stride =
+        full page (2*hidden), V at intra-block offset +hidden.
+
+        kvcached (non-contiguous MHA/GQA) instead lays each layer out *split-half*:
+        all K blocks contiguous in one region, all V blocks in a separate region
+        far away; per-block stride = hidden. NIXL's per-block stride is therefore
+        exactly 2x kvcached's real stride and its within-block V descriptor lands
+        inside kvcached's K region -> every transferred block is misaligned and V
+        is never transferred -> garbled decode. (Single-instance attention is fine
+        because the kernel honors the tensor's real strides; only NIXL's raw-offset
+        RDMA ignores them.)
+
+        Fix: present each split-half attention tensor to NIXL as a K/V-first
+        ``(2, num_blocks, ...)`` view (transpose dims 0 and 1) and force the
+        ``split_k_and_v`` registration path (``_is_kv_layout_blocks_first=False``),
+        so NIXL registers K and V as two separate block-contiguous regions whose
+        base addresses / block_len exactly match kvcached's real memory. Returns a
+        (possibly transposed) kv_caches dict.
+
+        This is layout-driven, not assumption-driven:
+          * split-half tensor  -> transpose + signal the paired topology patch to
+            force split_k_and_v (the current kvcached non-contiguous MHA case);
+          * already interleaved / K-V-first tensor (matches NIXL natively) -> left
+            untouched, no signal, NIXL keeps its native path (future-proofs a
+            kvcached layout change);
+          * anything else       -> fail loud rather than silently corrupting.
+
+        The actual topology flip lives in the paired TransferTopology.__init__
+        patch, because the topology is (re)constructed *inside* register_kv_caches,
+        after this wrapper runs; we hand it the decision via ``_pending_force_split``.
+        """
+        fixed: dict = {}
+        saw_split_half = False
+        for name, value in kv_caches.items():
+            t = value
+            # Blocks-first attention tensors are (num_blocks, 2, block, H, D)
+            # (shape[1]==2). Older K/V-first tensors are (2, num_blocks, ...) and
+            # won't match here; mamba/MLA tensors have different shapes. All left
+            # untouched unless they are blocks-first attention.
+            if not (hasattr(t, "dim") and t.dim() == 5 and int(t.shape[1]) == 2):
+                fixed[name] = value
+                continue
+            hidden = 1
+            for d in t.shape[2:]:
+                hidden *= int(d)
+            block_stride = int(t.stride()[0])
+            if block_stride == 2 * hidden:
+                # Interleaved/contiguous already: matches NIXL, nothing to fix.
+                fixed[name] = value
+                continue
+            if block_stride != hidden:
+                raise RuntimeError(
+                    "kvcached NixlConnector: unexpected attention KV block stride "
+                    f"(layer={name}, shape={tuple(t.shape)}, stride={tuple(t.stride())}); "
+                    "expected split-half (block stride == K-or-V hidden size = "
+                    f"{hidden}). Refusing to register a layout NIXL would corrupt."
+                )
+            # Split-half confirmed: (num_blocks, 2, ...) -> (2, num_blocks, ...) view.
+            # view[0] = all K blocks (base = K region), view[1] = all V blocks
+            # (base = V region); each is block-contiguous with stride = hidden,
+            # exactly what the split_k_and_v register path expects.
+            fixed[name] = t.transpose(0, 1)
+            saw_split_half = True
+
+        # Signal the paired TransferTopology.__init__ patch whether to force the
+        # split_k_and_v path for the topology it is about to build. Only True when
+        # we actually transposed a split-half tensor, so the flip stays in lockstep
+        # with the transpose (interleaved/native layouts keep NIXL's default path).
+        NixlConnectorPatch._pending_force_split = saw_split_half
+
+        if not saw_split_half:
+            return kv_caches
+
+        if getattr(worker, "_has_mamba", False):
+            NixlConnectorPatch._pending_force_split = False
+            raise RuntimeError(
+                "kvcached NixlConnector: PD disaggregation is not supported for "
+                "hybrid/mamba models on blocks-first vLLM (>=0.23). Refusing to "
+                "register a layout that would silently corrupt KV transfers."
+            )
+
+        self.logger.info(
+            "kvcached: reconciled blocks-first KV layout -> split_k_and_v "
+            "(K/V registered as separate regions to match kvcached split-half memory)"
+        )
+        return fixed
 
     def _ensure_supported_kvcached_layout(self) -> None:
         if not CONTIGUOUS_LAYOUT:

--- a/tests/test_vllm_nixl_compat.py
+++ b/tests/test_vllm_nixl_compat.py
@@ -8,6 +8,16 @@ from importlib.machinery import ModuleSpec
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _reset_force_split_signal():
+    # NixlConnectorPatch._pending_force_split is a process-global class attribute;
+    # reset it after every test so state can't leak between tests.
+    yield
+    mod = sys.modules.get("kvcached.integration.vllm.nixl_compat")
+    if mod is not None:
+        mod.NixlConnectorPatch._pending_force_split = False
+
+
 class FakeTensor:
     def __init__(self, shape):
         self.shape = shape
@@ -49,9 +59,20 @@ def _install_fake_nixl_module(monkeypatch, module_style="legacy"):
             # (= attn_backends[0].get_name()), not a `_use_flashinfer` attr.
             self.backend_name = backend_name
             self.use_mla = use_mla
+            self.transfer_topo = None
 
         def register_kv_caches(self, kv_caches, *args, **kwargs):
             self.calls += 1
+            # Mirror real vLLM base register_kv_caches: build a TransferTopology.
+            # Only when a test has installed a fake utils.TransferTopology, so the
+            # existing tests (which don't) are unaffected. This lets tests drive the
+            # full reconcile->build-topology->consume-signal chain end to end.
+            utils = sys.modules.get(
+                "vllm.distributed.kv_transfer.kv_connector.utils"
+            )
+            topo_cls = getattr(utils, "TransferTopology", None) if utils else None
+            if topo_cls is not None:
+                self.transfer_topo = topo_cls()
             return self.num_blocks
 
     if module_style == "legacy":
@@ -298,3 +319,252 @@ def test_nixl_connector_base_patch_adapter(monkeypatch):
 
     worker = NixlConnectorWorker(num_blocks=17)
     assert worker.register_kv_caches({"layer": FakeTensor((2, 66, 4, 5, 6))}) == 66
+
+
+# ---------------------------------------------------------------------------
+# vLLM >=0.23 blocks-first split-half layout reconciliation
+# ---------------------------------------------------------------------------
+
+
+class FakeStridedTensor:
+    """Minimal tensor exposing the surface _reconcile_blocks_first_layout needs:
+    shape, dim(), stride(), transpose(). transpose() returns a view with the two
+    dims/strides swapped and records that it happened."""
+
+    def __init__(self, shape, stride, transposed=False):
+        self.shape = tuple(shape)
+        self._stride = tuple(stride)
+        self.transposed = transposed
+        self.is_null = False
+
+    def dim(self):
+        return len(self.shape)
+
+    def stride(self):
+        return self._stride
+
+    def transpose(self, a, b):
+        shp = list(self.shape)
+        strd = list(self._stride)
+        shp[a], shp[b] = shp[b], shp[a]
+        strd[a], strd[b] = strd[b], strd[a]
+        return FakeStridedTensor(shp, strd, transposed=True)
+
+
+def _split_half_tensor():
+    # (N, 2, block, H, D) with block_stride == hidden (= block*H*D) -> split-half.
+    hidden = 4 * 5 * 6  # 120
+    return FakeStridedTensor((8, 2, 4, 5, 6), (hidden, 10_000_000, 30, 6, 1))
+
+
+def _interleaved_tensor():
+    # block_stride == 2*hidden -> K/V interleaved within block (matches NIXL).
+    hidden = 4 * 5 * 6
+    return FakeStridedTensor((8, 2, 4, 5, 6), (2 * hidden, hidden, 30, 6, 1))
+
+
+def _make_patch(monkeypatch):
+    _install_fake_torch(monkeypatch)
+    _install_fake_nixl_module(monkeypatch)
+    from kvcached.integration.vllm import nixl_compat
+
+    _enable_kvcached_nixl(monkeypatch, nixl_compat)
+    nixl_compat.NixlConnectorPatch._pending_force_split = False
+    return nixl_compat, nixl_compat.NixlConnectorPatch()
+
+
+def test_reconcile_transposes_split_half_and_signals(monkeypatch):
+    nixl_compat, patch = _make_patch(monkeypatch)
+    worker = types.SimpleNamespace()  # no _has_mamba
+    out = patch._reconcile_blocks_first_layout(worker, {"layer": _split_half_tensor()})
+
+    # (N, 2, ...) presented to NIXL as (2, N, ...) so K/V is the outer dim.
+    assert out["layer"].shape == (2, 8, 4, 5, 6)
+    assert out["layer"].transposed is True
+    # signalled the topology hook to force split_k_and_v.
+    assert nixl_compat.NixlConnectorPatch._pending_force_split is True
+
+
+def test_reconcile_leaves_interleaved_untouched(monkeypatch):
+    nixl_compat, patch = _make_patch(monkeypatch)
+    t = _interleaved_tensor()
+    out = patch._reconcile_blocks_first_layout(types.SimpleNamespace(), {"layer": t})
+
+    assert out["layer"] is t  # not transposed
+    assert nixl_compat.NixlConnectorPatch._pending_force_split is False
+
+
+def test_reconcile_rejects_unknown_stride(monkeypatch):
+    nixl_compat, patch = _make_patch(monkeypatch)
+    bad = FakeStridedTensor((8, 2, 4, 5, 6), (999, 10_000_000, 30, 6, 1))
+    with pytest.raises(RuntimeError, match="unexpected attention KV block stride"):
+        patch._reconcile_blocks_first_layout(types.SimpleNamespace(), {"layer": bad})
+
+
+def test_reconcile_rejects_hybrid_mamba(monkeypatch):
+    nixl_compat, patch = _make_patch(monkeypatch)
+    worker = types.SimpleNamespace(_has_mamba=True)
+    with pytest.raises(RuntimeError, match="hybrid/mamba"):
+        patch._reconcile_blocks_first_layout(worker, {"layer": _split_half_tensor()})
+    # signal must not stay set after bailing out.
+    assert nixl_compat.NixlConnectorPatch._pending_force_split is False
+
+
+def _install_fake_transfer_topology(monkeypatch):
+    utils = types.ModuleType(
+        "vllm.distributed.kv_transfer.kv_connector.utils"
+    )
+
+    class TransferTopology:
+        def __init__(self, is_mla=False, is_mamba=False, blocks_first=True):
+            self.is_mla = is_mla
+            self.is_mamba = is_mamba
+            self._is_kv_layout_blocks_first = blocks_first
+
+    setattr(utils, "TransferTopology", TransferTopology)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.distributed.kv_transfer.kv_connector.utils",
+        utils,
+    )
+    parent = sys.modules["vllm.distributed.kv_transfer.kv_connector"]
+    monkeypatch.setattr(parent, "utils", utils, raising=False)
+    return TransferTopology
+
+
+def test_topology_flip_only_when_signalled(monkeypatch):
+    nixl_compat, _ = _make_patch(monkeypatch)
+    TransferTopology = _install_fake_transfer_topology(monkeypatch)
+    assert nixl_compat.patch_nixl_connector() is True
+
+    # Signalled (wrapper transposed a split-half tensor): flip + consume.
+    nixl_compat.NixlConnectorPatch._pending_force_split = True
+    t = TransferTopology()
+    assert t._is_kv_layout_blocks_first is False
+    assert nixl_compat.NixlConnectorPatch._pending_force_split is False
+
+    # Not signalled (interleaved / native): keep NIXL's default path.
+    t2 = TransferTopology()
+    assert t2._is_kv_layout_blocks_first is True
+
+    # Signalled but MLA/mamba topology: never flip (but still consume).
+    nixl_compat.NixlConnectorPatch._pending_force_split = True
+    t3 = TransferTopology(is_mla=True)
+    assert t3._is_kv_layout_blocks_first is True
+    assert nixl_compat.NixlConnectorPatch._pending_force_split is False
+
+
+def test_register_to_topology_flip_end_to_end(monkeypatch):
+    """Drive the full chain and the idempotency regression together.
+
+    register wrapper -> _reconcile transposes a split-half tensor and signals ->
+    base register builds a TransferTopology -> its patched __init__ consumes the
+    signal and flips. Also runs after a SECOND patch_nixl_connector() call: that is
+    the exact scenario the reviewer flagged, and this asserts the wrapper's signal
+    still reaches the topology hook (it would NOT with a per-instance, unguarded
+    signal, where the second call rewraps register onto a new instance).
+    """
+    _install_fake_torch(monkeypatch)
+    _, NixlConnectorWorker = _install_fake_nixl_module(monkeypatch)
+    from kvcached.integration.vllm import nixl_compat
+
+    _enable_kvcached_nixl(monkeypatch, nixl_compat)
+    nixl_compat.NixlConnectorPatch._pending_force_split = False
+    _install_fake_transfer_topology(monkeypatch)
+
+    assert nixl_compat.patch_nixl_connector() is True
+    assert nixl_compat.patch_nixl_connector() is True  # second patch (the regression)
+
+    # split-half -> full chain flips the topology built inside register.
+    worker = NixlConnectorWorker(num_blocks=8)
+    worker.register_kv_caches({"layer": _split_half_tensor()})
+    assert worker.transfer_topo is not None
+    assert worker.transfer_topo._is_kv_layout_blocks_first is False
+
+    # interleaved -> no transpose, no signal -> topology keeps NIXL's default path.
+    worker2 = NixlConnectorWorker(num_blocks=8)
+    worker2.register_kv_caches({"layer": _interleaved_tensor()})
+    assert worker2.transfer_topo._is_kv_layout_blocks_first is True
+
+
+def _install_fake_nixl_with_push(monkeypatch):
+    """Install a base/pull/push worker hierarchy mirroring real vLLM: the base
+    defines register_kv_caches, the pull subclass inherits it, and the push
+    subclass overrides it but delegates via super()."""
+    _install_package_hierarchy(
+        monkeypatch,
+        [
+            "vllm",
+            "vllm.distributed",
+            "vllm.distributed.kv_transfer",
+            "vllm.distributed.kv_transfer.kv_connector",
+            "vllm.distributed.kv_transfer.kv_connector.v1",
+        ],
+    )
+
+    class NixlConnector:
+        @classmethod
+        def get_required_kvcache_layout(cls, vllm_config):
+            return "HND"
+
+    class NixlBaseConnectorWorker:
+        def __init__(self, num_blocks=0, backend_name="", use_mla=False):
+            self.num_blocks = num_blocks
+            self.backend_name = backend_name
+            self.use_mla = use_mla
+            self.transfer_topo = None
+
+        def register_kv_caches(self, kv_caches, *args, **kwargs):
+            utils = sys.modules.get(
+                "vllm.distributed.kv_transfer.kv_connector.utils"
+            )
+            topo_cls = getattr(utils, "TransferTopology", None) if utils else None
+            if topo_cls is not None:
+                self.transfer_topo = topo_cls()
+            return self.num_blocks
+
+    class NixlPullConnectorWorker(NixlBaseConnectorWorker):
+        pass  # inherits register_kv_caches from the base
+
+    class NixlPushConnectorWorker(NixlBaseConnectorWorker):
+        def register_kv_caches(self, kv_caches, *args, **kwargs):
+            return super().register_kv_caches(kv_caches, *args, **kwargs)
+
+    module = types.ModuleType(
+        "vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector"
+    )
+    setattr(module, "NixlConnector", NixlConnector)
+    # _import_nixl_connector_classes resolves NixlConnectorWorker to the pull class.
+    setattr(module, "NixlConnectorWorker", NixlPullConnectorWorker)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector",
+        module,
+    )
+    return NixlPullConnectorWorker, NixlPushConnectorWorker
+
+
+def test_patch_covers_both_pull_and_push_workers(monkeypatch):
+    """The wrapper must run for BOTH pull and push workers. Push overrides
+    register_kv_caches and delegates via super(); patching the base worker (the
+    class that defines register) covers it, whereas patching only the pull
+    subclass would leave push silently unpatched -> silent corruption."""
+    _install_fake_torch(monkeypatch)
+    Pull, Push = _install_fake_nixl_with_push(monkeypatch)
+    from kvcached.integration.vllm import nixl_compat
+
+    _enable_kvcached_nixl(monkeypatch, nixl_compat)
+    nixl_compat.NixlConnectorPatch._pending_force_split = False
+    _install_fake_transfer_topology(monkeypatch)
+
+    assert nixl_compat.patch_nixl_connector() is True
+
+    # Pull: inherits the (patched) base register -> reconcile runs -> flip.
+    pull = Pull(num_blocks=8)
+    pull.register_kv_caches({"layer": _split_half_tensor()})
+    assert pull.transfer_topo._is_kv_layout_blocks_first is False
+
+    # Push: its super().register_kv_caches() hits the patched base -> also covered.
+    push = Push(num_blocks=8)
+    push.register_kv_caches({"layer": _split_half_tensor()})
+    assert push.transfer_topo._is_kv_layout_blocks_first is False


### PR DESCRIPTION
## Summary

Fixes garbled decode output from kvcached's NIXL PD disaggregation on vLLM >= 0.23. This is a correctness bug, independent of the `block_hash` (transfer-volume) issue. Single-instance serving is unaffected.

## Root cause

The bug comes from a mismatch between a tensor's logical shape (what .shape advertises) and its physical layout (how the bytes are actually arranged in memory) — and from NIXL trusting the former to infer the latter.

Logical shape. In vLLM 0.23 (PR #42095) the attention backends switched their KV-cache shape from K/V-first (2, num_blocks, ...) to blocks-first (num_blocks, 2, ...). NIXL infers the physical layout purely from this logical shape: seeing the 2 in the block dimension, it assumes K and V are interleaved within each block.

Physical layout. kvcached (non-contiguous MHA/GQA) does not store the bytes that way. It uses a split-half layout — all K blocks packed in one region, all V blocks in a separate region far away — regardless of what logical shape it advertises to the kernel. The blocks-first .shape is just a stride-encoded view over those two regions.

Why the kernel is fine but NIXL is not. The attention kernel addresses the cache through the tensor's real strides, so it lands on the correct K and V bytes and single-instance decode is correct. NIXL, however, does raw-offset RDMA: it ignores the strides and derives per-block offsets from the interleaved assumption above. Its per-block stride is therefore 2× kvcached's real stride, and its V descriptor points into kvcached's K region. Every transferred block is misaligned and V is never sent — producing garbled decode on the decode instance.

In short: kvcached's logical shape says "interleaved," its physical layout is "split-half," and only NIXL is fooled because it's the one reader that trusts the shape instead of the strides.
## Fix

Contained to `nixl_compat.py`; kvcached's memory layout is unchanged. Present split-half attention tensors to NIXL as a K/V-first `(2, num_blocks, ...)` view (transpose, zero-copy) and force the `split_k_and_v` path, so K and V register as two separate block-contiguous regions matching kvcached's real memory. The transpose and the topology flip are kept in lockstep (the flip fires only when a tensor was actually transposed), so it stays layout-driven — if kvcached ever lays K/V out interleaved, NIXL's native path is kept. Unrecognized strides and hybrid/mamba blocks-first are rejected loudly rather than silently corrupted.

## Validation

Real single-GPU 1P1D NIXL run (Qwen2.5-0.5B): decode output goes from garbled `' (A 14- A 63'` to coherent (matching stock vLLM), and per-layer NIXL descriptors drop from 1392 (interleaved per-block) to 48 (2 regions x 24 layers). Single-instance kvcached output is unchanged.