### PR TITLE
fix(kv_cache_manager): free reserved blocks before the resize assertion, not after

### DIFF
--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -374,8 +374,12 @@ class KVCacheManager:
     @synchronized
     def free_reserved(self):
         if self.reserved_blocks:
-            self.free(self.reserved_blocks)
-            self.reserved_blocks.clear()
+            # Detach first: once off the ledger the blocks are ordinary
+            # blocks, so free()'s sanity check (which forbids freeing a
+            # block that is still reserved) correctly stays quiet. Freeing
+            # before detaching trips that check under KVCACHED_SANITY_CHECK.
+            blocks, self.reserved_blocks = self.reserved_blocks, []
+            self.free(blocks)
 
     @synchronized
     def resize(self, new_mem_size: int):

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -390,14 +390,15 @@ class KVCacheManager:
                 self.in_shrink = False
                 self.target_num_blocks = None
             return True  # Successfully resized.
-        # Failed to resize due to too many in-use blocks.
-        assert (len(self.reserved_blocks) == 0
-                ), "Reserved blocks must be freed before resizing."
+        # Failed to resize due to too many in-use blocks. Free any
+        # outstanding reserved blocks before entering the lazy shrink wait.
         # NOTE: we can support resizing with reserved blocks, but we want to
         # enforce this check for now to ensure correctness.
+        self.free_reserved()
+        assert (len(self.reserved_blocks) == 0
+                ), "Reserved blocks must be freed before resizing."
         self.in_shrink = True
         self.target_num_blocks = new_mem_size // self.block_mem_size
-        self.free_reserved()
         return False
 
     @synchronized

--- a/tests/test_resize_reserved_order.py
+++ b/tests/test_resize_reserved_order.py
@@ -91,14 +91,13 @@ def _make_manager(resize_return=False):
 
     freed = []
     manager.free = lambda indices: freed.append(list(indices))
-    manager._freed_calls = freed
-    return manager
+    return manager, freed
 
 
 def test_resize_frees_reserved_blocks_before_entering_shrink_wait():
     """When the allocator can't shrink immediately, resize() must free the
     outstanding reserved blocks and enter in_shrink, not crash."""
-    manager = _make_manager(resize_return=False)
+    manager, freed = _make_manager(resize_return=False)
 
     result = manager.resize(4096)
 
@@ -106,12 +105,12 @@ def test_resize_frees_reserved_blocks_before_entering_shrink_wait():
     assert manager.in_shrink is True
     assert manager.target_num_blocks == 4096 // manager.block_mem_size
     assert manager.reserved_blocks == []
-    assert manager._freed_calls == [[1, 2, 3]]
+    assert freed == [[1, 2, 3]]
 
 
 def test_resize_with_no_reserved_blocks_still_works():
     """Sanity check: the common case (nothing reserved) is unaffected."""
-    manager = _make_manager(resize_return=False)
+    manager, _freed = _make_manager(resize_return=False)
     manager.reserved_blocks = []
 
     result = manager.resize(4096)

--- a/tests/test_resize_reserved_order.py
+++ b/tests/test_resize_reserved_order.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Regression test for KVCacheManager.resize(): when the page allocator cannot
+shrink immediately (too many blocks in use), resize() must free any
+outstanding reserved blocks before it enters the lazy in_shrink wait, not
+crash on an assertion that only the free it hasn't reached yet could satisfy.
+
+This test stubs out the compiled kvcached.vmm_ops C++ extension (which
+requires a CUDA/HIP build and a physical GPU to import and run) so the pure
+control-flow logic in KVCacheManager.resize()/free_reserved() can be
+exercised deterministically on CPU-only hardware. The lower-level `free()`
+call that free_reserved() makes is stubbed too: this test is about the
+*ordering* between the reserved-blocks assertion and the free, not about
+free()'s own page-bookkeeping, which is exercised by the existing
+GPU-dependent test_kvcache_manager.py.
+"""
+
+import sys
+import threading
+import types
+
+import pytest
+
+
+def _install_fake_vmm_ops():
+    """Register a minimal fake kvcached.vmm_ops so kv_cache_manager.py's
+    hard import succeeds without the compiled CUDA/HIP extension."""
+
+    class FakeInternalPage:
+        pass
+
+    class FakePageAllocator:
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def set_should_use_worker_ipc_callback(self, cb):
+            pass
+
+        def set_broadcast_map_callback(self, cb):
+            pass
+
+        def set_broadcast_unmap_callback(self, cb):
+            pass
+
+        def start_prealloc_thread(self):
+            pass
+
+        def resize(self, new_mem_size):
+            return False
+
+        def trim(self):
+            pass
+
+    fake_module = types.ModuleType("kvcached.vmm_ops")
+    fake_module.PageAllocator = FakePageAllocator  # type: ignore[attr-defined]
+    fake_module.InternalPage = FakeInternalPage  # type: ignore[attr-defined]
+    fake_module.kv_tensors_created = lambda *a, **kw: True  # type: ignore[attr-defined]
+    fake_module.map_to_kv_tensors = lambda *a, **kw: None  # type: ignore[attr-defined]
+    fake_module.unmap_from_kv_tensors = lambda *a, **kw: None  # type: ignore[attr-defined]
+    sys.modules["kvcached.vmm_ops"] = fake_module
+
+
+_install_fake_vmm_ops()
+
+from kvcached.kv_cache_manager import KVCacheManager  # noqa: E402
+from kvcached.locks import NoOpLock  # noqa: E402
+
+
+def _make_manager(resize_return=False):
+    """Build a KVCacheManager instance without running __init__ (which
+    spawns a background thread and talks to the real page allocator);
+    set exactly the attributes resize()/free_reserved() read or write."""
+    manager = object.__new__(KVCacheManager)
+    manager._lock = NoOpLock()
+    manager.block_mem_size = 1024
+    manager.reserved_blocks = [1, 2, 3]
+    manager.in_shrink = False
+    manager.target_num_blocks = None
+    manager._post_init_done = threading.Event()
+    manager._post_init_done.set()
+
+    class StubPageAllocator:
+
+        def resize(self, new_mem_size):
+            return resize_return
+
+    manager.page_allocator = StubPageAllocator()
+
+    freed = []
+    manager.free = lambda indices: freed.append(list(indices))
+    manager._freed_calls = freed
+    return manager
+
+
+def test_resize_frees_reserved_blocks_before_entering_shrink_wait():
+    """When the allocator can't shrink immediately, resize() must free the
+    outstanding reserved blocks and enter in_shrink, not crash."""
+    manager = _make_manager(resize_return=False)
+
+    result = manager.resize(4096)
+
+    assert result is False
+    assert manager.in_shrink is True
+    assert manager.target_num_blocks == 4096 // manager.block_mem_size
+    assert manager.reserved_blocks == []
+    assert manager._freed_calls == [[1, 2, 3]]
+
+
+def test_resize_with_no_reserved_blocks_still_works():
+    """Sanity check: the common case (nothing reserved) is unaffected."""
+    manager = _make_manager(resize_return=False)
+    manager.reserved_blocks = []
+
+    result = manager.resize(4096)
+
+    assert result is False
+    assert manager.in_shrink is True
+    assert manager.reserved_blocks == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_resize_reserved_order.py
+++ b/tests/test_resize_reserved_order.py
@@ -122,3 +122,43 @@ def test_resize_with_no_reserved_blocks_still_works():
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))
+
+
+def test_free_reserved_survives_sanity_check():
+    """Regression: free_reserved() must detach blocks from the ledger BEFORE
+    handing them to free(); otherwise free()'s KVCACHED_SANITY_CHECK guard
+    (which forbids freeing a block still listed as reserved) rejects the
+    legitimate release path with ValueError. Uses the REAL free() -- only the
+    page allocator below it is stubbed."""
+    import kvcached.kv_cache_manager as kcm
+
+    manager = object.__new__(KVCacheManager)
+    manager._lock = NoOpLock()
+    manager.block_mem_size = 1024
+    manager.reserved_blocks = [1, 2, 3]
+    manager.in_shrink = False
+    manager.target_num_blocks = None
+    manager._post_init_done = threading.Event()
+    manager._post_init_done.set()
+    manager.num_avail_blocks = 0
+
+    class StubPageAllocator:
+
+        def resize(self, new_mem_size):
+            return False
+
+        def group_indices_by_page(self, indices, block_mem_size):
+            return {}
+
+    manager.page_allocator = StubPageAllocator()
+
+    original = kcm.SANITY_CHECK
+    kcm.SANITY_CHECK = True
+    try:
+        result = manager.resize(4096)
+    finally:
+        kcm.SANITY_CHECK = original
+
+    assert result is False
+    assert manager.reserved_blocks == []
+    assert manager.in_shrink is True


### PR DESCRIPTION
fix(kv_cache_manager): free reserved blocks before the resize assertion, not after

`KVCacheManager.resize()` is meant to degrade gracefully when the page
allocator cannot shrink immediately: free any outstanding reserved blocks,
then enter the lazy `in_shrink` wait. The current order does the opposite.
It asserts `len(self.reserved_blocks) == 0` first, and only calls
`free_reserved()` afterward, so the one call that could satisfy the
assertion never runs before it fires. Every caller that has reserved blocks
outstanding when a shrink cannot apply immediately (a normal sequence:
`try_to_reserve()` followed by a `kvctl`-driven limit reduction that the
allocator cannot honor right away) hits `AssertionError` instead of the
documented degrade path.

Fix: call `free_reserved()` before checking the assertion, so the
reserved blocks are cleared first and the assertion becomes a genuine
post-condition check instead of a precondition that nothing upstream
of it can satisfy.

Verified in a clean `python:3.12-slim` container. `kv_cache_manager.py`
hard-imports the compiled `kvcached.vmm_ops` CUDA/HIP extension, which this
environment has no GPU to build or run, so the regression test stubs that
extension (a fake `PageAllocator`/`InternalPage`/`kv_tensors_created`
registered in `sys.modules` before import) and constructs the manager
without running `__init__`, to exercise `resize()`/`free_reserved()`
directly. On `b55096c` (current main) the added test fails with the
`AssertionError` above; on this branch it passes. I have not run the
GPU-backed integration suite (`tests/test_kvcache_manager.py`), since this
box has no CUDA device.

Fixes #406
