### PR TITLE
fix(vllm): preserve duplicate prefix cache blocks

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -441,16 +441,36 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 self.null_block = self.kv_block_pool[0]
                 self.null_block.is_null = True
 
-                # Prefix cache: (block_hash, group_id) -> KVCacheBlock
+                # Prefix cache: (block_hash, group_id) -> {block_id: block}.
+                # Multiple in-flight requests can materialize the same prefix
+                # before either block becomes reusable. vLLM preserves every
+                # such block because request block tables are append-only.
                 # The key embeds group_id to support hybrid attention
                 # (multiple KV cache groups with different attention types).
-                self._cached_blocks: dict[Any, KVCacheBlock] = {}
+                self._cached_blocks: dict[Any, dict[int, KVCacheBlock]] = {}
                 # Reverse index: block_id -> cache key for O(1) eviction.
                 # Each block_id belongs to exactly one group.
                 self._block_id_to_key: dict[int, Any] = {}
                 # LRU evictable pool: blocks with ref_cnt==0 retained for
                 # cross-request prefix reuse. Insertion order = LRU order.
                 self._evictable_blocks: OrderedDict[int, KVCacheBlock] = OrderedDict()
+
+            def _get_one_cached_block(self, key: Any) -> Optional[KVCacheBlock]:
+                blocks = self._cached_blocks.get(key)
+                if not blocks:
+                    return None
+                return next(iter(blocks.values()))
+
+            def _remove_cached_block(
+                self, key: Any, block_id: int
+            ) -> Optional[KVCacheBlock]:
+                blocks = self._cached_blocks.get(key)
+                if not blocks:
+                    return None
+                block = blocks.pop(block_id, None)
+                if not blocks:
+                    self._cached_blocks.pop(key, None)
+                return block
 
             def get_cached_block(
                 self,
@@ -467,14 +487,14 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 #   expect one block per group.
                 if kv_cache_group_ids is None:
                     key = _make_cache_key(block_hash, 0)
-                    return self._cached_blocks.get(key)
+                    return self._get_one_cached_block(key)
                 if isinstance(kv_cache_group_ids, int):
                     kv_cache_group_ids = [int(kv_cache_group_ids)]
 
                 cached_blocks: list[KVCacheBlock] = []
                 for group_id in kv_cache_group_ids:
                     key = _make_cache_key(block_hash, int(group_id))
-                    block = self._cached_blocks.get(key)
+                    block = self._get_one_cached_block(key)
                     if block is None:
                         # Atomic: all groups must hit or return None
                         return None
@@ -547,17 +567,17 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                     block_hash = block_hashes[block_idx]
                     key = _make_cache_key(block_hash, kv_cache_group_id)
 
-                    # Already cached, idempotent
-                    if key in self._cached_blocks:
-                        continue
-
                     # ElasticBlockPool tracks cached blocks through its own maps,
                     # but vLLM manager code may still read KVCacheBlock.block_hash
                     # after cache_full_blocks. Preserve that metadata contract and
                     # clear it before the block is evicted or reused.
+                    previous_key = self._block_id_to_key.get(block.block_id)
+                    if previous_key is not None and previous_key != key:
+                        self._remove_cached_block(previous_key, block.block_id)
+                        _reset_block_hash(block)
                     if getattr(block, "block_hash", None) is None:
                         _set_block_hash(block, key)
-                    self._cached_blocks[key] = block
+                    self._cached_blocks.setdefault(key, {})[block.block_id] = block
                     self._block_id_to_key[block.block_id] = key
 
             def _page_aligned_victims(self, num_to_evict: int) -> list[int]:
@@ -636,7 +656,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                     block = self._evictable_blocks.pop(bid, None)
                     key = self._block_id_to_key.pop(bid, None)
                     if key is not None:
-                        self._cached_blocks.pop(key, None)
+                        self._remove_cached_block(key, bid)
                     if block is not None:
                         _reset_block_hash(block)
                     ids_to_free.append(bid)
@@ -746,7 +766,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 for bid in block_ids:
                     key = self._block_id_to_key.pop(bid, None)
                     if key is not None:
-                        block = self._cached_blocks.pop(key, None)
+                        block = self._remove_cached_block(key, bid)
                         if block is not None:
                             _reset_block_hash(block)
                         removed += 1

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -552,6 +552,29 @@ class TestEdgeCases:
         pool.cache_full_blocks(req, blocks, 0, 2, 16, 0)
         assert len(pool._cached_blocks) == 2
 
+    def test_duplicate_hashes_keep_each_block_metadata(self, pool_and_manager):
+        """Concurrent requests may materialize the same prefix twice."""
+        pool, _ = pool_and_manager
+        first = pool.get_new_blocks(1)
+        second = pool.get_new_blocks(1)
+        req = MockRequest(["shared-prefix"])
+
+        pool.cache_full_blocks(req, first, 0, 1, 16, 0)
+        pool.cache_full_blocks(req, second, 0, 1, 16, 0)
+
+        assert first[0].block_hash is not None
+        assert second[0].block_hash == first[0].block_hash
+        assert len(pool._cached_blocks) == 1
+        assert pool.get_cached_block("shared-prefix", [0]) is not None
+
+        _finish_request(pool, first)
+        _finish_request(pool, second)
+        pool._evict_blocks_from_pool(1)
+
+        assert first[0].block_hash is None
+        assert second[0].block_hash is not None
+        assert pool.get_cached_block("shared-prefix", [0]) == [second[0]]
+
     def test_reuse_after_eviction_and_realloc(self, pool_factory):
         """After eviction, block IDs can be reallocated and recached."""
         pool, mgr = pool_factory(5)  # +1 for null_block


### PR DESCRIPTION
## Summary

Preserve every physical vLLM prefix-cache block when concurrent requests materialize the same `(block_hash, group_id)`.

Closes #401.

## Root cause

`ElasticBlockPool._cached_blocks` currently maps each cache key to one `KVCacheBlock`. `cache_full_blocks()` treats an existing key as an idempotent call and skips the new block.

Concurrent requests can produce the same full prefix before either physical block becomes reusable. In that case the second block is distinct, not an idempotent repeat. Skipping it leaves `KVCacheBlock.block_hash` unset and omits its reverse-index entry. vLLM's later cache accounting can then fail at `assert block.block_hash is not None`, terminating the EngineCore.

This complements #363: that PR fixed hash set/reset lifecycle, while this PR preserves multiple physical blocks that legitimately share one hash.

## Changes

- change the prefix index from `cache key -> block` to `cache key -> {block_id: block}`
- keep lookup compatibility by returning one matching block
- remove and reset cached entries by exact `block_id`, so evicting one duplicate does not delete its siblings
- handle a reused block moving from an old cache key to a new one
- add a regression test for two blocks with the same prefix, followed by separate release and eviction

## Validation

- `python -m pytest tests/test_prefix_cache.py -q` -> `30 passed`
- complete `pre-commit run --all-files` -> all hooks passed
- manual mypy matrix for Python 3.9, 3.10, 3.11, 3.12, and 3.13 -> all passed
- high-concurrency two-instance vLLM integration replay with prefix caching -> `1440/1440` requests completed, with no block-hash assertion or EngineCore failure

The branch is based on current upstream `main` (`927ef66c`) and contains one focused commit.