### PR TITLE
fix(sglang): support SGLang 0.5.13+ 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ GPT-OSS support in SGLang updated to **v0.5.9**.
 
 | Engine | Versions | Attention types | Example models |
 |--------|----------|-----------------|----------------|
-| SGLang | ≥ v0.4.9 (tested up to v0.5.10) | MHA / GQA / MLA | Llama 3.1/3.3, Qwen 2.5, DeepSeek-V3, openai/gpt-oss-20b, etc. |
+| SGLang | ≥ v0.4.9 (tested up to v0.5.15) | MHA / GQA / MLA | Llama 3.1/3.3, Qwen 2.5, DeepSeek-V3, openai/gpt-oss-20b, etc. |
 | vLLM | ≥ v0.8.4 (tested up to v0.24.0) | MHA / GQA / MLA | Llama 3.1/3.3, Qwen 2.5, DeepSeek-V3, openai/gpt-oss-20b |
 
 ## Example use cases
@@ -126,7 +126,7 @@ Details can be found in [benchmarks/bench_latency_benefit](https://github.com/ov
 ### Prerequisites
 
 - Python (tested with 3.9 - 3.13)
-- SGLang (tested with v0.5.10) or vLLM (tested with v0.19.0)
+- SGLang (tested with v0.5.15) or vLLM (tested with v0.19.0)
 
 kvcached can be installed as a plugin with existing SGLang or vLLM environment.
 

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -150,8 +150,21 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
             import torch
 
             BaseTokenToKVPoolAllocator = getattr(alloc_mod, "BaseTokenToKVPoolAllocator")
-            alloc_extend_kernel = getattr(alloc_mod, "alloc_extend_kernel")
-            alloc_decode_kernel = getattr(alloc_mod, "alloc_decode_kernel")
+            try:
+                alloc_extend_kernel = getattr(alloc_mod, "alloc_extend_kernel")
+                alloc_decode_kernel = getattr(alloc_mod, "alloc_decode_kernel")
+            except AttributeError:
+                from sglang.srt.mem_cache.triton_ops import allocator as triton_allocator
+
+                alloc_extend_kernel = triton_allocator.alloc_extend_kernel
+                alloc_decode_kernel = triton_allocator.alloc_decode_kernel
+
+            alloc_extend_kernel_fn = getattr(
+                alloc_extend_kernel, "fn", alloc_extend_kernel
+            )
+            alloc_extend_uses_max_tokens = (
+                len(inspect.signature(alloc_extend_kernel_fn).parameters) == 8
+            )
 
             from sglang.srt.utils import get_num_new_pages, next_power_of_2
 
@@ -205,6 +218,7 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
                     seq_lens_cpu: torch.Tensor,
                     last_loc: torch.Tensor,
                     extend_num_tokens: int,
+                    num_new_pages: Optional[int] = None,
                 ):
                     self.seen_max_num_extend_tokens_next_power_of_2 = max(
                         self.seen_max_num_extend_tokens_next_power_of_2,
@@ -212,11 +226,12 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
                     )
                     bs = len(prefix_lens)
 
-                    num_new_pages = get_num_new_pages(
-                        seq_lens=seq_lens_cpu,
-                        page_size=self.page_size,
-                        prefix_lens=prefix_lens_cpu,
-                    )
+                    if num_new_pages is None:
+                        num_new_pages = get_num_new_pages(
+                            seq_lens=seq_lens_cpu,
+                            page_size=self.page_size,
+                            prefix_lens=prefix_lens_cpu,
+                        )
 
                     if num_new_pages > 0:
                         block_ids = self.kvcached_allocator.alloc(num_new_pages)
@@ -231,7 +246,7 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
                     out_indices = torch.empty(
                         (extend_num_tokens,), dtype=torch.int64, device=self.device
                     )
-                    alloc_extend_kernel[(bs,)](
+                    kernel_args: List[Any] = [
                         prefix_lens,
                         seq_lens,
                         last_loc,
@@ -239,8 +254,12 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
                         out_indices,
                         next_power_of_2(bs),
                         self.page_size,
-                        self.seen_max_num_extend_tokens_next_power_of_2,
-                    )
+                    ]
+                    if alloc_extend_uses_max_tokens:
+                        kernel_args.append(
+                            self.seen_max_num_extend_tokens_next_power_of_2
+                        )
+                    alloc_extend_kernel[(bs,)](*kernel_args)
                     return out_indices
 
                 def alloc_decode(
@@ -1234,8 +1253,8 @@ class SchedulerMemoryLeakPatch(VersionAwarePatch, BasePatch):
 
         Older SGLang keeps the whole check in a single Scheduler method whose
         source mentions ``token_to_kv_pool_allocator``.  Newer SGLang
-        (>=0.5.11) moved it into ``SchedulerRuntimeCheckerMixin`` and split it
-        across several small methods (e.g. ``_check_req_pool`` raises directly,
+        moved it into helpers such as ``SchedulerRuntimeCheckerMixin`` or
+        ``SchedulerInvariantChecker`` (e.g. ``_check_req_pool`` raises directly,
         ``_report_leak`` is the generic choke point for *token/KV* pool leaks).
 
         We suppress only the leak checks for pools kvcached actually manages
@@ -1251,23 +1270,31 @@ class SchedulerMemoryLeakPatch(VersionAwarePatch, BasePatch):
         if Scheduler is None:
             return False
 
-        target_method_names: List[str] = []
-        for name, fn in inspect.getmembers(Scheduler, predicate=inspect.isfunction):
-            try:
-                src = inspect.getsource(fn)
-            except Exception:
-                continue
-            if "memory leak detected" not in src:
-                continue
-            # Skip a check that is specific to the request pool, which kvcached
-            # does not manage.  The generic reporter names no pool (so it is not
-            # excluded) and the legacy combined check names the KV allocator.
-            if "req_to_token_pool" in src and "token_to_kv_pool" not in src:
-                continue
-            target_method_names.append(name)
+        target_classes: List[Tuple[str, Any]] = [("Scheduler", Scheduler)]
+        InvariantChecker = getattr(sched_mod, "SchedulerInvariantChecker", None)
+        if InvariantChecker is not None:
+            target_classes.append(("SchedulerInvariantChecker", InvariantChecker))
 
-        if not target_method_names:
-            self.logger.debug("No memory leak detection method found in Scheduler")
+        target_methods: List[Tuple[str, Any, str]] = []
+        for class_name, cls in target_classes:
+            for name, fn in inspect.getmembers(cls, predicate=inspect.isfunction):
+                try:
+                    src = inspect.getsource(fn)
+                except Exception:
+                    continue
+                if "memory leak detected" not in src:
+                    continue
+                # Skip a check that is specific to the request pool, which kvcached
+                # does not manage.  The generic reporter names no pool (so it is not
+                # excluded) and the legacy combined check names the KV allocator.
+                if "req_to_token_pool" in src and "token_to_kv_pool" not in src:
+                    continue
+                target_methods.append((class_name, cls, name))
+
+        if not target_methods:
+            self.logger.debug(
+                "No memory leak detection method found in SGLang scheduler"
+            )
             return False
 
         def _make_wrapped(original: Callable[..., Any]) -> Callable[..., Any]:
@@ -1283,17 +1310,18 @@ class SchedulerMemoryLeakPatch(VersionAwarePatch, BasePatch):
             return _wrapped
 
         patched_any = False
-        for target_method_name in target_method_names:
-            original = getattr(Scheduler, target_method_name)
+        for class_name, cls, target_method_name in target_methods:
+            original = getattr(cls, target_method_name)
             if self._is_already_patched(original):
                 self.logger.debug(
-                    f"Scheduler.{target_method_name} leak check already patched")
+                    f"{class_name}.{target_method_name} leak check already patched"
+                )
                 patched_any = True
                 continue
 
             wrapped = _make_wrapped(original)
             self._mark_as_patched(wrapped)
-            setattr(Scheduler, target_method_name, wrapped)
+            setattr(cls, target_method_name, wrapped)
             patched_any = True
 
         return patched_any

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -162,8 +162,8 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
             alloc_extend_kernel_fn = getattr(
                 alloc_extend_kernel, "fn", alloc_extend_kernel
             )
-            alloc_extend_uses_max_tokens = (
-                len(inspect.signature(alloc_extend_kernel_fn).parameters) == 8
+            alloc_extend_param_names = tuple(
+                inspect.signature(alloc_extend_kernel_fn).parameters
             )
 
             from sglang.srt.utils import get_num_new_pages, next_power_of_2
@@ -246,20 +246,25 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
                     out_indices = torch.empty(
                         (extend_num_tokens,), dtype=torch.int64, device=self.device
                     )
-                    kernel_args: List[Any] = [
-                        prefix_lens,
-                        seq_lens,
-                        last_loc,
-                        free_pages,
-                        out_indices,
-                        next_power_of_2(bs),
-                        self.page_size,
-                    ]
-                    if alloc_extend_uses_max_tokens:
-                        kernel_args.append(
+                    kernel_kwargs: dict[str, Any] = {
+                        "pre_lens_ptr": prefix_lens,
+                        "seq_lens_ptr": seq_lens,
+                        "last_loc_ptr": last_loc,
+                        "free_page_ptr": free_pages,
+                        "out_indices": out_indices,
+                        "bs_upper": next_power_of_2(bs),
+                        "page_size": self.page_size,
+                    }
+                    if "ret_values" in alloc_extend_param_names:
+                        kernel_kwargs["ret_values"] = torch.empty(
+                            (), dtype=torch.int64, device=self.device
+                        )
+                    if "max_num_extend_tokens" in alloc_extend_param_names:
+                        kernel_kwargs["max_num_extend_tokens"] = (
                             self.seen_max_num_extend_tokens_next_power_of_2
                         )
-                    alloc_extend_kernel[(bs,)](*kernel_args)
+
+                    alloc_extend_kernel[(bs,)](**kernel_kwargs)
                     return out_indices
 
                 def alloc_decode(

--- a/tests/test_sglang_allocator_patch.py
+++ b/tests/test_sglang_allocator_patch.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import inspect
+import sys
+import types
+from typing import Any
+
+import pytest
+
+from kvcached.integration.sglang.patches import ElasticAllocatorPatch
+
+
+class FakeTensor:
+    def __init__(self, data=None, shape=None, dtype=None, device=None):
+        self.data = data
+        self.shape = shape
+        self.dtype = dtype
+        self.device = device
+
+    def __len__(self):
+        if self.shape:
+            return self.shape[0]
+        return len(self.data)
+
+
+class FakeKVCachedAllocator:
+    def alloc(self, num_pages):
+        return list(range(num_pages))
+
+
+class FakeKVCache:
+    def __init__(self):
+        self.kvcached_allocator = FakeKVCachedAllocator()
+
+
+class FakeBaseTokenToKVPoolAllocator:
+    def __init__(self, size, page_size, dtype, device, kvcache, *args, **kwargs):
+        self.size = size
+        self.page_size = page_size
+        self.dtype = dtype
+        self.device = device
+        self.kvcache = kvcache
+        self.is_not_in_free_group = True
+        self.free_group = []
+
+
+class FakeTritonKernel:
+    def __init__(self, fn):
+        self.fn = fn
+        self.calls = []
+
+    def __getitem__(self, grid):
+        def launch(**kwargs):
+            expected_names = tuple(inspect.signature(self.fn).parameters)
+            if set(kwargs) != set(expected_names):
+                missing = set(expected_names) - set(kwargs)
+                unexpected = set(kwargs) - set(expected_names)
+                raise AssertionError(
+                    f"kernel kwargs mismatch: missing={missing}, unexpected={unexpected}"
+                )
+            self.calls.append({"grid": grid, "kwargs": kwargs})
+
+        return launch
+
+
+class FakeKernelFn:
+    def __init__(self, parameter_names):
+        self.__signature__ = inspect.Signature(
+            [
+                inspect.Parameter(name, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+                for name in parameter_names
+            ]
+        )
+
+    def __call__(self, *args, **kwargs):
+        pass
+
+
+def _install_fake_torch(monkeypatch):
+    torch: Any = types.ModuleType("torch")
+    torch.Tensor = FakeTensor
+    torch.int64 = "int64"
+
+    def empty(shape, dtype=None, device=None):
+        return FakeTensor(shape=shape, dtype=dtype, device=device)
+
+    def tensor(data, dtype=None, device=None):
+        return FakeTensor(data=list(data), shape=(len(data),), dtype=dtype, device=device)
+
+    torch.empty = empty
+    torch.tensor = tensor
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+
+def _install_fake_sglang_utils(monkeypatch):
+    sglang: Any = types.ModuleType("sglang")
+    srt: Any = types.ModuleType("sglang.srt")
+    utils: Any = types.ModuleType("sglang.srt.utils")
+
+    def next_power_of_2(value):
+        return 1 << (value - 1).bit_length()
+
+    utils.get_num_new_pages = lambda **kwargs: 0
+    utils.next_power_of_2 = next_power_of_2
+    sglang.srt = srt
+    srt.utils = utils
+
+    monkeypatch.setitem(sys.modules, "sglang", sglang)
+    monkeypatch.setitem(sys.modules, "sglang.srt", srt)
+    monkeypatch.setitem(sys.modules, "sglang.srt.utils", utils)
+
+
+def _make_allocator_module(alloc_extend_kernel):
+    alloc_mod: Any = types.ModuleType("sglang.srt.mem_cache.allocator")
+    alloc_mod.BaseTokenToKVPoolAllocator = FakeBaseTokenToKVPoolAllocator
+    alloc_mod.alloc_extend_kernel = alloc_extend_kernel
+    alloc_mod.alloc_decode_kernel = FakeTritonKernel(
+        FakeKernelFn(
+            (
+                "seq_lens_ptr",
+                "last_loc_ptr",
+                "free_page_ptr",
+                "out_indices",
+                "bs_upper",
+                "page_size",
+            )
+        )
+    )
+    return alloc_mod
+
+
+@pytest.mark.parametrize(
+    ("parameter_names", "expected_optional_kwargs"),
+    [
+        (
+            (
+                "pre_lens_ptr",
+                "seq_lens_ptr",
+                "last_loc_ptr",
+                "free_page_ptr",
+                "out_indices",
+                "ret_values",
+                "bs_upper",
+                "page_size",
+                "max_num_extend_tokens",
+            ),
+            {"ret_values", "max_num_extend_tokens"},
+        ),
+        (
+            (
+                "pre_lens_ptr",
+                "seq_lens_ptr",
+                "last_loc_ptr",
+                "free_page_ptr",
+                "out_indices",
+                "bs_upper",
+                "page_size",
+                "max_num_extend_tokens",
+            ),
+            {"max_num_extend_tokens"},
+        ),
+        (
+            (
+                "pre_lens_ptr",
+                "seq_lens_ptr",
+                "last_loc_ptr",
+                "free_page_ptr",
+                "out_indices",
+                "bs_upper",
+                "page_size",
+            ),
+            set(),
+        ),
+    ],
+    ids=["sglang-0.4.9-0.5.2", "sglang-0.5.5-0.5.9", "sglang-0.5.10-0.5.15"],
+)
+def test_alloc_extend_kernel(
+    monkeypatch, parameter_names, expected_optional_kwargs
+):
+    """Regression: supported SGLang versions use 9-, 8-, and 7-argument
+    alloc_extend_kernel signatures, so the patch must pass only the optional
+    names present in the installed kernel."""
+    _install_fake_torch(monkeypatch)
+    _install_fake_sglang_utils(monkeypatch)
+    alloc_extend_kernel = FakeTritonKernel(FakeKernelFn(parameter_names))
+    alloc_mod = _make_allocator_module(alloc_extend_kernel)
+
+    assert ElasticAllocatorPatch().inject_elastic_paged_allocator(alloc_mod) is True
+
+    allocator = alloc_mod.ElasticPagedTokenToKVPoolAllocator(
+        size=64,
+        page_size=4,
+        dtype=object(),
+        device="cuda:0",
+        kvcache=FakeKVCache(),
+    )
+    prefix_lens = FakeTensor(shape=(2,))
+    seq_lens = FakeTensor(shape=(2,))
+    out_indices = allocator.alloc_extend(
+        prefix_lens=prefix_lens,
+        prefix_lens_cpu=prefix_lens,
+        seq_lens=seq_lens,
+        seq_lens_cpu=seq_lens,
+        last_loc=FakeTensor(shape=(2,)),
+        extend_num_tokens=5,
+        num_new_pages=2,
+    )
+
+    assert isinstance(out_indices, FakeTensor)
+    assert len(alloc_extend_kernel.calls) == 1
+    call = alloc_extend_kernel.calls[0]
+    kwargs = call["kwargs"]
+    assert call["grid"] == (2,)
+    assert kwargs["bs_upper"] == 2
+    assert kwargs["page_size"] == 4
+    assert kwargs["free_page_ptr"].data == [0, 1]
+    assert kwargs["out_indices"] is out_indices
+    assert expected_optional_kwargs <= set(kwargs)
+    assert ("ret_values" in kwargs) == ("ret_values" in expected_optional_kwargs)
+    assert ("max_num_extend_tokens" in kwargs) == (
+        "max_num_extend_tokens" in expected_optional_kwargs
+    )
+    if "max_num_extend_tokens" in kwargs:
+        assert kwargs["max_num_extend_tokens"] == 8


### PR DESCRIPTION
Summary
---
This PR fixes two SGLang 0.5.13+ compatibility defects in the SGLang integration.
- Allocator refactor: allocator kernels moved out of the patched allocator module, and `alloc_extend()` now accepts `num_new_pages`.
- Scheduler leak-check refactor: the leak raiser can now live in `SchedulerInvariantChecker`
 
The fix preserves the old behavior for existing SGLang layouts while adding compatibility with the newer allocator and scheduler structures.

### Allocator 

  - `alloc_extend_kernel` and `alloc_decode_kernel` now live under `sglang.srt.mem_cache.triton_ops.allocator`: [code](https://github.com/sgl-project/sglang/blob/v0.5.13.post1/python/sglang/srt/mem_cache/triton_ops/allocator.py)
  - `PagedTokenToKVPoolAllocator.alloc_extend()` accepts `num_new_pages`:  [code](https://github.com/sgl-project/sglang/blob/85fd90072d1a9f2432842b03588f63b745e524e4/python/sglang/srt/mem_cache/allocator/paged.py#L153)

```
[kvcached][INFO][2026-07-24 15:35:37][version_utils.py:199] Detected sglang version: 0.5.15.post1
[kvcached][ERROR][2026-07-24 15:35:37][patches.py:317] Failed to inject ElasticPagedTokenToKVPoolAllocator: module 'sglang.srt.mem_cache.allocator' has no attribute 'alloc_extend_kernel'
[kvcached][WARNING][2026-07-24 15:35:37][patch_base.py:119] Failed to apply elastic_allocator
```

Fix:   fall back to importing kernels from `sglang.srt.mem_cache.triton_ops.allocator`, accept optional num_new_pages, compute it only when not supplied, and inspect the kernel signature so max_num_extend_tokens is passed only to kernels that require it.

### Scheduler leak-check 

Previous compatibility work generalized the patch for newer scheduler runtime checker layouts. SGLang 0.5.13+ can route the leak raiser through `SchedulerInvariantChecker` [code](https://github.com/sgl-project/sglang/blob/35e25f53567c3290f3d96aebc21019b87ced710f/python/sglang/srt/managers/scheduler_components/invariant_checker.py#L44), so scanning only Scheduler can **miss** the method containing "memory leak detected". 

Fix: scan both `Scheduler` and `SchedulerInvariantChecker` when present.

### Test

Manual test on 0.5.12, 0.5.13.post1, 0.5.15.post1

```
[kvcached][INFO][2026-07-24 16:00:47][patches.py:1397] [kvcached] RadixCache evictable size capped at 16000 tokens (KVCACHED_MAX_CACHED_TOKENS)
[kvcached][INFO][2026-07-24 16:00:47][patch_base.py:178] Successfully patched sglang: elastic_allocator, elastic_memory_pool, elastic_mla_memory_pool, elastic_mamba_pool, elastic_hybrid_linear_memory_pool, scheduler_memory_leak, radix_cache_limit
```

