### PR TITLE
fix(sglang): keep KV pool ownership local to each TP worker

### DIFF
--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -453,12 +453,15 @@ def get_kv_cache_manager(
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
 
+    # Each SGLang TP worker owns and drives its local pool. Keep the real TP
+    # world size in init_kvcached() for rank-aware IPC listener setup, but do
+    # not broadcast this worker's local map/unmap operations to its peers.
     manager = KVCacheManager(
         num_blocks,
         block_size,
         cell_size,
         num_layers,
-        world_size=_world_size,
+        world_size=1,
         pp_rank=_pp_rank,
         async_sched=_async_sched,
         reserve_null_block=reserve_null_block,

--- a/tests/manifests/cpu.txt
+++ b/tests/manifests/cpu.txt
@@ -12,6 +12,7 @@ tests/test_prefix_cache.py
 tests/test_resize_reserved_order.py
 tests/test_sglang_allocator_patch.py
 tests/test_sglang_autopatch_order.py
+tests/test_sglang_local_pool_ownership.py
 tests/test_sglang_virtual_kv_capacity.py
 tests/test_shm_info_tracker.py
 tests/test_sleep_manager.py

--- a/tests/test_sglang_local_pool_ownership.py
+++ b/tests/test_sglang_local_pool_ownership.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+import types
+
+try:
+    import torch
+except ImportError:
+    torch = types.ModuleType("torch")
+    sys.modules["torch"] = torch
+
+if not hasattr(torch, "Tensor"):
+    torch.Tensor = object
+if not hasattr(torch, "dtype"):
+    torch.dtype = object
+if not hasattr(torch, "cuda"):
+    torch.cuda = types.SimpleNamespace(current_device=lambda: 0)
+
+try:
+    import kvcached.vmm_ops as vmm_ops
+except Exception:  # noqa: BLE001 - any extension import failure uses the CPU stub
+    vmm_ops = types.ModuleType("kvcached.vmm_ops")
+    sys.modules["kvcached.vmm_ops"] = vmm_ops
+
+for name, value in {
+    "PageAllocator": object,
+    "InternalPage": object,
+    "create_kv_tensors": lambda *args, **kwargs: [],
+    "init_kvcached": lambda *args, **kwargs: None,
+    "shutdown_kvcached": lambda: None,
+    "kv_tensors_created": lambda *args, **kwargs: True,
+    "map_to_kv_tensors": lambda *args, **kwargs: None,
+    "unmap_from_kv_tensors": lambda *args, **kwargs: None,
+}.items():
+    if not hasattr(vmm_ops, name):
+        setattr(vmm_ops, name, value)
+
+from kvcached.integration.sglang import interfaces  # noqa: E402
+
+
+def test_sglang_keeps_real_tp_size_for_ipc_but_owns_pool_locally(monkeypatch):
+    initialized = []
+    listeners = []
+    manager_args = []
+
+    class FakeManager:
+        def __init__(self, *args, **kwargs):
+            manager_args.append((args, kwargs))
+
+    monkeypatch.setattr(interfaces, "_kvcached_initialized", False)
+    monkeypatch.setattr(interfaces, "_kvcached_device", None)
+    monkeypatch.setattr(interfaces, "_async_sched", False)
+    monkeypatch.setattr(interfaces, "_world_size", 1)
+    monkeypatch.setattr(interfaces, "_pp_rank", 0)
+    monkeypatch.setattr(interfaces, "_init_kvcached_impl", lambda *args: initialized.append(args))
+    monkeypatch.setattr(
+        interfaces,
+        "start_worker_listener_thread",
+        lambda tp_rank, pp_rank: listeners.append((tp_rank, pp_rank)),
+    )
+    monkeypatch.setattr(interfaces, "KVCacheManager", FakeManager)
+
+    interfaces.init_kvcached(
+        tp_rank=2,
+        world_size=4,
+        pp_rank=1,
+        device="cuda:2",
+        async_sched=True,
+    )
+    interfaces.get_kv_cache_manager(128, 16, 64, 8, group_id=3)
+
+    assert initialized
+    assert listeners == [(2, 1)]
+    assert interfaces._world_size == 4
+    assert manager_args[0][1] == {
+        "world_size": 1,
+        "pp_rank": 1,
+        "async_sched": True,
+        "reserve_null_block": True,
+        "num_kv_buffers": 2,
+        "group_id": 3,
+        "pool_name": None,
+    }


### PR DESCRIPTION
## Summary

- keep SGLang `KVCacheManager` map/unmap ownership local to each TP worker
- preserve the real TP world size for rank-aware kvcached IPC listener setup
- add a CPU regression test covering the ownership split

## Problem

SGLang constructs and drives a KV pool independently in every TP worker. Passing the real TP world size into each `KVCacheManager` makes every worker broadcast its own local map/unmap operations. During null-block reservation, peers receive a second map for their already-mapped local page 0 and emit `Page 0 is already mapped`.

The TP world size is still required by `init_kvcached()` for listener/socket setup, so this change only scopes the manager itself to `world_size=1`.

## Real TP2 validation

Tested on two physical RTX 4090 GPUs with strict Docker GPU isolation:

- image: `docker.1ms.run/lmsysorg/sglang:v0.5.13`
- model: `Qwen3-8B`
- topology: SGLang TP2 on physical GPUs 6 and 7
- PyTorch: `2.11.0+cu130`
- CUDA runtime: `13.0`
- MPS active thread percentage: `100`
- kvcached page preallocation: disabled

Both runs used the same image, model, launch arguments, and environment. The fixed run differed only by overlaying this PR's `kvcached/integration/sglang/interfaces.py`.

| Case | Commit | Manager world size | `Page 0 is already mapped` | Request result |
| --- | --- | ---: | ---: | --- |
| Base | `ce76a129` | 2 | 2 | 1/1 HTTP 200, non-empty `OK.` |
| Fix | `79b8e5d5` | 1 | 0 | 5/5 HTTP 200, non-empty `OK.` |

Neither same-condition run had a scheduler exception, CUDA error, OOM, illegal-memory error, or traceback. The base run remained serviceable, so the verified defect is the duplicate cross-worker map operation and its error, not a demonstrated server outage.

SGLang 0.5.13's idle pool invariant was set to non-fatal warning mode in both runs because the existing `scheduler_memory_leak` compatibility patch does not apply to that SGLang version. This is independent of the ownership change and was held constant across the comparison.

## Focused validation

- `python -m pytest -q tests/test_sglang_local_pool_ownership.py`
- `python -m ruff check kvcached/integration/sglang/interfaces.py tests/test_sglang_local_pool_ownership.py`
- `python -m isort --check-only kvcached/integration/sglang/interfaces.py tests/test_sglang_local_pool_ownership.py`
- repository pre-commit and mypy CI: passed
