### PR TITLE
fix(vllm): reserve block id 0 as the null block in ElasticBlockPool

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ GPT-OSS support in SGLang updated to **v0.5.9**.
 | Engine | Versions | Attention types | Example models |
 |--------|----------|-----------------|----------------|
 | SGLang | ≥ v0.4.9 (tested up to v0.5.10) | MHA / GQA / MLA | Llama 3.1/3.3, Qwen 2.5, DeepSeek-V3, openai/gpt-oss-20b, etc. |
-| vLLM | ≥ v0.8.4 (tested up to v0.25.1) | MHA / GQA / MLA | Llama 3.1/3.3, Qwen 2.5, DeepSeek-V3, openai/gpt-oss-20b |
+| vLLM | ≥ v0.8.4 (tested up to v0.24.0) | MHA / GQA / MLA | Llama 3.1/3.3, Qwen 2.5, DeepSeek-V3, openai/gpt-oss-20b |
 
 ## Example use cases
 

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -335,4 +335,5 @@ def get_kv_cache_manager(
         async_sched=_async_sched,
         num_kv_buffers=num_kv_buffers,
         group_id=group_id,
+        reserve_null_block=True,
     )

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -371,9 +371,17 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 # we mirror that by allocating one real block from kvcached so
                 # the block_id is valid on the GPU (the attention kernel may
                 # read from it, but results are masked out).
-                _null_ids = self.kv_cache_manager.alloc(1)
-                assert _null_ids is not None and len(_null_ids) == 1
-                self.null_block = self.kv_block_pool[_null_ids[0]]
+                # vLLM hard-codes null == block 0: native BlockPool pops
+                # block 0 as the null block, NULL_BLOCK_ID = 0, block tables
+                # are fill_(0) so padded/unused slots read 0, and mamba/GDN
+                # state kernels skip index 0 on both read and write. If any
+                # real request owns block 0, its GDN state is silently
+                # skipped as "null" and its output garbles. The manager is
+                # created with reserve_null_block=True (see get_kv_cache_manager),
+                # which reserves and maps block 0 synchronously before the
+                # page-prealloc thread starts (and fails loud if it cannot),
+                # so block 0 never enters circulation. Just wrap it here.
+                self.null_block = self.kv_block_pool[0]
                 self.null_block.is_null = True
 
                 # Prefix cache: (block_hash, group_id) -> KVCacheBlock

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -77,8 +77,13 @@ class MockKVCacheManager:
     """
 
     def __init__(self, num_blocks: int):
-        self._free: list[int] = list(range(num_blocks))
+        # Mirror KVCacheManager(reserve_null_block=True): block 0 is reserved
+        # as the null block during manager init and never enters circulation,
+        # so the free list starts at 1 (same id sequence the old code produced
+        # by allocating block 0 for the null block).
+        self._free: list[int] = list(range(1, num_blocks))
         self._allocated: set[int] = set()
+        self.null_block = [0]
 
     def alloc(self, n: int):
         if len(self._free) < n:


### PR DESCRIPTION
vLLM hard-codes null == block 0: native `BlockPool` pops block 0 as the null block, `NULL_BLOCK_ID = 0`, block tables are `fill_(0)` so padded/unused slots read 0, and the mamba/GDN state kernels skip index 0 on both read and write. `ElasticBlockPool` took its null block from `kv_cache_manager.alloc(1)` without checking the id; a race with the C++ page-prealloc thread (which grabs the first pages to pre-map them) can make that first alloc return a non-zero id (observed: 10 on Qwen3.5-35B-A3B, whose hybrid blocks are one-per-page). Block 0 then flows to a real request, whose GDN recurrent state is silently skipped as "null" by every state kernel — never read, never written — and its output garbles deterministically.

Fix: create the vLLM-side `KVCacheManager` with `reserve_null_block=True` — the existing mechanism already used by the SGLang path, which reserves and maps block 0 synchronously in `_post_init` before the page-prealloc thread starts (no race window) and fails loud if block 0 cannot be obtained — and let `ElasticBlockPool` simply wrap block 0 as its null block instead of allocating one.

Validated on vLLM 0.22.1 / H100 80GB / `Qwen/Qwen3.5-35B-A3B-FP8` (greedy, 4 prompts, `KVCACHED_CONTIGUOUS_LAYOUT=false`, `KVCACHED_PAGE_SIZE_MB=4`): unpatched `main` garbles (`"The capital of France is"` → `'rint纯天然, 20 2'`, only the request holding block 0 affected), while `main` + this fix restores token-for-token parity with the no-kvcached baseline on all 4 prompts.

## Regression testing

Since this fix changes global allocator behavior (every vLLM-side `KVCacheManager` now reserves block 0), it was regression-tested beyond the hybrid case that motivated it. All comparisons are greedy token-level parity against a no-kvcached baseline with identical engine args (H100 80GB, `enforce_eager`, bf16).

| Test | Config | Result |
|---|---|---|
| CPU unit suite | full `pytest tests/` diffed between this fix and its parent commit | identical pass/fail set (the 16 `test_prefix_cache.py` expectations are updated in this PR: the mock now models `reserve_null_block=True`, same block-id sequence as before, no assertion changed) |
| Standard attention, contiguous (default) | vLLM 0.22.1, Qwen2.5-0.5B-Instruct | 4/4 token-identical |
| Standard attention, non-contiguous | vLLM 0.22.1, `KVCACHED_CONTIGUOUS_LAYOUT=false` | 4/4 token-identical |
| Prefix caching ON, 2 rounds (cache-hit paths exercised) | vLLM 0.22.1, Qwen2.5-0.5B-Instruct | 8/8 token-identical |
| Hybrid GDN (tiny) | vLLM 0.22.1, tiny-random/qwen3.5-moe, non-contiguous | 4/4 token-identical |
| Hybrid GDN (real) | vLLM 0.22.1, Qwen3.5-35B-A3B-FP8 | the bug this PR fixes: unpatched `main` garbles, with fix 4/4 token-identical |
| Elasticity e2e | vLLM 0.22.1, `tests/test_elastic_serving.py` | grew (96 MB → 1536 MB under load), shrank back to 96 MB, output correct after the cycle; the idle 96 MB includes the synchronously reserved null block — the fix's mechanism visibly working |
| Boundary stress | vLLM 0.22.1, 2000-token generation + 8×256 batch | no allocation warnings/errors |

Two findings from the matrix that are **not** caused by this fix: (1) on vLLM 0.25.1 the worker-side `init_kvcached` IPC hook never fires, so kvcached was already non-functional there — before this fix it silently fell back to vLLM's native block pool, and with this fix the same pre-existing breakage fails loud at the first allocation instead; it will be tracked in a separate issue, and this PR rolls the README support matrix back to "tested up to v0.24.0" accordingly. (2) Tiny MLA models cannot be used for parity testing because baseline vLLM 0.22.1 rejects their small head dims; MLA coverage is unchanged from before this PR.