### PR TITLE
Fix small max cached token limits

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -262,12 +262,14 @@ def _get_max_cached_blocks(block_size: int) -> int:
 
     Returns -1 (unlimited) when MAX_CACHED_TOKENS < 0.
     Returns 0  (disabled — evict on free) when MAX_CACHED_TOKENS == 0.
-    Otherwise returns MAX_CACHED_TOKENS // block_size.
+    Otherwise returns enough blocks to cover MAX_CACHED_TOKENS.
     """
     from kvcached.utils import MAX_CACHED_TOKENS
     if MAX_CACHED_TOKENS < 0:
         return -1
-    return MAX_CACHED_TOKENS // block_size
+    if MAX_CACHED_TOKENS == 0:
+        return 0
+    return (MAX_CACHED_TOKENS + block_size - 1) // block_size
 
 
 def _make_cache_key(block_hash: Any, group_id: int) -> bytes:

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -121,6 +121,30 @@ def test_set_block_hash_supports_legacy_writable_property():
     assert block.block_hash == key
 
 
+@pytest.mark.parametrize(
+    ("max_cached_tokens", "block_size", "expected_blocks"),
+    [
+        (-1, 16, -1),
+        (0, 16, 0),
+        (1, 16, 1),
+        (8, 16, 1),
+        (16, 16, 1),
+        (17, 16, 2),
+        (32, 16, 2),
+    ],
+)
+def test_get_max_cached_blocks_rounds_positive_limits_up(
+    monkeypatch, max_cached_tokens, block_size, expected_blocks
+):
+    """Positive token limits should keep at least one cache block."""
+    import kvcached.utils as utils
+    from kvcached.integration.vllm.patches import _get_max_cached_blocks
+
+    monkeypatch.setattr(utils, "MAX_CACHED_TOKENS", max_cached_tokens)
+
+    assert _get_max_cached_blocks(block_size) == expected_blocks
+
+
 # ---------------------------------------------------------------------------
 # Fixture: create an ElasticBlockPool via the real patch injection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix `_get_max_cached_blocks()` so positive `KVCACHED_MAX_CACHED_TOKENS` values are rounded up to at least one cache block.
- Preserve the existing special cases: negative means unlimited, zero means disabled.
- Add a parameterized unit test for negative, zero, sub-block, exact-block, and non-divisible positive limits.

## Motivation

Before this change, `KVCACHED_MAX_CACHED_TOKENS=8` with `block_size=16` produced `0` cached blocks because the conversion used floor division. That silently disabled prefix caching even though the user requested a small positive cache budget.

## Validation

- `python -m pytest tests/test_prefix_cache.py`
- `python -m pytest tests/test_prefix_cache.py tests/test_make_cache_key.py tests/test_vllm_nixl_compat.py`
- `git diff --check`

I also tried `python -m pytest tests`, but this local macOS environment is missing optional project dependencies such as `torch`, `vllm`, and `aiohttp`, so full collection does not run here.

Fixes #343
