### PR TITLE
feat(vllm): support heterogeneous-geometry hybrid models (Gemma 3/4)

### DIFF
--- a/benchmarks/bench_gemma_hetero/README.md
+++ b/benchmarks/bench_gemma_hetero/README.md
@@ -1,0 +1,44 @@
+# bench_gemma_hetero — kvcached correctness on heterogeneous-KV-group models (Gemma 3/4)
+
+Byte-exact correctness of kvcached on a **heterogeneous-KV-group** hybrid model,
+where sliding-window and full-attention layers have different block geometry
+(`block_size`/`cell_size`) but the same `block_mem_size`. `google/gemma-4-12B-it`
+is the reference: sliding-window layers `block_size=16/cell=4096`, full-attention
+layers `block_size=64/cell=1024` (full layers use 1 shared KV head x head_dim 512). Support for this landed on branch
+`integration-with-new-vllm` (per-group `as_strided` KV views over one shared pool).
+
+Verified on **NVIDIA GB10 (DGX Spark)**, vLLM **0.24.0**, torch 2.11.0+cu130.
+
+## Requirements
+- A CUDA vLLM **>= 0.24** (Gemma 4 native support) + kvcached in the active env.
+- Gemma is **gated** — `huggingface-cli login` first.
+- Heterogeneous Gemma requires kvcached's **non-contiguous** layout
+  (`KVCACHED_CONTIGUOUS_LAYOUT=false`); do **not** pass
+  `--disable-hybrid-kv-cache-manager` (it unifies the groups and defeats the test).
+- Gemma is multimodal; the check runs it text-only (`limit_mm_per_prompt` all 0).
+
+## How to run
+
+```bash
+# baseline (no kvcached)
+python correctness_check.py --tag baseline
+# kvcached (heterogeneous -> non-contiguous, hybrid manager on)
+ENABLE_KVCACHED=true KVCACHED_AUTOPATCH=1 KVCACHED_CONTIGUOUS_LAYOUT=false \
+  python correctness_check.py --tag kvcached
+# compare token ids
+python correctness_check.py --compare baseline kvcached
+```
+
+The prompts are long (> the 1024 sliding window) so the sliding-window layers are
+exercised, not just the prefix.
+
+## Result — PASS (byte-exact)
+kvcached (non-contiguous, hybrid manager on → real 16/64 heterogeneous groups)
+produced token-for-token **identical** output to the no-kvcached baseline:
+- 4/4 long (>1024-token, sliding-window-spanning) raw prompts, and
+- 2/2 chat-template coherent long-context generations (128 tokens each).
+
+This confirms the per-group KV views read correctly, including on the
+sliding-window layers at long context — the one residual risk (that the sliding
+group's `as_strided` stride matches what the attention kernel expects) that only a
+live forward pass can close.

--- a/benchmarks/bench_gemma_hetero/correctness_check.py
+++ b/benchmarks/bench_gemma_hetero/correctness_check.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Byte-exact correctness check for kvcached on a heterogeneous-KV-group model.
+
+Greedy-decode a long-context chat request (prompt > sliding window, so the
+sliding-window layers are exercised) and save the output token ids. Run once
+with kvcached OFF and once ON, then diff — identical token ids prove kvcached's
+per-group KV views are correct.
+
+  # baseline
+  python correctness_check.py --tag baseline
+  # kvcached (heterogeneous -> non-contiguous)
+  ENABLE_KVCACHED=true KVCACHED_AUTOPATCH=1 KVCACHED_CONTIGUOUS_LAYOUT=false \
+    python correctness_check.py --tag kvcached
+  # compare
+  python correctness_check.py --compare baseline kvcached
+
+Gemma is gated + multimodal: authenticate first, and this runs it text-only
+(limit_mm_per_prompt=0). Requires vLLM >=0.24 for Gemma 4.
+"""
+import argparse
+import json
+import sys
+
+MODEL_DEFAULT = "google/gemma-4-12B-it"
+# ~1500-token document (> the 1024 sliding window) + a question over it.
+_DOC = ("In the kingdom of Eldoria seven cities each guarded a colored gem: "
+        "Aurora red, Belfor orange, Caldera yellow, Dawnhaven green, Evermoor "
+        "blue, Frosthold indigo, Grimstone violet. They traded along the river. ") * 60
+MSGS = [
+    [{"role": "user", "content": _DOC + " List the seven cities with their gem colors, then explain the trade."}],
+    [{"role": "user", "content": _DOC + " Which city held the blue gem and which the violet? Describe the route between them."}],
+]
+
+
+def run(tag: str, model: str):
+    from vllm import LLM, SamplingParams
+    llm = LLM(model=model, enforce_eager=True, max_model_len=8192,
+              gpu_memory_utilization=0.5, enable_prefix_caching=False,
+              limit_mm_per_prompt={"image": 0, "video": 0, "audio": 0}, max_num_seqs=8)
+    outs = llm.chat(MSGS, SamplingParams(max_tokens=128, temperature=0.0))
+    toks = [list(o.outputs[0].token_ids) for o in outs]
+    json.dump(toks, open(f"toks_{tag}.json", "w"))
+    print(f"saved toks_{tag}.json | uniq[0]={len(set(toks[0]))} | "
+          f"sample={outs[0].outputs[0].text[:80]!r}")
+
+
+def compare(a: str, b: str) -> int:
+    ta = json.load(open(f"toks_{a}.json"))
+    tb = json.load(open(f"toks_{b}.json"))
+    ok = ta == tb
+    for i, (x, y) in enumerate(zip(ta, tb)):
+        print(f"  prompt {i}: {'IDENTICAL' if x == y else 'DIFF'} "
+              f"({len(x)} vs {len(y)} toks)")
+    print("RESULT:", "PASS - byte-exact identical" if ok else "FAIL - token mismatch")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--tag")
+    p.add_argument("--model", default=MODEL_DEFAULT)
+    p.add_argument("--compare", nargs=2, metavar=("A", "B"))
+    args = p.parse_args()
+    if args.compare:
+        sys.exit(compare(*args.compare))
+    run(args.tag, args.model)

--- a/docs/SUPPORTED_MODELS_AND_LAYOUT.md
+++ b/docs/SUPPORTED_MODELS_AND_LAYOUT.md
@@ -1,0 +1,167 @@
+# kvcached 支持的模型架构与 KV-Cache 布局
+
+本文档说明 kvcached 当前支持哪些模型架构,以及 **contiguous / non-contiguous** 两种 KV-cache 布局的含义、默认值和适用范围。所有结论均基于源码核实(文末附关键文件),并在 NVIDIA DGX Spark(GB10)上有运行实证(见 [§5](#5-实测验证))。
+
+> 适用范围:本文对应 `main` / `integration-with-new-vllm` 分支。行号为参考,可能随版本变动。
+
+---
+
+## 1. kvcached 如何判断一个模型是否支持
+
+kvcached **不按模型名识别**,而是检查推理引擎给出的 **KV-cache spec**,据此推断内部 `attention_type`。能识别其 spec 的模型即透明支持,识别不了的在 setup 阶段直接报错。
+
+- **vLLM**:`_infer_attention_type`(`kvcached/integration/vllm/patches.py`)把整个 KV-cache 配置归为一种内部类型,优先级:`MLA` > `HYBRID_LINEAR` > `MHA`(默认)。
+- **SGLang**:不做推断,而是用**专用弹性池(Elastic*Pool)子类替换** SGLang 原生池(`kvcached/integration/sglang/patches.py`)。
+
+---
+
+## 2. 支持的模型架构
+
+### 2.1 按注意力类型
+
+| 注意力类型 | 模型例子 | vLLM 触发的 spec | vLLM 内部类型 | SGLang 弹性池 |
+|---|---|---|---|---|
+| **MHA / GQA**(稠密) | Llama 3.1/3.3、Qwen 2.5/3 | `FullAttentionSpec` | `MHA`(GQA 共用,KV 头更少) | `ElasticMHATokenToKVPool` |
+| **MLA**(潜在注意力) | DeepSeek-V2/V3 | `MLAAttentionSpec`(≥0.11)/ 旧版 `use_mla=True` | `MLA`,单融合 buffer,`num_kv_buffers=1` | `ElasticMLATokenToKVPool`(含 NSA / fp8 KV) |
+| **滑窗 / 注意力混合** | **openai/gpt-oss-20b** | `SlidingWindowSpec`(+`FullAttentionSpec`) | 归 `MHA` 路径,多 group | `ElasticMHATokenToKVPool`(SWA 池独立 VM 预留) |
+| **Hybrid-linear / Mamba** | Jamba、Bamba、NemotronH、Zamba2、Plamo2、Qwen3-Next/GDN | `FullAttentionSpec` + `MambaSpec` 同时存在 | `HYBRID_LINEAR` | `ElasticHybridLinearKVPool`(全注意力池 + `ElasticMambaPool`) |
+
+vLLM 端**只接受 4 种 spec**:`FullAttentionSpec`、`SlidingWindowSpec`、`MLAAttentionSpec`、`MambaSpec`;其它类型报错
+`kvcached only supports FullAttentionSpec, SlidingWindowSpec, MLAAttentionSpec, and MambaSpec, got {type} in group {idx}`。
+`MambaSpec` 被接受但**不作为注意力管理**——其状态以 int8 原始 buffer 分配,再用 `torch.as_strided` 重塑。
+
+### 2.2 关键约束:多注意力 group 必须共享「物理 block 几何」
+
+`_validate_kv_cache_groups`(`patches.py` ~78–116)要求**所有注意力 group 的 `block_mem_size`(= `block_size × cell_size`,每块每 K-或-V 的字节数)和 `num_kv_buffers` 相同**,否则报错。**注意:不再要求 `block_size`/`cell_size` 各自相等** —— 只要物理块大小一致即可(见下「异构几何」支持)。
+
+```
+kvcached requires all attention KV cache groups to share one physical block
+geometry (block_mem_size and num_kv_buffers). ...
+```
+
+- 根因:kvcached 的弹性池用**一套统一的物理 page/block 布局**服务所有 group(单池假设),只要 `block_mem_size` 一致,一个物理块就能同时被不同 group 以不同的 `as_strided` 视图解读。
+- Mamba / 非注意力 group **豁免**此检查。
+- **会被拒绝的情况**:
+  1. 出现不支持的 spec 类型;
+  2. **物理块几何真正冲突**:`block_mem_size` 不同,或 `num_kv_buffers` 不同(例如把 MLA 的 `num_kv_buffers=1` 与 MHA 的 `=2` 混在一起)。
+  3. **纯 Mamba**(完全没有注意力 group):校验提前返回,但后续报 `kvcached is enabled but the KV cache config contains no attention groups`。
+
+#### 异构几何混合模型(Gemma 3/4)—— 已支持
+
+滑窗层与全注意力层 **`block_size`/`cell_size` 不同但 `block_mem_size` 相同** 的模型(如 **Gemma 3/4**:滑窗 `block_size=16`/`cell=4096`(8 KV 头×256)、全注意力 `block_size=64`/`cell=1024`(1 共享 KV 头×512),两者 `block_mem_size=65536` 相同)**现已支持**。
+
+- 机制:一份统一物理池,`_reshape_kv_cache_tensors_from_kvcached` 按**每个 group 自己的** `(block_size, num_kv_heads, head_size)` 用 `interfaces.build_kv_views()` 建 `as_strided` 视图(`patches.py` 的异构分支 + `interfaces.py:build_kv_views`)。
+- **要求**:vLLM ≥0.9(`KVCacheCoordinatorPatch` 多-group 路径)、且 **`KVCACHED_CONTIGUOUS_LAYOUT=false`**(异构目前仅支持非连续布局,连续布局会报错提示)。**不要**加 `--disable-hybrid-kv-cache-manager`(那会把各层并成 `UniformTypeKVCacheSpecs` 且 per-layer page 大小不一,反而无法承载)。
+- 已 byte-exact 验证:见 [§5](#5-实测验证)。
+
+> 对照:`gpt-oss` 也是滑窗混合,但其滑窗层与全注意力层 block 几何本就**一致**(单 group / 统一),走同构快路径。滑窗/多-group 基础支持由上游 PR #259 引入(放开到 `SlidingWindowSpec` + 多 group,前提是 `block_mem_size` 一致);**异构几何**的按-group 视图支持是在 `integration-with-new-vllm` 分支追加的。
+
+### 2.3 MoE vs 稠密
+
+**MoE 透明支持**——kvcached 只管 KV cache,与 FFN/专家路由正交,代码中无任何 MoE 逻辑。只要其注意力 spec 被支持即可(如 gpt-oss-20b)。注:README/examples 未对 MoE 做明文承诺,属「按架构支持」。
+
+### 2.4 暂不支持 / 未声明
+
+- **异构且 `block_mem_size` 也不同**的注意力 group(真正需要多物理池):当前单池承载不了,fallback 是「每 group 独立池」(未实现)。Gemma 3/4 这类 `block_mem_size` 相同的异构模型**已支持**(见 §2.2)。
+- **异构几何 + 连续布局**:目前异构只支持 `KVCACHED_CONTIGUOUS_LAYOUT=false`;连续布局下的按-group 重排未实现。
+- **纯 Mamba**(无任何全注意力层)。
+- **多模态 LLM 的 KV-cache**、**MTP**:README/examples 未声明支持(视觉/扩散模型仅作为**同卡共置**负载出现,不由 kvcached 管理 KV)。
+
+---
+
+## 3. KV-Cache 布局:Contiguous vs Non-Contiguous
+
+### 3.1 控制变量与默认值
+
+环境变量 **`KVCACHED_CONTIGUOUS_LAYOUT`**,在 import 时读取一次并冻结为 `kvcached/utils.py` 的全局 `CONTIGUOUS_LAYOUT`(`_default_contiguous_layout`,~150–171):
+
+```python
+explicit = os.getenv("KVCACHED_CONTIGUOUS_LAYOUT")
+if explicit is not None:                 # 显式设置永远优先
+    return explicit.lower() == "true"
+if getattr(torch.version, "hip", None):  # ROCm/HIP
+    return False                         # → 非连续
+return True                              # CUDA → 连续
+```
+
+| 平台 | 默认布局 |
+|---|---|
+| **CUDA** | `True`(连续) |
+| **HIP / ROCm** | `False`(非连续) |
+
+显式设置 `KVCACHED_CONTIGUOUS_LAYOUT` 在两个平台上都会覆盖自动默认值。
+
+### 3.2 两种布局的定义
+
+- **连续(contiguous)**:所有层 + K/V 打包进**一个**大 tensor,每个 block 由单个「复合页」backing——**一次 `map` 调用即覆盖某 block 跨所有层和 K/V**(复合页大小 = `kPageSize * num_layers * num_kv_buffers`)。每层 KV 是对这个大 tensor 的**跨步视图**(block 在最外维,block 间 stride 比紧凑布局大 `num_layers * num_kv_buffers` 倍),层在物理上交错。
+- **非连续(non-contiguous)**:**每层各自**一个 tensor / 各自 VM 预留,每层 KV 是标准紧凑 contiguous。物理映射对每层分别 map K 和 V → 每 block `2 * num_layers` 次 VMM 操作(`unified_pool` 时每层 1 次)。
+
+### 3.3 哪种架构/后端需要哪种布局
+
+| 场景 | 要求 | 原因 |
+|---|---|---|
+| **vLLM hybrid-linear / Mamba** | **必须非连续** | `is_hybrid_linear and contiguous` 直接 `ValueError`,提示设 `KVCACHED_CONTIGUOUS_LAYOUT=false`;并强制 `unified_pool` |
+| **AMD ROCm / HIP**(任何模型) | **必须非连续**(自动默认) | 连续的交错布局喂给 ROCm 的 `PagedAttention.split_kv_cache` + paged kernel 会读错;CUDA 的 FlashAttention/FlashInfer 能容忍跨步视图 |
+| **vLLM NIXL PD 分离** | **必须非连续** | `NixlConnector` 按 block-contiguous 注册每层 K/V,连续布局的跨层交错与之冲突 |
+| **SGLang hybrid-linear / Mamba 投机解码** | **必须连续** | `fused_mamba_state_scatter` / MTP-verify 需要单个 `(num_layers, slots, *)` tensor |
+| **NVIDIA 稠密 MHA/GQA/MLA** | **两者皆可** | FlashAttention/FlashInfer 读取路径对布局不敏感;CUDA 默认连续 |
+
+### 3.4 正确性 / 性能权衡
+
+| | 连续(CUDA 默认) | 非连续(ROCm 默认) |
+|---|---|---|
+| 物理映射 | 每 block 一次复合 map 覆盖所有层 → **VMM 操作更少**、map 并行更好、单一 tensor | 每 block `2*num_layers` 次 map(unified_pool 时每层 1 次) |
+| 每层 KV tensor | 跨步视图(大 stride) | 紧凑标准 contiguous |
+| ROCm paged kernel 正确 | ❌ | ✅ |
+| NIXL PD | ❌ | ✅ |
+| vLLM hybrid-linear/Mamba | ❌ | ✅(必需) |
+| SGLang hybrid-linear 投机解码 | ✅(必需) | ❌ |
+
+**净取舍**:连续 = 用「跨步的每层视图」换「更少的 VMM 操作」,CUDA 稠密/MLA 首选;非连续 = 紧凑每层 tensor,ROCm / NIXL / vLLM-hybrid-linear 必需,代价是更多 map 调用。
+
+> 另:每个 block(或 Mamba 每槽 super-cell)必须放进一个 `PAGE_SIZE`(默认 2MB),否则 `kv_cache_manager.py` 抛 `KVCachedConfigError`(对 GDN/Mamba 这类 recurrent state 较大的模型,需调大 `KVCACHED_PAGE_SIZE_MB`)。
+
+---
+
+## 4. 引擎与版本支持
+
+| 引擎 | 版本范围(代码) | 已测 | 注意力类型 | 备注 |
+|---|---|---|---|---|
+| **vLLM** | `>=0.8.4`(`ALL`);多 group/混合需 `>=0.9.0` | README 测到 0.19;本仓库已验证 0.20–0.24 | MHA/GQA、MLA、滑窗、hybrid-linear | 0.8.x 路径仅单 group 且禁用 prefix cache |
+| **SGLang** | `>=0.4.9`(`SGLANG_ALL_RANGE`) | README 测到 0.5.10,近期支持 0.5.11+ | MHA/GQA、MLA、Mamba、hybrid-linear | 仅 GPU |
+
+其它:仅 **GPU**(CUDA/HIP);仅 **NHD** KV layout(非 NHD 的 FlashInfer 后端会报错);prefix caching **支持**(受 `KVCACHED_MAX_CACHED_TOKENS` 约束,默认 16000;vLLM 0.8.x 除外)。
+
+---
+
+## 5. 实测验证
+
+在 NVIDIA DGX Spark(GB10,aarch64,CUDA 13)上,kvcached + vLLM(pip 安装,torch 2.11.0+cu130)实测:
+
+| 模型 | 架构 | vLLM | 结果 |
+|---|---|---|---|
+| Qwen2.5-0.5B / Qwen3-8B | 稠密 MHA/GQA | 0.20.2 / 0.21.0 / 0.22.1 | ✅ patch + 输出与 baseline 字节一致 + on-demand map/unmap |
+| **openai/gpt-oss-20b** | **滑窗混合(几何统一)** | 0.24.0 | ✅ patch 全过、`contiguous_layout=1`、MAP +1.0GB / UNMAP −0.8GB、答案正确、**0 次 block-geometry 拒绝** |
+| google/gemma-4-12B-it | 滑窗混合(几何异构) | 0.24.0(原生加载) | ✅ **(方案 D 实现后)** `KVCACHED_CONTIGUOUS_LAYOUT=false`、hybrid manager 产生 16/64 异构组、越过 validate、kvcached engage;与 baseline **逐 token 一致**(裸长 prompt 4/4 + chat 长上下文连贯输出 2/2) |
+
+验证脚本:`tests/test_kvcached_map_unmap.py`(map/unmap + 正确性,pytest 与 CLI 双模式)。
+
+---
+
+## 附录:关键文件与环境变量
+
+**关键文件**
+- `kvcached/integration/vllm/patches.py` — vLLM patch、`_infer_attention_type`、`_validate_kv_cache_groups`
+- `kvcached/integration/vllm/interfaces.py` — vLLM 分配/reshape、布局分支、hybrid-linear 守卫
+- `kvcached/integration/sglang/patches.py` / `interfaces.py` — SGLang 弹性池
+- `kvcached/utils.py` — `CONTIGUOUS_LAYOUT` / `_default_contiguous_layout`、`MAX_CACHED_TOKENS`
+- `kvcached/kv_cache_manager.py` — block 须放进单页的校验(`KVCachedConfigError`)
+- `csrc/allocator.cpp` / `csrc/page_allocator.cpp` — 连续/非连续的 C++ 实现
+- `kvcached/integration/vllm/nixl_compat.py` — NIXL PD 与布局约束
+
+**相关环境变量**
+- `ENABLE_KVCACHED` / `KVCACHED_AUTOPATCH` — 启用 + import 时自动 patch
+- `KVCACHED_CONTIGUOUS_LAYOUT` — 布局(见 §3.1)
+- `KVCACHED_GPU_UTILIZATION` — 物理池上限
+- `KVCACHED_PAGE_SIZE_MB` — page 大小(默认 2)
+- `KVCACHED_MAX_CACHED_TOKENS` — prefix cache 上限(默认 16000)

--- a/examples/08_hybrid_attention_models/README.md
+++ b/examples/08_hybrid_attention_models/README.md
@@ -8,10 +8,21 @@ vLLM uses the term "hybrid" for two very different things, and kvcached needs di
 
 | Flavor | Examples | vLLM flag | kvcached env |
 |---|---|---|---|
-| **Attention-only hybrid** (full attention + sliding window, all groups unify to `FullAttentionSpec`) | GPT-OSS | `--disable-hybrid-kv-cache-manager` | (default; `KVCACHED_CONTIGUOUS_LAYOUT=true`) |
+| **Attention-only hybrid, uniform geometry** (full + sliding window, all attention groups share the same block geometry) | GPT-OSS | `--disable-hybrid-kv-cache-manager` **optional** (see note) | (default; `KVCACHED_CONTIGUOUS_LAYOUT=true`) |
+| **Attention-only hybrid, heterogeneous geometry** (sliding vs full layers have different KV dims / block_size, same block_mem_size) | Gemma 3 / Gemma 4 | **do NOT pass** `--disable-hybrid-kv-cache-manager` | `KVCACHED_CONTIGUOUS_LAYOUT=false` |
 | **Linear-attention hybrid** (full attention + Mamba/SSM, groups have different specs and cannot be unified) | Jamba, Bamba, NemotronH, Zamba2, Plamo2 | **do NOT pass** `--disable-hybrid-kv-cache-manager` | `KVCACHED_CONTIGUOUS_LAYOUT=false` |
 
-The `start_two_models.sh` script defaults to GPT-OSS (attention-only). For Jamba/Bamba and other Mamba-hybrid models, drop `--disable-hybrid-kv-cache-manager` from the `vllm serve` command and export `KVCACHED_CONTIGUOUS_LAYOUT=false` before launching.
+> **Note on GPT-OSS / `--disable-hybrid-kv-cache-manager`:** kvcached now supports
+> multiple attention KV-cache groups directly, so GPT-OSS runs correctly **with the
+> hybrid KV-cache manager enabled** (flag omitted) — verified byte-for-byte identical
+> to the disabled-manager output on vLLM 0.24. The flag is therefore no longer
+> required for GPT-OSS. In our measurement the flag makes ~no difference to the
+> static KV-cache capacity (GPT-OSS's attention groups are homogeneous, so vLLM's
+> hybrid manager and the disabled path allocate the same per-block memory); its
+> benefit is runtime block recycling for long-context/high-concurrency workloads.
+> `start_two_models.sh` still passes it for GPT-OSS for backward compatibility.
+
+The `start_two_models.sh` script defaults to GPT-OSS (attention-only). For Jamba/Bamba and other Mamba-hybrid models, drop `--disable-hybrid-kv-cache-manager` from the `vllm serve` command and export `KVCACHED_CONTIGUOUS_LAYOUT=false` before launching. For Gemma 3/4 (heterogeneous attention geometry), likewise do not disable the hybrid manager and export `KVCACHED_CONTIGUOUS_LAYOUT=false`.
 
 ## Prerequisites
 - A working vLLM installation with kvcached.

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -112,6 +112,10 @@ def build_kv_views(
     num_k_or_v = 1 if is_mla else 2
     if kernel_block_size is None:
         kernel_block_size = block_size
+    if block_size % kernel_block_size != 0:
+        raise ValueError(
+            f"block_size ({block_size}) must be a multiple of "
+            f"kernel_block_size ({kernel_block_size})")
     ratio = block_size // kernel_block_size
 
     if is_mla:

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -85,6 +85,105 @@ def shutdown_kvcached() -> None:
     _async_sched = False
 
 
+def build_kv_views(
+    raw_kv_tensors: List[torch.Tensor],
+    kvcache_shape: Tuple[int, ...],
+    block_size: int,
+    dtype: torch.dtype,
+    attention_type: str,
+    num_blocks_per_layer: int,
+    gpu_mem_bytes_per_layer_k_or_v: int,
+    num_layers: int,
+    kernel_block_size: Optional[int] = None,
+) -> Tuple[List[torch.Tensor], int]:
+    """Reinterpret already-allocated raw KV pools as per-layer KV views.
+
+    Mirrors the view-building math inside ``alloc_kv_cache`` but takes
+    already-allocated ``raw_kv_tensors`` plus the (uniform) physical quantities
+    ``num_blocks_per_layer`` / ``gpu_mem_bytes_per_layer_k_or_v``. This lets a
+    heterogeneous hybrid model (e.g. Gemma: sliding-window + full-attention
+    groups with different ``(block_size, num_kv_heads, head_size)`` but identical
+    ``block_mem_size``) build a DIFFERENT view per group over the SAME physical
+    pools. Returns ``(kv_tensors, page_size_bytes)``. Non-contiguous layout only
+    for heterogeneous callers.
+    """
+    is_mla = attention_type == "MLA"
+    unified_pool = attention_type == "HYBRID_LINEAR"
+    num_k_or_v = 1 if is_mla else 2
+    if kernel_block_size is None:
+        kernel_block_size = block_size
+    ratio = block_size // kernel_block_size
+
+    if is_mla:
+        blocks_dim_idx = 0
+        permute_order = list(range(len(kvcache_shape)))
+    elif kvcache_shape[0] == num_k_or_v:
+        blocks_dim_idx = 1
+        permute_order = [1, 0] + list(range(2, len(kvcache_shape)))
+    elif kvcache_shape[1] == num_k_or_v:
+        blocks_dim_idx = 0
+        permute_order = [0, 1] + list(range(2, len(kvcache_shape)))
+    else:
+        raise ValueError(f"Unsupported kv cache shape: {kvcache_shape}")
+
+    actual_kvcache_shape: List[int] = list(kvcache_shape)
+    actual_kvcache_shape[blocks_dim_idx] = num_blocks_per_layer
+
+    page_size_bytes = math.prod(
+        actual_kvcache_shape[:blocks_dim_idx] + actual_kvcache_shape[blocks_dim_idx + 1:]
+    ) * dtype.itemsize
+
+    kernel_kvcache_shape: List[int] = list(actual_kvcache_shape)
+    if ratio > 1:
+        kernel_kvcache_shape[blocks_dim_idx] = num_blocks_per_layer * ratio
+        token_dim_idx = 2 if not is_mla else 1
+        kernel_kvcache_shape[token_dim_idx] = kernel_block_size
+
+    if not _contiguous_layout:
+        kv_tensors: List[torch.Tensor] = []
+        if is_mla:
+            num_eles = math.prod(kernel_kvcache_shape)
+            kv_tensors = [
+                t.view(dtype=dtype)[:num_eles].view(kernel_kvcache_shape)
+                for t in raw_kv_tensors
+            ]
+        else:
+            shape = list(kernel_kvcache_shape)
+            strides = [0] * len(shape)
+            strides[-1] = 1
+            for i in range(len(shape) - 2, 1, -1):
+                strides[i] = strides[i + 1] * shape[i + 1]
+            hidden_size_eles = strides[2] * shape[2]
+            if unified_pool:
+                if blocks_dim_idx == 1:
+                    strides[1] = 2 * hidden_size_eles
+                    strides[0] = hidden_size_eles
+                else:
+                    strides[0] = 2 * hidden_size_eles
+                    strides[1] = hidden_size_eles
+            else:
+                v_offset_eles = gpu_mem_bytes_per_layer_k_or_v // dtype.itemsize
+                if blocks_dim_idx == 1:
+                    strides[1] = hidden_size_eles
+                    strides[0] = v_offset_eles
+                else:
+                    strides[0] = hidden_size_eles
+                    strides[1] = v_offset_eles
+            for t in raw_kv_tensors:
+                kv_tensors.append(
+                    torch.as_strided(t.view(dtype=dtype), shape, strides))
+    else:
+        layer_elem_shape = actual_kvcache_shape[:blocks_dim_idx] + actual_kvcache_shape[blocks_dim_idx + 1:]
+        contiguous_shape = [num_blocks_per_layer, num_layers] + layer_elem_shape
+        num_eles = math.prod(contiguous_shape)
+        contiguous_tensor = raw_kv_tensors[0].view(dtype=dtype)[:num_eles].view(contiguous_shape)
+        kv_tensors = [
+            contiguous_tensor[:, i].permute(*permute_order) for i in range(num_layers)
+        ]
+
+    return kv_tensors, page_size_bytes
+
+
 def alloc_kv_cache(
     kvcache_shape: Tuple[int, ...],
     block_size: int,
@@ -95,8 +194,15 @@ def alloc_kv_cache(
     kv_layout: str = "NHD",  # NHD: (num_tokens, head_num, head_dim)
     group_id: int = 0,
     kernel_block_size: Optional[int] = None,
+    return_meta: bool = False,
 ) -> List[torch.Tensor]:
     """Allocate KV cache tensors for all supported attention types.
+
+    When ``return_meta`` is True, the physical-allocation metadata needed to
+    rebuild per-group views (for heterogeneous hybrid models like Gemma) is
+    appended to the return value as a final ``meta`` dict with keys:
+    ``raw_kv_tensors``, ``num_blocks_per_layer``, ``gpu_mem_bytes_per_layer_k_or_v``,
+    ``num_layers``, ``dtype``.
 
     For MHA/GQA, kvcache_shape is expected to be:
       - FlashAttn:  (2, num_blocks, block_size, head_num, head_dim)
@@ -297,7 +403,17 @@ def alloc_kv_cache(
             contiguous_tensor[:, i].permute(*permute_order) for i in range(num_layers)
         ]
 
+    meta = {
+        "raw_kv_tensors": raw_kv_tensors,
+        "num_blocks_per_layer": num_blocks_per_layer,
+        "gpu_mem_bytes_per_layer_k_or_v": gpu_mem_bytes_per_layer_k_or_v,
+        "num_layers": num_layers,
+        "dtype": dtype,
+    }
+
     if not unified_pool:
+        if return_meta:
+            return kv_tensors, meta  # type: ignore[return-value]
         return kv_tensors
 
     # --- Build raw int8 buffers for hybrid model (mamba) support ---
@@ -311,6 +427,8 @@ def alloc_kv_cache(
         "block_stride_bytes": page_size_bytes,
         "num_pools": num_layers,
     }
+    if return_meta:
+        return kv_tensors, raw_info, meta  # type: ignore[return-value]
     return kv_tensors, raw_info  # type: ignore[return-value]
 
 

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -1290,8 +1290,22 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 for gid, grp in enumerate(kv_cache_config.kv_cache_groups)
                 if _is_attention_spec(grp.kv_cache_spec)
             ]
+            distinct_attn_geoms = {_attn_geom(grp) for _, grp in attn_group_list}
+            # The relaxed validate gate admits attention groups with differing
+            # geometry as long as block_mem_size matches. Per-group views are only
+            # built for the pure-attention path; HYBRID_LINEAR (full attn + mamba)
+            # reshape still binds all attention layers to the first group's
+            # geometry, so heterogeneous attention geometry there would be wrong.
+            # No known hybrid-linear model has that, but fail loud rather than
+            # silently mis-stride.
+            if attention_type == "HYBRID_LINEAR" and len(distinct_attn_geoms) > 1:
+                raise NotImplementedError(
+                    "kvcached does not support hybrid-linear (attention + mamba) "
+                    "models with heterogeneous attention-group geometry "
+                    f"({sorted(distinct_attn_geoms)})."
+                )
             is_hetero = (attention_type != "HYBRID_LINEAR"
-                         and len({_attn_geom(grp) for _, grp in attn_group_list}) > 1)
+                         and len(distinct_attn_geoms) > 1)
             self._kvcached_attn_layer_views = None
 
             alloc_result = kvi.alloc_kv_cache(

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -99,20 +99,33 @@ def _validate_kv_cache_groups(kv_cache_config: Any) -> None:
 
     first_spec = first_attn_group.kv_cache_spec
     block_size = first_spec.block_size
-    cell_size, _ = _get_kv_cache_params(first_spec, block_size)
+    cell_size, num_kv_buffers = _get_kv_cache_params(first_spec, block_size)
+    block_mem_size = block_size * cell_size
 
     for idx, grp in enumerate(kv_groups):
         grp_spec = grp.kv_cache_spec
         if not _is_attention_spec(grp_spec):
             continue
         grp_block_size = grp_spec.block_size
-        grp_cell_size, _ = _get_kv_cache_params(grp_spec, grp_block_size)
-        if grp_block_size != block_size or grp_cell_size != cell_size:
+        grp_cell_size, grp_num_kv_buffers = _get_kv_cache_params(grp_spec, grp_block_size)
+        grp_block_mem_size = grp_block_size * grp_cell_size
+        # kvcached needs one uniform physical block stride (block_mem_size =
+        # bytes/block per K-or-V) and one K/V buffer count. It does NOT require
+        # identical block_size/cell_size individually: attention groups that split
+        # a block into different token counts (e.g. Gemma's sliding-window
+        # block_size=64/cell=1024 vs full-attention block_size=16/cell=4096, both
+        # block_mem_size=65536) share one physical pool and get a per-group
+        # as_strided view. Reject only when the physical block stride or the K/V
+        # buffer count actually differ (a genuine single-pool violation, e.g.
+        # mixing MLA num_kv_buffers=1 with MHA num_kv_buffers=2).
+        if grp_block_mem_size != block_mem_size or grp_num_kv_buffers != num_kv_buffers:
             raise ValueError(
-                "kvcached requires all attention KV cache groups to have the "
-                f"same block geometry. First attention group: block_size={block_size},"
-                f" cell_size={cell_size}; group {idx}: "
-                f"block_size={grp_block_size}, cell_size={grp_cell_size}"
+                "kvcached requires all attention KV cache groups to share one "
+                "physical block geometry (block_mem_size and num_kv_buffers). "
+                f"First attention group: block_mem_size={block_mem_size}, "
+                f"num_kv_buffers={num_kv_buffers}; group {idx}: "
+                f"block_mem_size={grp_block_mem_size}, "
+                f"num_kv_buffers={grp_num_kv_buffers}"
             )
 
 
@@ -1262,6 +1275,25 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                     "produce invalid KV cache strides."
                 )
 
+            # Detect heterogeneous attention groups (Gemma-style: sliding-window
+            # + full-attention groups with different (block_size, num_kv_heads,
+            # head_size) but identical block_mem_size, validated above). For
+            # those we allocate ONE uniform physical pool set and build a
+            # per-group as_strided view; homogeneous / single-group models keep
+            # the original fast path byte-for-byte.
+            def _attn_geom(grp):
+                s = grp.kv_cache_spec
+                return (s.block_size, s.num_kv_heads, s.head_size)
+
+            attn_group_list = [
+                (gid, grp)
+                for gid, grp in enumerate(kv_cache_config.kv_cache_groups)
+                if _is_attention_spec(grp.kv_cache_spec)
+            ]
+            is_hetero = (attention_type != "HYBRID_LINEAR"
+                         and len({_attn_geom(grp) for _, grp in attn_group_list}) > 1)
+            self._kvcached_attn_layer_views = None
+
             alloc_result = kvi.alloc_kv_cache(
                 kv_cache_shape,
                 kv_cache_spec.block_size,
@@ -1271,11 +1303,45 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 attention_type=attention_type,
                 kv_layout="NHD",
                 kernel_block_size=kernel_block_size,
+                return_meta=is_hetero,
             )
 
             if attention_type == "HYBRID_LINEAR":
                 kv_cache_raw_tensors, raw_info = alloc_result
                 self._kvcached_mamba_raw_info = raw_info
+            elif is_hetero:
+                kv_cache_raw_tensors, meta = alloc_result
+                if getattr(kvi, "_contiguous_layout", False):
+                    raise RuntimeError(
+                        "kvcached: heterogeneous attention KV groups (e.g. Gemma "
+                        "sliding-window + full-attention) currently require the "
+                        "non-contiguous layout. Re-launch with "
+                        "KVCACHED_CONTIGUOUS_LAYOUT=false."
+                    )
+                # Build a per-group view over the shared physical pools using each
+                # group's own (block_size, num_kv_heads, head_size).
+                layer_views: dict = {}
+                for gid, grp in attn_group_list:
+                    gspec = grp.kv_cache_spec
+                    gbackend = patch_instance._get_version_specific_attention_backend(
+                        self, kv_cache_group_id=gid
+                    )
+                    gshape = gbackend.get_kv_cache_shape(
+                        num_blocks, gspec.block_size, gspec.num_kv_heads,
+                        gspec.head_size,
+                    )
+                    gkbs = (kernel_block_sizes[gid]
+                            if kernel_block_sizes is not None
+                            and gid < len(kernel_block_sizes) else None)
+                    gviews, _ = kvi.build_kv_views(
+                        meta["raw_kv_tensors"], gshape, gspec.block_size, dtype,
+                        attention_type, meta["num_blocks_per_layer"],
+                        meta["gpu_mem_bytes_per_layer_k_or_v"], meta["num_layers"],
+                        kernel_block_size=gkbs,
+                    )
+                    for pool_idx, layer_name in enumerate(grp.layer_names):
+                        layer_views[layer_name] = gviews[pool_idx]
+                self._kvcached_attn_layer_views = layer_views
             else:
                 kv_cache_raw_tensors = alloc_result
 
@@ -1325,6 +1391,10 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             kv_caches: dict[str, torch.Tensor] = {}
 
             mamba_info = getattr(self, "_kvcached_mamba_raw_info", None)
+            # Per-group attention views for heterogeneous hybrids (Gemma). None
+            # for homogeneous / single-group models, which use the raw-tensor
+            # index mapping below unchanged.
+            attn_layer_views = getattr(self, "_kvcached_attn_layer_views", None)
 
             for kv_cache_group in kv_cache_config.kv_cache_groups:
                 kv_cache_spec = kv_cache_group.kv_cache_spec
@@ -1343,7 +1413,10 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                         kv_caches[layer_name] = state_tensors  # type: ignore[assignment]
                 else:
                     for pool_idx, layer_name in enumerate(kv_cache_group.layer_names):
-                        kv_caches[layer_name] = kv_cache_raw_tensors[pool_idx]
+                        if attn_layer_views is not None and layer_name in attn_layer_views:
+                            kv_caches[layer_name] = attn_layer_views[layer_name]
+                        else:
+                            kv_caches[layer_name] = kv_cache_raw_tensors[pool_idx]
 
             return kv_caches
 


### PR DESCRIPTION
Fixes #370.

**NOTE: Gemma-4-12B-it must use chat template, otherwise, it will have garbled outputs!**

kvcached's vLLM integration required all attention KV-cache groups to have identical `block_size` and `cell_size`, which is stricter than what vLLM actually guarantees. For hybrid models vLLM only equalizes the physical bytes per block (`block_mem_size`): when two layer types have different per-token KV sizes, it adjusts each group's `block_size` so the products match. Gemma 3/4 is exactly this case — sliding-window layers (`block_size=16`, `cell=4096`, 8 KV heads × head_dim 256) interleaved with full-attention layers (`block_size=64`, `cell=1024`, 1 shared KV head × head_dim 512), both 65536 bytes per block — and the old validation rejected it even though a single elastic pool is already correct for both.

This PR relaxes the validation gate to `block_mem_size` + `num_kv_buffers`, allocates one uniform physical pool, and builds a per-group `as_strided` view via the new `build_kv_views()` helper, so each group addresses the same 64 KB blocks with its own shape/stride. Homogeneous and single-group models keep the original fast path byte-for-byte. Genuine conflicts still fail loud: groups with different physical block sizes, or single-buffer (MLA-style) groups mixed with two-buffer (MHA/GQA) groups — vLLM never validates the buffer-count dimension, so that check is the one doing real work here.

Validated on vLLM 0.24 / google/gemma-4-12B-it (hybrid KV manager on, real 16/64 heterogeneous groups, non-contiguous layout): output token-for-token identical to the no-kvcached baseline on long sliding-window-spanning prompts and **chat-template generations**. Regression: Qwen2.5-0.5B (homogeneous) remains byte-identical with kvcached on vs off, confirming the fast path is unchanged. Includes fail-loud guards from an adversarial review, a Gemma correctness benchmark under `benchmarks/bench_gemma_hetero/`, and doc updates (GPT-OSS no longer needs `--disable-hybrid-kv-cache-manager`).

Two open PRs touch the same boundaries, and this PR deliberately does not overlap with either. #357 fixes MLA memory mapping in the C++ allocator: MLA pools have one buffer instead of K/V two, and the allocator was mapping them twice; this PR's `num_kv_buffers` check guards the same one-vs-two distinction, but at validation time — the two changes are independent and complementary. #376 starts DeepSeek-V4 support: DeepSeek-V4 is the one model family where vLLM legitimately produces attention groups with *different* `block_mem_size` (its packed/bucketed planner), which the shared-pool design here cannot express. This PR does not attempt that — such configs hit the `block_mem_size` gate and fail loud instead of computing with wrong strides