### PR TITLE
ci: fix integration branch pre-commit checks

### DIFF
--- a/benchmarks/bench_gemma_hetero/README.md
+++ b/benchmarks/bench_gemma_hetero/README.md
@@ -18,6 +18,7 @@ Verified on **NVIDIA GB10 (DGX Spark)**, vLLM **0.24.0**, torch 2.11.0+cu130.
 - Gemma is multimodal; the check runs it text-only (`limit_mm_per_prompt` all 0).
 
 ## How to run
+
 ```bash
 # baseline (no kvcached)
 python correctness_check.py --tag baseline
@@ -27,6 +28,7 @@ ENABLE_KVCACHED=true KVCACHED_AUTOPATCH=1 KVCACHED_CONTIGUOUS_LAYOUT=false \
 # compare token ids
 python correctness_check.py --compare baseline kvcached
 ```
+
 The prompts are long (> the 1024 sliding window) so the sliding-window layers are
 exercised, not just the prefix.
 

--- a/benchmarks/bench_gemma_hetero/correctness_check.py
+++ b/benchmarks/bench_gemma_hetero/correctness_check.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
 """Byte-exact correctness check for kvcached on a heterogeneous-KV-group model.
 
 Greedy-decode a long-context chat request (prompt > sliding window, so the


### PR DESCRIPTION
## Summary

- add the required SPDX header to the heterogeneous Gemma correctness script
- apply the repository PyMarkdown formatting to its benchmark README

## Context

The current `integration-with-new-vllm` head fails its existing `pre-commit` workflow because these two newly added benchmark files are modified by `addlicense-py` and `pymarkdown`. This PR contains only the generated mechanical fixes so feature PRs targeting the branch can be checked on a clean base.

## Validation

Run in a Linux container without GPU devices, using the repository workflow commands:

- `pre-commit run --all-files`
- `pre-commit run --all-files --hook-stage manual mypy-3.9`
- `pre-commit run --all-files --hook-stage manual mypy-3.10`
- `pre-commit run --all-files --hook-stage manual mypy-3.11`
- `pre-commit run --all-files --hook-stage manual mypy-3.12`
- `pre-commit run --all-files --hook-stage manual mypy-3.13`

All checks passed. A second full pre-commit run produced no additional changes.