### PR TITLE
feat(vllm): adapt kvcached KV-cache reshape patch up to vLLM 0.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ GPT-OSS support in SGLang updated to **v0.5.9**.
 | Engine | Versions | Attention types | Example models |
 |--------|----------|-----------------|----------------|
 | SGLang | ≥ v0.4.9 (tested up to v0.5.10) | MHA / GQA / MLA | Llama 3.1/3.3, Qwen 2.5, DeepSeek-V3, openai/gpt-oss-20b, etc. |
-| vLLM | ≥ v0.8.4 (tested up to v0.19.0) | MHA / GQA / MLA | Llama 3.1/3.3, Qwen 2.5, DeepSeek-V3, openai/gpt-oss-20b |
+| vLLM | ≥ v0.8.4 (tested up to v0.25.1) | MHA / GQA / MLA | Llama 3.1/3.3, Qwen 2.5, DeepSeek-V3, openai/gpt-oss-20b |
 
 ## Example use cases
 

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -1364,12 +1364,20 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
         if self._is_already_patched(original_method, "reshape_kv_cache_tensors"):
             return True
 
-        def _patched_reshape_kv(self, kv_cache_config, kv_cache_raw_tensors, *args: Any, **kwargs: Any):
+        def _patched_reshape_kv(self, *args: Any, **kwargs: Any):
             if enable_kvcached():
+                # vLLM <0.20:  _reshape_kv_cache_tensors(self, kv_cache_config, kv_cache_raw_tensors, ...)
+                # vLLM >=0.20: _reshape_kv_cache_tensors(self, kv_cache_raw_tensors, kernel_block_sizes)
+                #   -> the kv_cache_config arg was dropped; pull it from self.kv_cache_config.
+                if args and hasattr(args[0], "kv_cache_groups"):
+                    kv_cache_config, kv_cache_raw_tensors = args[0], args[1]
+                else:
+                    kv_cache_config = getattr(self, "kv_cache_config", None)
+                    kv_cache_raw_tensors = args[0]
                 return self._reshape_kv_cache_tensors_from_kvcached(
-                    kv_cache_config, kv_cache_raw_tensors, *args, **kwargs
+                    kv_cache_config, kv_cache_raw_tensors
                 )
-            return original_method(self, kv_cache_config, kv_cache_raw_tensors, *args, **kwargs)
+            return original_method(self, *args, **kwargs)
 
         self._mark_as_patched(_patched_reshape_kv, "reshape_kv_cache_tensors")
         setattr(GPUModelRunner, "_reshape_kv_cache_tensors", _patched_reshape_kv)


### PR DESCRIPTION
vLLM 0.20 changed `GPUModelRunner._reshape_kv_cache_tensors` to `(self, kv_cache_raw_tensors, kernel_block_sizes)`, dropping the `kv_cache_config` argument, so kvcached's patched reshape crashed at engine init on vLLM >=0.20 with `AttributeError: 'list' object has no attribute 'kv_cache_groups'`. This PR makes the patch signature-agnostic (detect the config by `.kv_cache_groups`, otherwise pull it from `self.kv_cache_config`), keeping <=0.19 working while adding >=0.20 support, and bumps the README support matrix to "tested up to v0.25.1" accordingly. Validated byte-identical output vs the no-kvcached baseline on vLLM 0.20.2, 0.22.1 and 0.25.1.