### PR TITLE
fix(controller): don't fail the losing racer of a concurrent wakeup_model() call

### DIFF
--- a/controller/sleep_manager.py
+++ b/controller/sleep_manager.py
@@ -202,7 +202,7 @@ class SleepManager:
                     f"No vLLM or SGLang configuration found for model {model_name}, using fallback behavior"
                 )
 
-            del self.sleeping_models[model_name]
+            self.sleeping_models.pop(model_name, None)
             self.manual_sleep_models.discard(model_name)
 
             logger.info(

--- a/tests/test_wakeup_race.py
+++ b/tests/test_wakeup_race.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""
+Regression test: two concurrent wakeup_model() calls for the same sleeping
+model must both report success when both of their own upstream wake calls
+succeed.
+"""
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "controller"))
+
+from controller.sleep_manager import SleepConfig, SleepManager
+
+
+async def test_concurrent_wakeup_both_succeed():
+    model_name = "test-model"
+    config = SleepConfig(
+        min_sleep_duration=0,
+        vllm_models_config={
+            model_name: {
+                "host": "localhost",
+                "port": "8000"
+            }
+        },
+    )
+    manager = SleepManager(config)
+    manager.sleeping_models[model_name] = time.time() - 10
+
+    async def slow_wake(host, port):
+        await asyncio.sleep(0.05)
+        return True
+
+    manager._call_vllm_wakeup_api = slow_wake  # type: ignore[method-assign]
+
+    results = await asyncio.gather(
+        manager.wakeup_model(model_name),
+        manager.wakeup_model(model_name),
+    )
+
+    assert results == [
+        True, True
+    ], f"expected both racers to report success, got {results}"
+    assert model_name not in manager.sleeping_models
+
+
+async def main():
+    await test_concurrent_wakeup_both_succeed()
+    print("OK: concurrent wakeup_model() calls both report success")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Fixes #408.

`wakeup_model()` checks `model_name in self.sleeping_models`, awaits the
real upstream wake call, then does `del self.sleeping_models[model_name]`.
That dict has exactly two writers in the package (`put_model_to_sleep` sets
it, `wakeup_model` deleted it): no lock guards the check-then-mutate across
the `await`. Two concurrent `wakeup_model()` calls for the same model both
pass the membership check, both call their own real upstream wake API, and
both reach the `del`. Only the first succeeds; the second raises
`KeyError`, caught by the surrounding `except Exception`, so that caller
reports `False` even though its own upstream wake call succeeded.

Fix: `self.sleeping_models.pop(model_name, None)` instead of `del`. The
losing racer no longer raises, so both callers reach `return True`, which
is correct since both of their own upstream calls succeeded.

Verified in a clean `python:3.11-slim` container at HEAD (`b55096c`):
`tests/test_wakeup_race.py` fires two concurrent `wakeup_model()` calls
with a mocked (always-succeeding) upstream wake API. Before the fix:
`[True, False]`. After: `[True, True]`. The mock only replaces the
upstream HTTP call, not `sleeping_models` or either of its two writers.

Also ran the repo's own gates on the changed files: `pre-commit run`
(ruff, codespell, isort, SPDX header check, trailing-whitespace, local
mypy) and the CI-only `mypy-3.12` manual hook, all passing.

Not verified: behavior against the real vLLM/SGLang wake APIs (only the
mocked upstream call), and whether two concurrent upstream wake calls to
the same backend are themselves safe to fire together, that's existing
behavior this change does not touch.
