### PR TITLE
Add KV cache operation observability

### DIFF
--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -9,6 +9,8 @@ import torch
 from kvcached.kv_cache_manager import KVCacheManager
 from kvcached.observability import (
     build_runtime_snapshot,
+    get_registered_kv_cache_pool_operation_snapshot_dicts,
+    get_registered_kv_cache_pool_operation_snapshots,
     get_registered_kv_cache_pool_snapshot_dicts,
     get_registered_kv_cache_pool_snapshots,
 )
@@ -100,6 +102,16 @@ def kv_cache_pool_snapshots():
 def kv_cache_pool_snapshot_dicts() -> List[Dict[str, Any]]:
     """Return JSON-serializable snapshots for all live SGLang KV pools."""
     return get_registered_kv_cache_pool_snapshot_dicts(integration="sglang")
+
+
+def kv_cache_pool_operation_snapshots():
+    """Return operation snapshots for all live SGLang KV pools."""
+    return get_registered_kv_cache_pool_operation_snapshots(integration="sglang")
+
+
+def kv_cache_pool_operation_snapshot_dicts() -> List[Dict[str, Any]]:
+    """Return JSON-serializable operation snapshots for live SGLang KV pools."""
+    return get_registered_kv_cache_pool_operation_snapshot_dicts(integration="sglang")
 
 
 def alloc_kv_cache(

--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -7,6 +7,15 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import torch
 
 from kvcached.kv_cache_manager import KVCacheManager
+from kvcached.observability import (
+    build_runtime_snapshot,
+    get_registered_kv_cache_pool_snapshot_dicts,
+    get_registered_kv_cache_pool_snapshots,
+)
+from kvcached.pool_registry import (
+    clear_registered_kv_cache_pools,
+    register_kv_cache_pool,
+)
 from kvcached.tp_ipc_util import start_worker_listener_thread
 from kvcached.utils import CONTIGUOUS_LAYOUT, PAGE_SIZE, get_kvcached_logger, normalize_gpu_device
 from kvcached.vmm_ops import (
@@ -55,12 +64,42 @@ def init_kvcached(
 def shutdown_kvcached() -> None:
     global _kvcached_initialized, _kvcached_device, _async_sched
     if not _kvcached_initialized:
+        clear_registered_kv_cache_pools(integration="sglang")
         return
 
     _shutdown_kvcached_impl()
+    clear_registered_kv_cache_pools(integration="sglang")
     _kvcached_initialized = False
     _kvcached_device = None
     _async_sched = False
+
+
+def observability_snapshot():
+    """Return a read-only snapshot of the SGLang integration state."""
+    return build_runtime_snapshot(
+        engine="sglang",
+        initialized=_kvcached_initialized,
+        device=_kvcached_device,
+        world_size=_world_size,
+        pp_rank=_pp_rank,
+        async_sched=_async_sched,
+        contiguous_layout=_contiguous_layout,
+    )
+
+
+def observability_snapshot_dict() -> Dict[str, Any]:
+    """Return a JSON-serializable snapshot of the SGLang integration state."""
+    return observability_snapshot().to_dict()
+
+
+def kv_cache_pool_snapshots():
+    """Return read-only snapshots for all live SGLang KV pools."""
+    return get_registered_kv_cache_pool_snapshots(integration="sglang")
+
+
+def kv_cache_pool_snapshot_dicts() -> List[Dict[str, Any]]:
+    """Return JSON-serializable snapshots for all live SGLang KV pools."""
+    return get_registered_kv_cache_pool_snapshot_dicts(integration="sglang")
 
 
 def alloc_kv_cache(
@@ -409,11 +448,12 @@ def get_kv_cache_manager(
     reserve_null_block: bool = True,
     num_kv_buffers: int = 2,
     group_id: int = 0,
+    pool_name: Optional[str] = None,
 ) -> KVCacheManager:
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
 
-    return KVCacheManager(
+    manager = KVCacheManager(
         num_blocks,
         block_size,
         cell_size,
@@ -424,4 +464,10 @@ def get_kv_cache_manager(
         reserve_null_block=reserve_null_block,
         num_kv_buffers=num_kv_buffers,
         group_id=group_id,
+        pool_name=pool_name,
     )
+    register_kv_cache_pool(
+        manager,
+        integration="sglang",
+    )
+    return manager

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -412,6 +412,7 @@ class ElasticMemoryPoolPatch(VersionAwarePatch, BasePatch):
                     self.kvcached_allocator = kvi.get_kv_cache_manager(
                         math.ceil(size / page_size) + 1, page_size, self.cell_size, layer_num,
                         group_id=self._group_id,
+                        pool_name="mha",
                     )
 
                     k_size, v_size = self.get_kv_size_bytes()
@@ -653,6 +654,7 @@ class ElasticMLAMemoryPoolPatch(VersionAwarePatch, BasePatch):
                     self.kvcached_allocator = kvi.get_kv_cache_manager(
                         size + page_size, page_size, self.cell_size, layer_num,
                         num_kv_buffers=1,
+                        pool_name="mla",
                     )
 
                     kv_size = self.get_kv_size_bytes()
@@ -982,6 +984,7 @@ class ElasticMambaPoolPatch(VersionAwarePatch, BasePatch):
                         reserve_null_block=True,
                         num_kv_buffers=1,
                         group_id=self._group_id,
+                        pool_name="mamba",
                     )
 
                     # Placeholder so code that touches self.free_slots in

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -2,11 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 
 from kvcached.kv_cache_manager import KVCacheManager
+from kvcached.observability import (
+    build_runtime_snapshot,
+    get_registered_kv_cache_pool_snapshot_dicts,
+    get_registered_kv_cache_pool_snapshots,
+)
+from kvcached.pool_registry import (
+    clear_registered_kv_cache_pools,
+    register_kv_cache_pool,
+)
 from kvcached.tp_ipc_util import start_worker_listener_thread
 from kvcached.utils import CONTIGUOUS_LAYOUT, PAGE_SIZE, get_kvcached_logger, normalize_gpu_device
 from kvcached.vmm_ops import (
@@ -77,9 +86,11 @@ def init_kvcached(
 def shutdown_kvcached() -> None:
     global _kvcached_initialized, _kvcached_device, _async_sched
     if not _kvcached_initialized:
+        clear_registered_kv_cache_pools(integration="vllm")
         return
 
     _shutdown_kvcached_impl()
+    clear_registered_kv_cache_pools(integration="vllm")
     _kvcached_initialized = False
     _kvcached_device = None
     _async_sched = False
@@ -190,6 +201,35 @@ def build_kv_views(
         ]
 
     return kv_tensors, page_size_bytes
+
+
+def observability_snapshot():
+    """Return a read-only snapshot of the vLLM integration state."""
+    return build_runtime_snapshot(
+        engine="vllm",
+        initialized=_kvcached_initialized,
+        device=_kvcached_device,
+        world_size=_world_size,
+        pp_rank=_pp_rank,
+        async_sched=_async_sched,
+        contiguous_layout=_contiguous_layout,
+        is_worker=_is_worker,
+    )
+
+
+def observability_snapshot_dict() -> Dict[str, Any]:
+    """Return a JSON-serializable snapshot of the vLLM integration state."""
+    return observability_snapshot().to_dict()
+
+
+def kv_cache_pool_snapshots():
+    """Return read-only snapshots for all live vLLM KV pools."""
+    return get_registered_kv_cache_pool_snapshots(integration="vllm")
+
+
+def kv_cache_pool_snapshot_dicts() -> List[Dict[str, Any]]:
+    """Return JSON-serializable snapshots for all live vLLM KV pools."""
+    return get_registered_kv_cache_pool_snapshot_dicts(integration="vllm")
 
 
 def alloc_kv_cache(
@@ -506,11 +546,12 @@ def get_kv_cache_manager(
     num_layers: int,
     num_kv_buffers: int = 2,
     group_id: int = 0,
+    pool_name: Optional[str] = None,
 ) -> KVCacheManager:
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
 
-    return KVCacheManager(
+    manager = KVCacheManager(
         num_blocks,
         block_size,
         cell_size,
@@ -521,4 +562,10 @@ def get_kv_cache_manager(
         num_kv_buffers=num_kv_buffers,
         group_id=group_id,
         reserve_null_block=True,
+        pool_name=pool_name,
     )
+    register_kv_cache_pool(
+        manager,
+        integration="vllm",
+    )
+    return manager

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -9,6 +9,8 @@ import torch
 from kvcached.kv_cache_manager import KVCacheManager
 from kvcached.observability import (
     build_runtime_snapshot,
+    get_registered_kv_cache_pool_operation_snapshot_dicts,
+    get_registered_kv_cache_pool_operation_snapshots,
     get_registered_kv_cache_pool_snapshot_dicts,
     get_registered_kv_cache_pool_snapshots,
 )
@@ -230,6 +232,16 @@ def kv_cache_pool_snapshots():
 def kv_cache_pool_snapshot_dicts() -> List[Dict[str, Any]]:
     """Return JSON-serializable snapshots for all live vLLM KV pools."""
     return get_registered_kv_cache_pool_snapshot_dicts(integration="vllm")
+
+
+def kv_cache_pool_operation_snapshots():
+    """Return operation snapshots for all live vLLM KV pools."""
+    return get_registered_kv_cache_pool_operation_snapshots(integration="vllm")
+
+
+def kv_cache_pool_operation_snapshot_dicts() -> List[Dict[str, Any]]:
+    """Return JSON-serializable operation snapshots for live vLLM KV pools."""
+    return get_registered_kv_cache_pool_operation_snapshot_dicts(integration="vllm")
 
 
 def alloc_kv_cache(

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -181,6 +181,39 @@ class KVCacheManager:
 
         self.in_shrink: bool = False
         self.target_num_blocks: Optional[int] = None
+        self._operation_lock = threading.RLock()
+        self._operation_counters = {
+            "allocation_requests_total": 0,
+            "allocation_successes_total": 0,
+            "allocation_failures_total": 0,
+            "capacity_exhausted_total": 0,
+            "allocated_blocks_total": 0,
+            "free_requests_total": 0,
+            "free_successes_total": 0,
+            "free_failures_total": 0,
+            "freed_blocks_total": 0,
+            "physical_page_allocations_total": 0,
+            "physical_page_allocation_failures_total": 0,
+            "physical_page_frees_total": 0,
+            "resize_requests_total": 0,
+            "resize_successes_total": 0,
+            "resize_deferred_total": 0,
+            "resize_completions_total": 0,
+            "trim_requests_total": 0,
+            "trim_successes_total": 0,
+            "clear_requests_total": 0,
+            "clear_successes_total": 0,
+            "operation_errors_total": 0,
+            "post_init_errors_total": 0,
+            "allocation_errors_total": 0,
+            "free_errors_total": 0,
+            "resize_errors_total": 0,
+            "trim_errors_total": 0,
+            "clear_errors_total": 0,
+            "state_inconsistency_errors_total": 0,
+        }
+        self._last_error_code: Optional[str] = None
+        self._last_error_timestamp_ns: Optional[int] = None
         # NOTE: we use a no-op lock for sync scheduling to avoid overhead
         self._lock = threading.RLock() if async_sched else NoOpLock()
 
@@ -223,6 +256,10 @@ class KVCacheManager:
 
             self.page_allocator.start_prealloc_thread()
         except Exception as e:
+            self._record_operation_error(
+                "post_init_failed",
+                "post_init_errors_total",
+            )
             logger.error(
                 f"Error during KVCacheManager post-initialization: {e}")
             # Set the event even on error to unblock waiting threads
@@ -233,6 +270,25 @@ class KVCacheManager:
     def _wait_post_init(self):
         if not self._post_init_done.is_set():
             self._post_init_done.wait()
+
+    def _increment_operation_counter(self, name: str, value: int = 1) -> None:
+        with self._operation_lock:
+            counters = getattr(self, "_operation_counters", None)
+            if counters is None:
+                counters = {}
+                self._operation_counters = counters
+            counters[name] = counters.get(name, 0) + value
+
+    def _get_operation_counter(self, name: str) -> int:
+        with self._operation_lock:
+            return getattr(self, "_operation_counters", {}).get(name, 0)
+
+    def _record_operation_error(self, code: str, counter_name: str) -> None:
+        with self._operation_lock:
+            self._increment_operation_counter("operation_errors_total")
+            self._increment_operation_counter(counter_name)
+            self._last_error_code = code
+            self._last_error_timestamp_ns = time.time_ns()
 
     def _reserve_null_block(self) -> None:
         """
@@ -254,6 +310,33 @@ class KVCacheManager:
     def _alloc(self,
                need_size: int,
                _skip_wait: bool = False) -> Optional[List[int]]:
+        track_operation = not _skip_wait
+        if track_operation:
+            self._increment_operation_counter("allocation_requests_total")
+        try:
+            indices = self._alloc_impl(need_size, _skip_wait=_skip_wait)
+        except Exception:
+            if track_operation:
+                self._increment_operation_counter("allocation_failures_total")
+                self._record_operation_error(
+                    "allocation_failed",
+                    "allocation_errors_total",
+                )
+            raise
+
+        if not track_operation:
+            return indices
+        if indices is None:
+            self._increment_operation_counter("allocation_failures_total")
+            self._increment_operation_counter("capacity_exhausted_total")
+        else:
+            self._increment_operation_counter("allocation_successes_total")
+            self._increment_operation_counter("allocated_blocks_total", len(indices))
+        return indices
+
+    def _alloc_impl(self,
+                    need_size: int,
+                    _skip_wait: bool = False) -> Optional[List[int]]:
         if not _skip_wait:
             # Normal callers must wait until background initialisation is
             # finished and then perform the usual capacity check.
@@ -282,7 +365,14 @@ class KVCacheManager:
 
         while remaining_need > 0:  # Allocate the remaining blocks from pages
             if not self.avail_pages:
-                page = self.page_allocator.alloc_page()
+                try:
+                    page = self.page_allocator.alloc_page()
+                except Exception:
+                    self._increment_operation_counter(
+                        "physical_page_allocation_failures_total"
+                    )
+                    raise
+                self._increment_operation_counter("physical_page_allocations_total")
                 page.init(self.block_mem_size)
                 # A page may have zero usable blocks when block_mem_size is
                 # large (e.g. HYBRID_LINEAR) and every aligned block would
@@ -345,10 +435,30 @@ class KVCacheManager:
 
     @synchronized
     def free(self, indices: List[int]):
+        self._increment_operation_counter("free_requests_total")
+        errors_before = self._get_operation_counter("operation_errors_total")
+        try:
+            freed_blocks, had_inconsistency = self._free(indices)
+        except Exception:
+            self._increment_operation_counter("free_failures_total")
+            if self._get_operation_counter("operation_errors_total") == errors_before:
+                self._record_operation_error(
+                    "free_failed",
+                    "free_errors_total",
+                )
+            raise
+
+        if had_inconsistency:
+            self._increment_operation_counter("free_failures_total")
+        else:
+            self._increment_operation_counter("free_successes_total")
+        self._increment_operation_counter("freed_blocks_total", freed_blocks)
+
+    def _free(self, indices: List[int]) -> tuple[int, bool]:
         self._wait_post_init()
 
         if len(indices) == 0:
-            return  # Nothing to free
+            return 0, False  # Nothing to free
 
         if SANITY_CHECK:
             for idx in indices:
@@ -359,6 +469,8 @@ class KVCacheManager:
         idx_dict = self.page_allocator.group_indices_by_page(indices, self.block_mem_size)
 
         pages_to_free: List[int] = []
+        freed_blocks = 0
+        had_inconsistency = False
         for page_id, idxs in idx_dict.items():
             # Find the page - it must be in either full_pages or avail_pages
             page = None
@@ -367,6 +479,11 @@ class KVCacheManager:
             elif page_id in self.avail_pages:
                 page = self.avail_pages.pop(page_id)
             else:
+                had_inconsistency = True
+                self._record_operation_error(
+                    "state_inconsistency",
+                    "state_inconsistency_errors_total",
+                )
                 if SANITY_CHECK:
                     # This is a serious error - the page should exist
                     raise ValueError(
@@ -381,6 +498,7 @@ class KVCacheManager:
 
             self.num_avail_blocks += len(idxs)
             page.free_batch(idxs)
+            freed_blocks += len(idxs)
 
             if page.empty():
                 pages_to_free.append(page.page_id)
@@ -390,14 +508,20 @@ class KVCacheManager:
 
         if pages_to_free:
             self.page_allocator.free_pages(pages_to_free)
+            self._increment_operation_counter(
+                "physical_page_frees_total",
+                len(pages_to_free),
+            )
 
         if self.in_shrink:
             assert self.target_num_blocks is not None
             if self._get_num_alloced_blocks() <= self.target_num_blocks:
                 self.page_allocator.resize(self.target_num_blocks *
                                            self.block_mem_size)
+                self._increment_operation_counter("resize_completions_total")
                 self.in_shrink = False
                 self.target_num_blocks = None
+        return freed_blocks, had_inconsistency
 
     @synchronized
     def try_to_reserve(self, need_size: int) -> bool:
@@ -423,6 +547,23 @@ class KVCacheManager:
 
     @synchronized
     def resize(self, new_mem_size: int):
+        self._increment_operation_counter("resize_requests_total")
+        try:
+            resized = self._resize(new_mem_size)
+        except Exception:
+            self._record_operation_error(
+                "resize_failed",
+                "resize_errors_total",
+            )
+            raise
+
+        if resized:
+            self._increment_operation_counter("resize_successes_total")
+        else:
+            self._increment_operation_counter("resize_deferred_total")
+        return resized
+
+    def _resize(self, new_mem_size: int):
         """
         Reset the limit of the K or V tensor in one layer.
         new_mem_size: the memory size of the K or V tensor in one layer
@@ -447,6 +588,18 @@ class KVCacheManager:
 
     @synchronized
     def trim(self) -> None:
+        self._increment_operation_counter("trim_requests_total")
+        try:
+            self._trim()
+        except Exception:
+            self._record_operation_error(
+                "trim_failed",
+                "trim_errors_total",
+            )
+            raise
+        self._increment_operation_counter("trim_successes_total")
+
+    def _trim(self) -> None:
         """
         Trim the reserved pages to free up physical memory.
         """
@@ -532,7 +685,43 @@ class KVCacheManager:
         ).to_dict()
 
     @synchronized
+    def operation_snapshot(self, *, integration=None):
+        """Return monotonic operation counters for this KV cache pool."""
+        from kvcached.observability import build_kv_cache_pool_operation_snapshot
+        return build_kv_cache_pool_operation_snapshot(
+            self,
+            integration=integration,
+        )
+
+    @synchronized
+    def operation_snapshot_dict(self, *, integration=None):
+        """Return JSON-serializable operation counters for this KV cache pool."""
+        return self.operation_snapshot(
+            integration=integration,
+        ).to_dict()
+
+    def _get_operation_observability_state(self):
+        with self._operation_lock:
+            return (
+                dict(getattr(self, "_operation_counters", {})),
+                getattr(self, "_last_error_code", None),
+                getattr(self, "_last_error_timestamp_ns", None),
+            )
+
+    @synchronized
     def clear(self):
+        self._increment_operation_counter("clear_requests_total")
+        try:
+            self._clear()
+        except Exception:
+            self._record_operation_error(
+                "clear_failed",
+                "clear_errors_total",
+            )
+            raise
+        self._increment_operation_counter("clear_successes_total")
+
+    def _clear(self):
         """
         Free all allocated blocks and reset the allocator to initial state.
         """
@@ -556,6 +745,10 @@ class KVCacheManager:
             pages_to_free.append(page.page_id)
         if pages_to_free:
             self.page_allocator.free_pages(pages_to_free)
+            self._increment_operation_counter(
+                "physical_page_frees_total",
+                len(pages_to_free),
+            )
         self.avail_pages.clear()
         self.full_pages.clear()
 

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -69,6 +69,7 @@ class KVCacheManager:
         reserve_null_block: bool = False,
         num_kv_buffers: int = 2,
         group_id: int = 0,
+        pool_name: Optional[str] = None,
     ):
         """
         Args:
@@ -85,6 +86,8 @@ class KVCacheManager:
                 1 for MLA combined KV).
             group_id: KV cache group identifier for hybrid attention models.
                 Different groups have independent FTensors and page spaces.
+            pool_name: Stable, low-cardinality name assigned by the engine
+                integration when this pool is created.
         """
         self.num_blocks = num_blocks
         self.block_mem_size = block_size * cell_size
@@ -92,6 +95,7 @@ class KVCacheManager:
         self.num_kv_buffers = num_kv_buffers
         self.reserve_null_block = reserve_null_block
         self.group_id = group_id
+        self._pool_name = pool_name
 
         # The physical page size used by kvcached page allocator.
         self.page_size = PAGE_SIZE
@@ -505,6 +509,27 @@ class KVCacheManager:
             return memory_bytes / (1024**3)
         else:
             raise ValueError(f"Unknown unit: {unit}")
+
+    @property
+    def pool_name(self) -> Optional[str]:
+        """Return the stable name assigned when this pool was created."""
+        return self._pool_name
+
+    @synchronized
+    def observability_snapshot(self, *, integration=None):
+        """Return a read-only snapshot of this KV cache pool."""
+        from kvcached.observability import build_kv_cache_pool_snapshot
+        return build_kv_cache_pool_snapshot(
+            self,
+            integration=integration,
+        )
+
+    @synchronized
+    def observability_snapshot_dict(self, *, integration=None):
+        """Return a JSON-serializable read-only snapshot of this KV cache pool."""
+        return self.observability_snapshot(
+            integration=integration,
+        ).to_dict()
 
     @synchronized
     def clear(self):

--- a/kvcached/observability.py
+++ b/kvcached/observability.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Read-only observability snapshots for kvcached integrations.
+
+The structures in this module are intentionally policy-free.  They expose
+allocator and runtime state so monitoring systems or external control planes
+can consume kvcached status without depending on private patch details.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional
+
+from kvcached.pool_registry import get_registered_kv_cache_pools
+
+SCHEMA_VERSION = "kvcached.observability.v1"
+
+def _call_int(obj: Any, name: str) -> Optional[int]:
+    method = getattr(obj, name, None)
+    if method is None:
+        return None
+    return int(method())
+
+
+def _int_attr(obj: Any, name: str) -> Optional[int]:
+    value = getattr(obj, name, None)
+    if value is None:
+        return None
+    return int(value)
+
+
+@dataclass(frozen=True)
+class RuntimeSnapshot:
+    """Runtime integration state for an engine shim."""
+
+    schema_version: str
+    engine: str
+    initialized: bool
+    device: Optional[str]
+    world_size: int
+    pp_rank: int
+    async_sched: bool
+    contiguous_layout: bool
+    is_worker: Optional[bool] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class KVCachePoolSnapshot:
+    """Read-only state of one kvcached-backed KV pool."""
+
+    schema_version: str
+    pool_type: str
+    integration: Optional[str]
+    pool_name: Optional[str]
+    group_id: int
+    num_layers: int
+    num_kv_buffers: int
+    page_size_bytes: int
+    block_size_bytes: int
+    total_blocks: int
+    available_blocks: int
+    allocated_blocks: int
+    reserved_blocks: int
+    available_bytes: int
+    allocated_bytes: int
+    reserved_bytes: int
+    null_block_reserved: bool
+    virtual_per_layer_bytes: int
+    virtual_total_bytes: int
+    mapped_bytes: int
+    total_pages: Optional[int]
+    free_pages: Optional[int]
+    inuse_pages: Optional[int]
+    reserved_pages: Optional[int]
+    available_physical_pages: Optional[int]
+    effective_free_pages: Optional[int]
+    in_shrink: bool
+    shrink_target_blocks: Optional[int]
+    resize_target_bytes: Optional[int]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def get_capabilities() -> Dict[str, Any]:
+    """Return the stable observability surface currently exposed by kvcached."""
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "features": {
+            "runtime_snapshot": True,
+            "kv_cache_pool_snapshot": True,
+            "registered_kv_cache_pool_snapshots": True,
+            "read_only": True,
+            "policy_control": False,
+        },
+        "pool_snapshot_fields": list(KVCachePoolSnapshot.__dataclass_fields__.keys()),
+        "runtime_snapshot_fields": list(RuntimeSnapshot.__dataclass_fields__.keys()),
+    }
+
+
+def build_runtime_snapshot(
+    *,
+    engine: str,
+    initialized: bool,
+    device: Optional[str],
+    world_size: int,
+    pp_rank: int,
+    async_sched: bool,
+    contiguous_layout: bool,
+    is_worker: Optional[bool] = None,
+) -> RuntimeSnapshot:
+    return RuntimeSnapshot(
+        schema_version=SCHEMA_VERSION,
+        engine=engine,
+        initialized=initialized,
+        device=device,
+        world_size=world_size,
+        pp_rank=pp_rank,
+        async_sched=async_sched,
+        contiguous_layout=contiguous_layout,
+        is_worker=is_worker,
+    )
+
+
+def build_kv_cache_pool_snapshot(
+    manager: Any,
+    *,
+    integration: Optional[str] = None,
+) -> KVCachePoolSnapshot:
+    """Build a read-only snapshot from a ``KVCacheManager``-like object."""
+
+    allocator = manager.page_allocator
+    free_pages = _call_int(allocator, "get_num_free_pages")
+    reserved_pages = _call_int(allocator, "get_num_reserved_pages")
+    available_physical_pages = _call_int(allocator, "get_avail_physical_pages")
+    if free_pages is None or reserved_pages is None or available_physical_pages is None:
+        effective_free_pages = None
+    else:
+        effective_free_pages = min(free_pages, available_physical_pages + reserved_pages)
+
+    mapped_bytes = int(manager.get_mapped_memory_size("bytes"))
+    virtual_per_layer_bytes = _int_attr(manager, "mem_size") or 0
+    num_layers = _int_attr(manager, "num_layers") or 0
+    num_kv_buffers = _int_attr(manager, "num_kv_buffers") or 0
+    block_size_bytes = _int_attr(manager, "block_mem_size") or 0
+    bytes_per_block = block_size_bytes * num_layers * num_kv_buffers
+    available_blocks = int(manager.available_size())
+    allocated_blocks = int(manager._get_num_alloced_blocks())
+    reserved_blocks = len(getattr(manager, "reserved_blocks", []))
+
+    return KVCachePoolSnapshot(
+        schema_version=SCHEMA_VERSION,
+        pool_type="kv_cache",
+        integration=integration,
+        pool_name=getattr(manager, "pool_name", None),
+        group_id=_int_attr(manager, "group_id") or 0,
+        num_layers=num_layers,
+        num_kv_buffers=num_kv_buffers,
+        page_size_bytes=_int_attr(manager, "page_size") or 0,
+        block_size_bytes=block_size_bytes,
+        total_blocks=_int_attr(manager, "num_blocks") or 0,
+        available_blocks=available_blocks,
+        allocated_blocks=allocated_blocks,
+        reserved_blocks=reserved_blocks,
+        available_bytes=available_blocks * bytes_per_block,
+        allocated_bytes=allocated_blocks * bytes_per_block,
+        reserved_bytes=reserved_blocks * bytes_per_block,
+        null_block_reserved=getattr(manager, "null_block", None) is not None,
+        virtual_per_layer_bytes=virtual_per_layer_bytes,
+        virtual_total_bytes=virtual_per_layer_bytes * num_layers * num_kv_buffers,
+        mapped_bytes=mapped_bytes,
+        total_pages=_call_int(allocator, "get_num_total_pages"),
+        free_pages=free_pages,
+        inuse_pages=_call_int(allocator, "get_num_inuse_pages"),
+        reserved_pages=reserved_pages,
+        available_physical_pages=available_physical_pages,
+        effective_free_pages=effective_free_pages,
+        in_shrink=bool(getattr(manager, "in_shrink", False)),
+        shrink_target_blocks=getattr(manager, "target_num_blocks", None),
+        resize_target_bytes=_call_int(allocator, "get_resize_target"),
+    )
+
+
+def get_registered_kv_cache_pool_snapshots(
+    *,
+    integration: Optional[str] = None,
+) -> List[KVCachePoolSnapshot]:
+    """Return snapshots of currently live registered KV pools."""
+
+    snapshots = []
+    for manager, registered_integration in get_registered_kv_cache_pools(
+        integration=integration
+    ):
+        snapshots.append(
+            build_kv_cache_pool_snapshot(
+                manager,
+                integration=registered_integration,
+            )
+        )
+    return sorted(
+        snapshots,
+        key=lambda snapshot: (
+            snapshot.integration or "",
+            snapshot.pool_name or "",
+            snapshot.group_id,
+        ),
+    )
+
+
+def get_registered_kv_cache_pool_snapshot_dicts(
+    *,
+    integration: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Return JSON-serializable snapshots of currently live registered KV pools."""
+
+    return [
+        snapshot.to_dict()
+        for snapshot in get_registered_kv_cache_pool_snapshots(integration=integration)
+    ]

--- a/kvcached/observability.py
+++ b/kvcached/observability.py
@@ -17,6 +17,7 @@ from kvcached.pool_registry import get_registered_kv_cache_pools
 
 SCHEMA_VERSION = "kvcached.observability.v1"
 
+
 def _call_int(obj: Any, name: str) -> Optional[int]:
     method = getattr(obj, name, None)
     if method is None:
@@ -87,6 +88,50 @@ class KVCachePoolSnapshot:
         return asdict(self)
 
 
+@dataclass(frozen=True)
+class KVCachePoolOperationSnapshot:
+    """Monotonic operation counters for one kvcached-backed KV pool."""
+
+    schema_version: str
+    pool_type: str
+    integration: Optional[str]
+    pool_name: Optional[str]
+    group_id: int
+    allocation_requests_total: int
+    allocation_successes_total: int
+    allocation_failures_total: int
+    capacity_exhausted_total: int
+    allocated_blocks_total: int
+    free_requests_total: int
+    free_successes_total: int
+    free_failures_total: int
+    freed_blocks_total: int
+    physical_page_allocations_total: int
+    physical_page_allocation_failures_total: int
+    physical_page_frees_total: int
+    resize_requests_total: int
+    resize_successes_total: int
+    resize_deferred_total: int
+    resize_completions_total: int
+    trim_requests_total: int
+    trim_successes_total: int
+    clear_requests_total: int
+    clear_successes_total: int
+    operation_errors_total: int
+    post_init_errors_total: int
+    allocation_errors_total: int
+    free_errors_total: int
+    resize_errors_total: int
+    trim_errors_total: int
+    clear_errors_total: int
+    state_inconsistency_errors_total: int
+    last_error_code: Optional[str]
+    last_error_timestamp_ns: Optional[int]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
 def get_capabilities() -> Dict[str, Any]:
     """Return the stable observability surface currently exposed by kvcached."""
 
@@ -95,11 +140,16 @@ def get_capabilities() -> Dict[str, Any]:
         "features": {
             "runtime_snapshot": True,
             "kv_cache_pool_snapshot": True,
+            "kv_cache_pool_operation_snapshot": True,
             "registered_kv_cache_pool_snapshots": True,
+            "registered_kv_cache_pool_operation_snapshots": True,
             "read_only": True,
             "policy_control": False,
         },
         "pool_snapshot_fields": list(KVCachePoolSnapshot.__dataclass_fields__.keys()),
+        "pool_operation_snapshot_fields": list(
+            KVCachePoolOperationSnapshot.__dataclass_fields__.keys()
+        ),
         "runtime_snapshot_fields": list(RuntimeSnapshot.__dataclass_fields__.keys()),
     }
 
@@ -150,9 +200,9 @@ def build_kv_cache_pool_snapshot(
     num_kv_buffers = _int_attr(manager, "num_kv_buffers") or 0
     block_size_bytes = _int_attr(manager, "block_mem_size") or 0
     bytes_per_block = block_size_bytes * num_layers * num_kv_buffers
-    available_blocks = int(manager.available_size())
-    allocated_blocks = int(manager._get_num_alloced_blocks())
     reserved_blocks = len(getattr(manager, "reserved_blocks", []))
+    available_blocks = max(int(manager.available_size()) - reserved_blocks, 0)
+    allocated_blocks = max(int(manager._get_num_alloced_blocks()) - reserved_blocks, 0)
 
     return KVCachePoolSnapshot(
         schema_version=SCHEMA_VERSION,
@@ -184,6 +234,67 @@ def build_kv_cache_pool_snapshot(
         in_shrink=bool(getattr(manager, "in_shrink", False)),
         shrink_target_blocks=getattr(manager, "target_num_blocks", None),
         resize_target_bytes=_call_int(allocator, "get_resize_target"),
+    )
+
+
+def build_kv_cache_pool_operation_snapshot(
+    manager: Any,
+    *,
+    integration: Optional[str] = None,
+) -> KVCachePoolOperationSnapshot:
+    """Build an exporter-neutral operation snapshot from a manager-like object."""
+
+    get_state = getattr(manager, "_get_operation_observability_state", None)
+    if get_state is None:
+        counters = dict(getattr(manager, "_operation_counters", {}))
+        last_error_code = getattr(manager, "_last_error_code", None)
+        last_error_timestamp_ns = getattr(manager, "_last_error_timestamp_ns", None)
+    else:
+        counters, last_error_code, last_error_timestamp_ns = get_state()
+
+    def counter(name: str) -> int:
+        return int(counters.get(name, 0))
+
+    return KVCachePoolOperationSnapshot(
+        schema_version=SCHEMA_VERSION,
+        pool_type="kv_cache",
+        integration=integration,
+        pool_name=getattr(manager, "pool_name", None),
+        group_id=_int_attr(manager, "group_id") or 0,
+        allocation_requests_total=counter("allocation_requests_total"),
+        allocation_successes_total=counter("allocation_successes_total"),
+        allocation_failures_total=counter("allocation_failures_total"),
+        capacity_exhausted_total=counter("capacity_exhausted_total"),
+        allocated_blocks_total=counter("allocated_blocks_total"),
+        free_requests_total=counter("free_requests_total"),
+        free_successes_total=counter("free_successes_total"),
+        free_failures_total=counter("free_failures_total"),
+        freed_blocks_total=counter("freed_blocks_total"),
+        physical_page_allocations_total=counter("physical_page_allocations_total"),
+        physical_page_allocation_failures_total=counter(
+            "physical_page_allocation_failures_total"
+        ),
+        physical_page_frees_total=counter("physical_page_frees_total"),
+        resize_requests_total=counter("resize_requests_total"),
+        resize_successes_total=counter("resize_successes_total"),
+        resize_deferred_total=counter("resize_deferred_total"),
+        resize_completions_total=counter("resize_completions_total"),
+        trim_requests_total=counter("trim_requests_total"),
+        trim_successes_total=counter("trim_successes_total"),
+        clear_requests_total=counter("clear_requests_total"),
+        clear_successes_total=counter("clear_successes_total"),
+        operation_errors_total=counter("operation_errors_total"),
+        post_init_errors_total=counter("post_init_errors_total"),
+        allocation_errors_total=counter("allocation_errors_total"),
+        free_errors_total=counter("free_errors_total"),
+        resize_errors_total=counter("resize_errors_total"),
+        trim_errors_total=counter("trim_errors_total"),
+        clear_errors_total=counter("clear_errors_total"),
+        state_inconsistency_errors_total=counter(
+            "state_inconsistency_errors_total"
+        ),
+        last_error_code=last_error_code,
+        last_error_timestamp_ns=last_error_timestamp_ns,
     )
 
 
@@ -222,4 +333,44 @@ def get_registered_kv_cache_pool_snapshot_dicts(
     return [
         snapshot.to_dict()
         for snapshot in get_registered_kv_cache_pool_snapshots(integration=integration)
+    ]
+
+
+def get_registered_kv_cache_pool_operation_snapshots(
+    *,
+    integration: Optional[str] = None,
+) -> List[KVCachePoolOperationSnapshot]:
+    """Return operation snapshots of currently live registered KV pools."""
+
+    snapshots = []
+    for manager, registered_integration in get_registered_kv_cache_pools(
+        integration=integration
+    ):
+        snapshots.append(
+            build_kv_cache_pool_operation_snapshot(
+                manager,
+                integration=registered_integration,
+            )
+        )
+    return sorted(
+        snapshots,
+        key=lambda snapshot: (
+            snapshot.integration or "",
+            snapshot.pool_name or "",
+            snapshot.group_id,
+        ),
+    )
+
+
+def get_registered_kv_cache_pool_operation_snapshot_dicts(
+    *,
+    integration: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Return JSON-serializable operation snapshots of registered KV pools."""
+
+    return [
+        snapshot.to_dict()
+        for snapshot in get_registered_kv_cache_pool_operation_snapshots(
+            integration=integration
+        )
     ]

--- a/kvcached/pool_registry.py
+++ b/kvcached/pool_registry.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-local registry for live kvcached-backed KV pools."""
+
+from __future__ import annotations
+
+import threading
+import weakref
+from typing import Any, Dict, List, Optional, Tuple
+
+_registered_pools: Dict[int, Tuple[Any, Optional[str]]] = {}
+_registered_pools_lock = threading.RLock()
+
+
+def register_kv_cache_pool(
+    manager: Any,
+    *,
+    integration: Optional[str] = None,
+) -> None:
+    """Register a live KV pool without extending its lifetime."""
+
+    manager_id = id(manager)
+
+    def _remove(reference: Any) -> None:
+        with _registered_pools_lock:
+            current = _registered_pools.get(manager_id)
+            if current is not None and current[0] is reference:
+                _registered_pools.pop(manager_id, None)
+
+    reference = weakref.ref(manager, _remove)
+    with _registered_pools_lock:
+        _registered_pools[manager_id] = (reference, integration)
+
+
+def clear_registered_kv_cache_pools(*, integration: Optional[str] = None) -> None:
+    """Forget registered pools, optionally for one engine integration."""
+
+    with _registered_pools_lock:
+        if integration is None:
+            _registered_pools.clear()
+            return
+        stale_ids = [
+            manager_id
+            for manager_id, (_, registered_integration) in _registered_pools.items()
+            if registered_integration == integration
+        ]
+        for manager_id in stale_ids:
+            _registered_pools.pop(manager_id, None)
+
+
+def get_registered_kv_cache_pools(
+    *,
+    integration: Optional[str] = None,
+) -> List[Tuple[Any, Optional[str]]]:
+    """Return live KV managers and their engine integration metadata."""
+
+    with _registered_pools_lock:
+        entries = list(_registered_pools.values())
+
+    pools = []
+    for reference, registered_integration in entries:
+        if integration is not None and registered_integration != integration:
+            continue
+        manager = reference()
+        if manager is not None:
+            pools.append((manager, registered_integration))
+    return pools

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+if "torch" not in sys.modules and importlib.util.find_spec("torch") is None:
+    sys.modules.setdefault("torch", types.ModuleType("torch"))
+
+from kvcached.observability import (  # noqa: E402
+    build_kv_cache_pool_snapshot,
+    build_runtime_snapshot,
+    get_capabilities,
+    get_registered_kv_cache_pool_snapshot_dicts,
+)
+from kvcached.pool_registry import (  # noqa: E402
+    clear_registered_kv_cache_pools,
+    register_kv_cache_pool,
+)
+
+
+class FakePageAllocator:
+    def get_num_free_pages(self):
+        return 10
+
+    def get_num_inuse_pages(self):
+        return 6
+
+    def get_num_total_pages(self):
+        return 20
+
+    def get_num_reserved_pages(self):
+        return 2
+
+    def get_avail_physical_pages(self):
+        return 4
+
+    def get_resize_target(self):
+        return 0
+
+
+class FakeManager:
+    num_blocks = 128
+    block_mem_size = 4096
+    num_layers = 8
+    num_kv_buffers = 2
+    group_id = 3
+    pool_name = "full_attention"
+    page_size = 2 * 1024 * 1024
+    mem_size = num_blocks * block_mem_size
+    reserved_blocks = [0, 7]
+    null_block = [0]
+    in_shrink = False
+    target_num_blocks = None
+    page_allocator = FakePageAllocator()
+
+    def available_size(self):
+        return 64
+
+    def _get_num_alloced_blocks(self):
+        return 16
+
+    def get_mapped_memory_size(self, unit="bytes"):
+        assert unit == "bytes"
+        return 6 * self.num_layers * self.page_size * self.num_kv_buffers
+
+
+def test_capabilities_are_json_serializable():
+    capabilities = get_capabilities()
+
+    assert capabilities["schema_version"] == "kvcached.observability.v1"
+    assert capabilities["features"]["read_only"] is True
+    assert capabilities["features"]["policy_control"] is False
+    json.dumps(capabilities)
+
+
+def test_runtime_snapshot_dict():
+    snapshot = build_runtime_snapshot(
+        engine="vllm",
+        initialized=True,
+        device="cuda:0",
+        world_size=2,
+        pp_rank=1,
+        async_sched=True,
+        contiguous_layout=False,
+        is_worker=True,
+    )
+
+    assert snapshot.to_dict() == {
+        "schema_version": "kvcached.observability.v1",
+        "engine": "vllm",
+        "initialized": True,
+        "device": "cuda:0",
+        "world_size": 2,
+        "pp_rank": 1,
+        "async_sched": True,
+        "contiguous_layout": False,
+        "is_worker": True,
+    }
+
+
+def test_kv_cache_pool_snapshot_from_manager_like_object():
+    snapshot = build_kv_cache_pool_snapshot(
+        FakeManager(),
+        integration="sglang",
+    )
+    data = snapshot.to_dict()
+
+    assert data["pool_type"] == "kv_cache"
+    assert data["integration"] == "sglang"
+    assert data["pool_name"] == "full_attention"
+    assert data["group_id"] == 3
+    assert data["available_blocks"] == 64
+    assert data["allocated_blocks"] == 16
+    assert data["reserved_blocks"] == 2
+    bytes_per_block = 4096 * 8 * 2
+    assert data["available_bytes"] == 64 * bytes_per_block
+    assert data["allocated_bytes"] == 16 * bytes_per_block
+    assert data["reserved_bytes"] == 2 * bytes_per_block
+    assert data["null_block_reserved"] is True
+    assert data["virtual_total_bytes"] == 128 * 4096 * 8 * 2
+    assert data["mapped_bytes"] == 6 * 8 * (2 * 1024 * 1024) * 2
+    assert data["total_pages"] == 20
+    assert data["free_pages"] == 10
+    assert data["inuse_pages"] == 6
+    assert data["reserved_pages"] == 2
+    assert data["available_physical_pages"] == 4
+    assert data["effective_free_pages"] == 6
+    assert data["resize_target_bytes"] == 0
+    json.dumps(data)
+
+
+def test_registered_pool_snapshots_are_filtered_and_do_not_keep_managers_alive():
+    clear_registered_kv_cache_pools()
+    sglang_manager = FakeManager()
+    other_manager = FakeManager()
+    sglang_manager.pool_name = "mha"
+    other_manager.pool_name = "unified"
+    register_kv_cache_pool(
+        sglang_manager,
+        integration="sglang",
+    )
+    register_kv_cache_pool(
+        other_manager,
+        integration="vllm",
+    )
+
+    snapshots = get_registered_kv_cache_pool_snapshot_dicts(integration="sglang")
+
+    assert len(snapshots) == 1
+    assert snapshots[0]["integration"] == "sglang"
+    assert snapshots[0]["pool_name"] == "mha"
+
+    del sglang_manager
+    gc.collect()
+    assert get_registered_kv_cache_pool_snapshot_dicts(integration="sglang") == []
+    assert len(get_registered_kv_cache_pool_snapshot_dicts(integration="vllm")) == 1
+    clear_registered_kv_cache_pools()
+
+
+def test_sglang_manager_factory_registers_and_shutdown_clears_pool(monkeypatch):
+    clear_registered_kv_cache_pools()
+
+    torch = types.ModuleType("torch")
+    setattr(torch, "dtype", object)
+    setattr(torch, "Tensor", object)
+    setattr(torch, "cuda", types.SimpleNamespace(current_device=lambda: 0))
+
+    manager_module = types.ModuleType("kvcached.kv_cache_manager")
+
+    class FakeKVCacheManager(FakeManager):
+        def __init__(self, num_blocks, block_size, cell_size, num_layers, **kwargs):
+            self.num_blocks = num_blocks
+            self.block_mem_size = block_size * cell_size
+            self.num_layers = num_layers
+            self.num_kv_buffers = kwargs["num_kv_buffers"]
+            self.group_id = kwargs["group_id"]
+            self.pool_name = kwargs["pool_name"]
+            self.mem_size = num_blocks * self.block_mem_size
+            self.reserved_blocks = []
+            self.page_allocator = FakePageAllocator()
+
+    setattr(manager_module, "KVCacheManager", FakeKVCacheManager)
+
+    tp_ipc_module = types.ModuleType("kvcached.tp_ipc_util")
+    setattr(tp_ipc_module, "start_worker_listener_thread", lambda *args: None)
+
+    utils_module = types.ModuleType("kvcached.utils")
+    setattr(utils_module, "CONTIGUOUS_LAYOUT", False)
+    setattr(utils_module, "PAGE_SIZE", 2 * 1024 * 1024)
+    setattr(utils_module, "get_kvcached_logger", lambda: types.SimpleNamespace())
+    setattr(utils_module, "normalize_gpu_device", lambda device: device)
+
+    vmm_ops_module = types.ModuleType("kvcached.vmm_ops")
+    setattr(vmm_ops_module, "create_kv_tensors", lambda *args, **kwargs: [])
+    setattr(vmm_ops_module, "init_kvcached", lambda *args, **kwargs: None)
+    setattr(vmm_ops_module, "shutdown_kvcached", lambda: None)
+
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "kvcached.kv_cache_manager", manager_module)
+    monkeypatch.setitem(sys.modules, "kvcached.tp_ipc_util", tp_ipc_module)
+    monkeypatch.setitem(sys.modules, "kvcached.utils", utils_module)
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", vmm_ops_module)
+
+    module_path = (
+        Path(__file__).parents[1]
+        / "kvcached"
+        / "integration"
+        / "sglang"
+        / "interfaces.py"
+    )
+    spec = importlib.util.spec_from_file_location("_test_sglang_interfaces", module_path)
+    assert spec is not None and spec.loader is not None
+    interfaces = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(interfaces)
+    setattr(interfaces, "_kvcached_initialized", True)
+
+    manager = interfaces.get_kv_cache_manager(
+        128,
+        16,
+        256,
+        8,
+        group_id=4,
+        pool_name="mha",
+    )
+    snapshots = interfaces.kv_cache_pool_snapshot_dicts()
+
+    assert manager.group_id == 4
+    assert manager.pool_name == "mha"
+    assert len(snapshots) == 1
+    assert snapshots[0]["integration"] == "sglang"
+    assert snapshots[0]["pool_name"] == "mha"
+    assert snapshots[0]["group_id"] == 4
+
+    interfaces.shutdown_kvcached()
+    assert interfaces.kv_cache_pool_snapshot_dicts() == []
+def test_vllm_manager_factory_registers_and_shutdown_clears_pool(monkeypatch):
+    clear_registered_kv_cache_pools()
+
+    torch = types.ModuleType("torch")
+    setattr(torch, "dtype", object)
+    setattr(torch, "Tensor", object)
+    setattr(torch, "cuda", types.SimpleNamespace(current_device=lambda: 0))
+
+    manager_module = types.ModuleType("kvcached.kv_cache_manager")
+
+    class FakeKVCacheManager(FakeManager):
+        def __init__(
+            self,
+            num_blocks,
+            block_size,
+            cell_size,
+            num_layers,
+            world_size,
+            **kwargs,
+        ):
+            self.num_blocks = num_blocks
+            self.block_mem_size = block_size * cell_size
+            self.num_layers = num_layers
+            self.num_kv_buffers = kwargs["num_kv_buffers"]
+            self.group_id = kwargs["group_id"]
+            self.pool_name = kwargs["pool_name"]
+            self.mem_size = num_blocks * self.block_mem_size
+            self.reserved_blocks = []
+            self.page_allocator = FakePageAllocator()
+            self.world_size = world_size
+
+    setattr(manager_module, "KVCacheManager", FakeKVCacheManager)
+
+    tp_ipc_module = types.ModuleType("kvcached.tp_ipc_util")
+    setattr(tp_ipc_module, "start_worker_listener_thread", lambda *args: None)
+
+    utils_module = types.ModuleType("kvcached.utils")
+    setattr(utils_module, "CONTIGUOUS_LAYOUT", False)
+    setattr(utils_module, "PAGE_SIZE", 2 * 1024 * 1024)
+    setattr(utils_module, "get_kvcached_logger", lambda: types.SimpleNamespace())
+    setattr(utils_module, "normalize_gpu_device", lambda device: device)
+
+    vmm_ops_module = types.ModuleType("kvcached.vmm_ops")
+    setattr(vmm_ops_module, "create_kv_tensors", lambda *args, **kwargs: [])
+    setattr(vmm_ops_module, "init_kvcached", lambda *args, **kwargs: None)
+    setattr(vmm_ops_module, "shutdown_kvcached", lambda: None)
+
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "kvcached.kv_cache_manager", manager_module)
+    monkeypatch.setitem(sys.modules, "kvcached.tp_ipc_util", tp_ipc_module)
+    monkeypatch.setitem(sys.modules, "kvcached.utils", utils_module)
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", vmm_ops_module)
+
+    module_path = (
+        Path(__file__).parents[1]
+        / "kvcached"
+        / "integration"
+        / "vllm"
+        / "interfaces.py"
+    )
+    spec = importlib.util.spec_from_file_location("_test_vllm_interfaces", module_path)
+    assert spec is not None and spec.loader is not None
+    interfaces = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(interfaces)
+    setattr(interfaces, "_kvcached_initialized", True)
+
+    manager = interfaces.get_kv_cache_manager(
+        128,
+        16,
+        256,
+        8,
+        group_id=5,
+        pool_name="unified",
+    )
+    snapshots = interfaces.kv_cache_pool_snapshot_dicts()
+
+    assert manager.group_id == 5
+    assert manager.pool_name == "unified"
+    assert manager.world_size == 1
+    assert len(snapshots) == 1
+    assert snapshots[0]["integration"] == "vllm"
+    assert snapshots[0]["pool_name"] == "unified"
+    assert snapshots[0]["group_id"] == 5
+
+    interfaces.shutdown_kvcached()
+    assert interfaces.kv_cache_pool_snapshot_dicts() == []

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -5,6 +5,7 @@ import gc
 import importlib.util
 import json
 import sys
+import threading
 import types
 from pathlib import Path
 
@@ -12,9 +13,11 @@ if "torch" not in sys.modules and importlib.util.find_spec("torch") is None:
     sys.modules.setdefault("torch", types.ModuleType("torch"))
 
 from kvcached.observability import (  # noqa: E402
+    build_kv_cache_pool_operation_snapshot,
     build_kv_cache_pool_snapshot,
     build_runtime_snapshot,
     get_capabilities,
+    get_registered_kv_cache_pool_operation_snapshot_dicts,
     get_registered_kv_cache_pool_snapshot_dicts,
 )
 from kvcached.pool_registry import (  # noqa: E402
@@ -57,6 +60,22 @@ class FakeManager:
     in_shrink = False
     target_num_blocks = None
     page_allocator = FakePageAllocator()
+    _operation_counters = {
+        "allocation_requests_total": 7,
+        "allocation_successes_total": 5,
+        "allocation_failures_total": 2,
+        "capacity_exhausted_total": 1,
+        "allocated_blocks_total": 40,
+        "free_requests_total": 4,
+        "free_successes_total": 4,
+        "freed_blocks_total": 24,
+        "physical_page_allocations_total": 3,
+        "physical_page_frees_total": 2,
+        "operation_errors_total": 1,
+        "allocation_errors_total": 1,
+    }
+    _last_error_code = "allocation_failed"
+    _last_error_timestamp_ns = 123456789
 
     def available_size(self):
         return 64
@@ -69,12 +88,197 @@ class FakeManager:
         return 6 * self.num_layers * self.page_size * self.num_kv_buffers
 
 
+def test_kv_cache_manager_records_operation_counters_without_exporter(monkeypatch):
+    class FakeInternalPage:
+        page_id = 0
+
+        def __init__(self):
+            self.free_indices = list(range(8))
+
+        @staticmethod
+        def get_num_blocks(page_size, block_mem_size):
+            return 8
+
+        def init(self, block_mem_size):
+            assert block_mem_size > 0
+
+        def num_free_blocks(self):
+            return len(self.free_indices)
+
+        def alloc(self, count):
+            indices = self.free_indices[:count]
+            self.free_indices = self.free_indices[count:]
+            return indices
+
+        def free_batch(self, indices):
+            self.free_indices.extend(indices)
+            self.free_indices.sort()
+
+        def full(self):
+            return not self.free_indices
+
+        def empty(self):
+            return len(self.free_indices) == 8
+
+    class FakeOperationPageAllocator:
+        def __init__(self, *args, **kwargs):
+            self.page = FakeInternalPage()
+            self.page_inuse = False
+            self.fail_alloc = False
+
+        def set_should_use_worker_ipc_callback(self, callback):
+            self.should_use_worker_ipc = callback
+
+        def alloc_page(self):
+            if self.fail_alloc:
+                raise RuntimeError("injected allocation failure")
+            self.page_inuse = True
+            return self.page
+
+        def free_pages(self, page_ids):
+            assert page_ids == [0]
+            self.page_inuse = False
+
+        def group_indices_by_page(self, indices, block_mem_size):
+            return {0: indices}
+
+        def get_resize_target(self):
+            return 0
+
+        def resize(self, new_mem_size):
+            return True
+
+        def trim(self):
+            return None
+
+        def start_prealloc_thread(self):
+            return None
+
+        def get_num_free_pages(self):
+            return int(not self.page_inuse)
+
+        def get_avail_physical_pages(self):
+            return int(not self.page_inuse)
+
+        def get_num_reserved_pages(self):
+            return 0
+
+    vmm_ops_module = types.ModuleType("kvcached.vmm_ops")
+    setattr(vmm_ops_module, "InternalPage", FakeInternalPage)
+    setattr(vmm_ops_module, "PageAllocator", FakeOperationPageAllocator)
+    setattr(vmm_ops_module, "kv_tensors_created", lambda group_id=0: True)
+
+    tp_ipc_module = types.ModuleType("kvcached.tp_ipc_util")
+    setattr(tp_ipc_module, "broadcast_kv_tensors_created", lambda *args, **kwargs: True)
+
+    vllm_interfaces_module = types.ModuleType("kvcached.integration.vllm.interfaces")
+    setattr(vllm_interfaces_module, "should_use_worker_ipc", lambda: False)
+
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", vmm_ops_module)
+    monkeypatch.setitem(sys.modules, "kvcached.tp_ipc_util", tp_ipc_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "kvcached.integration.vllm.interfaces",
+        vllm_interfaces_module,
+    )
+
+    module_path = Path(__file__).parents[1] / "kvcached" / "kv_cache_manager.py"
+    spec = importlib.util.spec_from_file_location("_test_operation_manager", module_path)
+    assert spec is not None and spec.loader is not None
+    manager_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(manager_module)
+
+    manager = manager_module.KVCacheManager(
+        num_blocks=8,
+        block_size=1,
+        cell_size=256,
+        num_layers=2,
+        pool_name="unit",
+    )
+    assert manager._post_init_done.wait(timeout=1)
+
+    assert manager.alloc(manager.available_size() + 1) is None
+    indices = manager.alloc(2)
+    assert indices == [0, 1]
+    manager.free(indices)
+    assert manager.resize(manager.mem_size) is True
+    manager.trim()
+
+    data = manager.operation_snapshot_dict(integration="test")
+    assert data["allocation_requests_total"] == 2
+    assert data["allocation_successes_total"] == 1
+    assert data["allocation_failures_total"] == 1
+    assert data["capacity_exhausted_total"] == 1
+    assert data["allocated_blocks_total"] == 2
+    assert data["free_requests_total"] == 1
+    assert data["free_successes_total"] == 1
+    assert data["freed_blocks_total"] == 2
+    assert data["physical_page_allocations_total"] == 1
+    assert data["physical_page_frees_total"] == 1
+    assert data["resize_successes_total"] == 1
+    assert data["trim_successes_total"] == 1
+
+    manager.page_allocator.fail_alloc = True
+    try:
+        allocation_result = manager.alloc(1)
+    except RuntimeError as error:
+        assert str(error) == "injected allocation failure"
+        expected_error_count = 1
+        expected_capacity_miss_count = 1
+    else:
+        assert allocation_result is None
+        expected_error_count = 0
+        expected_capacity_miss_count = 2
+
+    error_data = manager.operation_snapshot_dict()
+    assert error_data["physical_page_allocation_failures_total"] == 1
+    assert error_data["capacity_exhausted_total"] == expected_capacity_miss_count
+    assert error_data["operation_errors_total"] == expected_error_count
+    assert error_data["allocation_errors_total"] == expected_error_count
+    if expected_error_count:
+        assert error_data["last_error_code"] == "allocation_failed"
+        assert error_data["last_error_timestamp_ns"] is not None
+    else:
+        assert error_data["last_error_code"] is None
+        assert error_data["last_error_timestamp_ns"] is None
+
+    error_count_before = error_data["operation_errors_total"]
+    worker_count = 4
+    errors_per_worker = 1000
+
+    def record_errors():
+        for _ in range(errors_per_worker):
+            manager._record_operation_error(
+                "concurrent_failure",
+                "post_init_errors_total",
+            )
+
+    workers = [threading.Thread(target=record_errors) for _ in range(worker_count)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join()
+
+    concurrent_data = manager.operation_snapshot_dict()
+    assert concurrent_data["operation_errors_total"] == (
+        error_count_before + worker_count * errors_per_worker
+    )
+    assert concurrent_data["post_init_errors_total"] == worker_count * errors_per_worker
+    assert concurrent_data["last_error_code"] == "concurrent_failure"
+
+    assert manager._get_operation_counter("operation_errors_total") == (
+        error_count_before + worker_count * errors_per_worker
+    )
+    assert manager._get_operation_counter("not_recorded") == 0
+
+
 def test_capabilities_are_json_serializable():
     capabilities = get_capabilities()
 
     assert capabilities["schema_version"] == "kvcached.observability.v1"
     assert capabilities["features"]["read_only"] is True
     assert capabilities["features"]["policy_control"] is False
+    assert capabilities["features"]["kv_cache_pool_operation_snapshot"] is True
     json.dumps(capabilities)
 
 
@@ -114,12 +318,12 @@ def test_kv_cache_pool_snapshot_from_manager_like_object():
     assert data["integration"] == "sglang"
     assert data["pool_name"] == "full_attention"
     assert data["group_id"] == 3
-    assert data["available_blocks"] == 64
-    assert data["allocated_blocks"] == 16
+    assert data["available_blocks"] == 62
+    assert data["allocated_blocks"] == 14
     assert data["reserved_blocks"] == 2
     bytes_per_block = 4096 * 8 * 2
-    assert data["available_bytes"] == 64 * bytes_per_block
-    assert data["allocated_bytes"] == 16 * bytes_per_block
+    assert data["available_bytes"] == 62 * bytes_per_block
+    assert data["allocated_bytes"] == 14 * bytes_per_block
     assert data["reserved_bytes"] == 2 * bytes_per_block
     assert data["null_block_reserved"] is True
     assert data["virtual_total_bytes"] == 128 * 4096 * 8 * 2
@@ -131,6 +335,31 @@ def test_kv_cache_pool_snapshot_from_manager_like_object():
     assert data["available_physical_pages"] == 4
     assert data["effective_free_pages"] == 6
     assert data["resize_target_bytes"] == 0
+    json.dumps(data)
+
+
+def test_kv_cache_pool_operation_snapshot_from_manager_like_object():
+    snapshot = build_kv_cache_pool_operation_snapshot(
+        FakeManager(),
+        integration="sglang",
+    )
+    data = snapshot.to_dict()
+
+    assert data["integration"] == "sglang"
+    assert data["pool_name"] == "full_attention"
+    assert data["group_id"] == 3
+    assert data["allocation_requests_total"] == 7
+    assert data["allocation_successes_total"] == 5
+    assert data["allocation_failures_total"] == 2
+    assert data["capacity_exhausted_total"] == 1
+    assert data["allocated_blocks_total"] == 40
+    assert data["free_requests_total"] == 4
+    assert data["freed_blocks_total"] == 24
+    assert data["physical_page_allocations_total"] == 3
+    assert data["physical_page_frees_total"] == 2
+    assert data["resize_requests_total"] == 0
+    assert data["last_error_code"] == "allocation_failed"
+    assert data["last_error_timestamp_ns"] == 123456789
     json.dumps(data)
 
 
@@ -150,10 +379,15 @@ def test_registered_pool_snapshots_are_filtered_and_do_not_keep_managers_alive()
     )
 
     snapshots = get_registered_kv_cache_pool_snapshot_dicts(integration="sglang")
+    operation_snapshots = get_registered_kv_cache_pool_operation_snapshot_dicts(
+        integration="sglang"
+    )
 
     assert len(snapshots) == 1
     assert snapshots[0]["integration"] == "sglang"
     assert snapshots[0]["pool_name"] == "mha"
+    assert len(operation_snapshots) == 1
+    assert operation_snapshots[0]["allocation_requests_total"] == 7
 
     del sglang_manager
     gc.collect()
@@ -228,6 +462,7 @@ def test_sglang_manager_factory_registers_and_shutdown_clears_pool(monkeypatch):
         pool_name="mha",
     )
     snapshots = interfaces.kv_cache_pool_snapshot_dicts()
+    operation_snapshots = interfaces.kv_cache_pool_operation_snapshot_dicts()
 
     assert manager.group_id == 4
     assert manager.pool_name == "mha"
@@ -235,9 +470,14 @@ def test_sglang_manager_factory_registers_and_shutdown_clears_pool(monkeypatch):
     assert snapshots[0]["integration"] == "sglang"
     assert snapshots[0]["pool_name"] == "mha"
     assert snapshots[0]["group_id"] == 4
+    assert len(operation_snapshots) == 1
+    assert operation_snapshots[0]["integration"] == "sglang"
 
     interfaces.shutdown_kvcached()
     assert interfaces.kv_cache_pool_snapshot_dicts() == []
+    assert interfaces.kv_cache_pool_operation_snapshot_dicts() == []
+
+
 def test_vllm_manager_factory_registers_and_shutdown_clears_pool(monkeypatch):
     clear_registered_kv_cache_pools()
 
@@ -313,6 +553,7 @@ def test_vllm_manager_factory_registers_and_shutdown_clears_pool(monkeypatch):
         pool_name="unified",
     )
     snapshots = interfaces.kv_cache_pool_snapshot_dicts()
+    operation_snapshots = interfaces.kv_cache_pool_operation_snapshot_dicts()
 
     assert manager.group_id == 5
     assert manager.pool_name == "unified"
@@ -321,6 +562,9 @@ def test_vllm_manager_factory_registers_and_shutdown_clears_pool(monkeypatch):
     assert snapshots[0]["integration"] == "vllm"
     assert snapshots[0]["pool_name"] == "unified"
     assert snapshots[0]["group_id"] == 5
+    assert len(operation_snapshots) == 1
+    assert operation_snapshots[0]["integration"] == "vllm"
 
     interfaces.shutdown_kvcached()
     assert interfaces.kv_cache_pool_snapshot_dicts() == []
+    assert interfaces.kv_cache_pool_operation_snapshot_dicts() == []


### PR DESCRIPTION
## Operation Accounting

Related to #375. Add exporter-neutral counters for manager operations and bounded error metadata, exposed through the existing vLLM and SGLang snapshot interfaces. Metrics backends remain outside the allocator.

Pool occupancy alone cannot distinguish successful allocation, recoverable capacity rejection, and a broken mapping transaction. A consumer attaching after an error also needs cumulative event counts, not a history entry created only when someone requests a snapshot.

## Execution Path

The manager records requests before allocation, outcomes after allocation, and completed progress during free. The allocation decision and native mapping protocol are unchanged. State-consistency exceptions from #418 still propagate; they are not turned into ordinary capacity rejection.

The implementation is in [`KVCacheManager`](https://github.com/shipiyouniao/kvcached/blob/740c74dd0aa3b4af6fe3f33cc0b72ee06354416d/kvcached/kv_cache_manager.py#L451):

```python
indices = self._alloc_impl(need_size, _skip_wait=_skip_wait)
if indices is None:
    self._increment_operation_counter("allocation_failures_total")
    self._increment_operation_counter("capacity_exhausted_total")
else:
    self._increment_operation_counter("allocation_successes_total")
    self._increment_operation_counter("allocated_blocks_total", len(indices))
```

`manager_page_allocations_total` and `manager_page_releases_total` count manager-page handoffs, including reserved-page reuse. They do not claim to count CUDA physical map/unmap operations: native preallocation, trimming and resizing have a different accounting boundary. Caller-free block counts retain completed progress if a later page release fails. Internal allocation rollback does not inflate those counts. Rejected deferred resize does not count as completed resize.

Before:

```mermaid
sequenceDiagram
    participant E as Engine
    participant M as KV manager
    participant A as Native allocator
    participant C as Metrics consumer
    E->>M: Allocate / free
    M->>A: Existing page operation
    A-->>M: Result or exception
    M-->>E: Existing result
    C->>M: Pool snapshot
    M-->>C: Current occupancy
```

After:

```mermaid
sequenceDiagram
    participant E as Engine
    participant M as KV manager
    participant A as Native allocator
    participant C as Metrics consumer
    E->>M: Allocate / free
    M->>M: Record request
    M->>A: Unchanged page operation
    A-->>M: Result or exception
    M->>M: Record outcome and completed progress
    M-->>E: Preserve result / exception
    C->>M: Operation snapshot
    M-->>C: Cumulative counters and bounded last-error metadata
```

## Concurrency and Cost

Counters use a per-manager lock, not a process-wide history lock. Reading a snapshot copies counters under that same lock. The allocation hot path still incurs counter updates even if no consumer is scraping, so read-only snapshots alone are not evidence of negligible cost. Validation below separates that cost from periodic snapshot collection.

The capability API added by #474 now advertises operation counters and lists the actual cumulative counter names. The list is derived from the snapshot schema, excludes last-error metadata, and leaves the upstream backend and integration capability fields intact.

## Validation

Current head: `740c74dd0aa3b4af6fe3f33cc0b72ee06354416d`, rebased on `main` at `7af4a2245e5cf6ffe4f22bf712a552ac1f8de72b` after #474 merged. The full CI matrix and native GPU fault tests below were rerun on this exact head.

| Check | Result |
| --- | --- |
| C++ CPU suite and full pre-commit | Passed |
| Python 3.9-3.13 CPU suites | 311 passed per version |
| Python 3.9-3.13 MyPy | Passed |
| Native CUDA/VMM regression suite on T4 | 88 passed |
| Actual native allocation-failure injection | One hit; counted once; retry and CUDA readback succeeded |
| Unknown peer result injected at the broadcast callback | State-consistency error propagated and allocator failed closed, without counting ordinary capacity exhaustion |
| Reserved-page reuse and later trim | Two manager handoffs counted; no claim of two physical mappings |
| Post-rebase two-engine vLLM serving regression, no sampling and 10 Hz sampling | 64/64 requests, 8192/8192 output tokens, normal chat and health checks passed; 1241 samples, zero collection errors |

### Allocation Microbenchmark

The performance measurements in this and the following section were collected on the pre-rebase candidate `5a4b3ae99f51365a85d5cc0ae906c6e970509859` against `944ed53399f989afc1317734e689c406cde2b097`. The rebase adds capability discovery integration and tests; `kv_cache_manager.py`, native allocator code and vLLM patches are unchanged from the measured candidate. These are retained measurements, not a new A/B run on the current head.

Real VMM-backed managers on one T4, preallocation and reserved pages disabled. An anchor block keeps the current page mapped, so each timed iteration allocates and frees one other block without paying for a new CUDA mapping. There are 50,000 iterations per round, one discarded warmup and five measured rounds; runs are ordered baseline/candidate/candidate/baseline. The table reports the median of ten measured round averages per configuration. Every run ends with CUDA readback verification.

| Pools | Snapshot rate | Baseline alloc/free pair | This PR |
| --- | --- | --- | --- |
| 1 | None | 21.469 us | 26.729 us |
| 1 | 1 Hz | 21.704 us | 26.610 us |
| 1 | 10 Hz | 21.846 us | 26.725 us |
| 8 | None | 21.592 us | 26.422 us |
| 8 | 1 Hz | 21.799 us | 27.081 us |
| 8 | 10 Hz | 22.156 us | 26.485 us |

The counters add about 5 us per alloc/free pair in this tight loop, roughly 22-25% without sampling. This is a measurable hot-path cost, not a claim of free observability. Periodic sampling does not materially amplify it in these tests. It also does not follow that model serving loses the same percentage: the serving comparison below measures that separately.

### Serving Comparison

One T4 runs two independent TP1 vLLM 0.28.0 V1 engines, Qwen2.5-0.5B-Instruct FP16, Triton attention, CUDA graph capture size 64, synchronous scheduling and prefix caching. Both revisions use 2 MiB pages, preallocation off, zero reserved pages, a 4096-token prefix cap, `KVCACHED_GPU_UTILIZATION=0.9`, and the same explicit 10 GiB logical KV capacity per engine. Engine limits are 8192 model tokens, 2048 batched tokens and 64 sequences. MPS is not enabled.

Each engine uses three warmups, fixed random-dataset seeds, temperature 0 and `ignore_eos`:

- Ordinary load: I256/O128, N32/C4, 4 requests/s.
- Memory pressure: I4096/O128, N64/C32, unlimited arrival rate. A separate fixed CUDA allocation leaves about 3.1 GiB device free before the workload on both revisions.

Runs are baseline/candidate/candidate/baseline, with 768/768 successful benchmark requests and all expected output tokens produced. Health and normal chat probes pass before and after each run. Combined throughput below is total output tokens divided by the longer of the two engines' timed benchmark intervals, averaged over the two runs of each revision.

| Workload | Baseline combined tok/s | This PR combined tok/s | Change | Baseline / PR mean TPOT |
| --- | --- | --- | --- | --- |
| Ordinary | 537.04 | 534.71 | -0.43% | 13.760 / 13.814 ms |
| Memory pressure | 80.883 | 80.508 | -0.46% | 364.643 / 367.866 ms |

These runs show a small end-to-end difference, not the roughly 25% difference in the isolated tight loop. They do not establish zero overhead or statistical equivalence. Sampling runs are reported below separately.

Two further runs sampled live pool and operation snapshots at 1 Hz and 10 Hz. These are single-run sampling checks, not another repeated A/B experiment:

| This PR sampling rate | Ordinary combined tok/s | Pressure combined tok/s | Samples / errors across both engines |
| --- | --- | --- | --- |
| None, two-run mean | 534.71 | 80.508 | Not sampled |
| 1 Hz | 537.43 | 80.850 | 500 / 0 |
| 10 Hz | 534.00 | 80.764 | 4974 / 0 |

Including those checks, all 1152 benchmark requests produced the full 147456 output tokens. No CUDA error, OOM, illegal memory access or EngineCore failure was found in the serving logs. Services were stopped by the test harness after their recovery probes; the T4 returned to idle.

The T4 tests cover single-GPU accounting, readback, error propagation and sampling. They do not establish multi-GPU transaction safety or large-model TP/MPS performance.
