### PR TITLE
feat(vllm): avoid CUDA context in EngineCore

### DIFF
--- a/examples/01_simple_two_models/README.md
+++ b/examples/01_simple_two_models/README.md
@@ -22,6 +22,19 @@ vllm serve "${MODEL}" \
   --port "${PORT}"
 ```
 
+To avoid creating an additional CUDA context in the vLLM EngineCore process,
+enable the worker-owned physical-admission path explicitly:
+
+```bash
+export KVCACHED_ENGINECORE_NO_CUDA=true
+```
+
+This mode is disabled by default. When enabled, EngineCore manages logical KV
+capacity while the existing CUDA-owning TP workers perform final physical page
+mapping. It does not add a separate synchronous memory-info query to the
+scheduler path, and page preallocation is disabled for the control-only
+EngineCore. Unset the variable to restore the original behavior for A/B tests.
+
 For SGLang:
 
 ```bash

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -27,7 +27,8 @@ from kvcached.vmm_ops import (
 logger = get_kvcached_logger()
 
 _kvcached_initialized: bool = False
-_kvcached_device = None
+_kvcached_gpu_initialized: bool = False
+_kvcached_device: Optional[str] = None
 _async_sched = False
 _world_size: int = 1
 _pp_rank: int = 0
@@ -48,6 +49,16 @@ def get_world_size() -> int:
     return _world_size
 
 
+def _cuda_device_index(device: str) -> int:
+    normalized = normalize_gpu_device(device)
+    device_type, separator, index = normalized.partition(":")
+    if device_type.lower() != "cuda":
+        raise ValueError(f"Expected a CUDA device, got {device}")
+    if separator and index:
+        return int(index)
+    return int(torch.cuda.current_device())
+
+
 def init_kvcached(
     tp_rank: int = 0,
     world_size: int = 1,
@@ -55,8 +66,12 @@ def init_kvcached(
     is_worker: bool = False,
     device: Optional[str] = None,
     async_sched: bool = False,
+    control_only: bool = False,
 ) -> None:
-    global _kvcached_initialized, _kvcached_device, _world_size, _async_sched, _pp_rank, _is_worker
+    global _kvcached_initialized, _kvcached_gpu_initialized, _kvcached_device
+    global _world_size, _async_sched, _pp_rank, _is_worker
+    if control_only and is_worker:
+        raise ValueError("control_only mode is only valid in the engine process")
     if _kvcached_initialized:
         # EngineCore call init_kvcached(is_worker=False) first. When TP=1 GPUModelRunner
         # then calls init_kvcached(is_worker=True) in the same process; without this branch
@@ -64,7 +79,17 @@ def init_kvcached(
         # (broadcast_kv_tensors_created) and fail with ENOENT on the socket path.
         if is_worker and not _is_worker:
             _is_worker = True
-            start_worker_listener_thread(tp_rank, pp_rank)
+            if not _kvcached_gpu_initialized:
+                if device is None:
+                    device = f"cuda:{torch.cuda.current_device()}"
+                device = normalize_gpu_device(device)
+                _init_kvcached_impl(device, PAGE_SIZE, _contiguous_layout)
+                _kvcached_gpu_initialized = True
+                _kvcached_device = device
+            assert _kvcached_device is not None
+            start_worker_listener_thread(
+                tp_rank, pp_rank,
+                device_index=_cuda_device_index(_kvcached_device))
         if async_sched and not _async_sched:
             _async_sched = True
             logger.info("kvcached async scheduler enabled")
@@ -72,13 +97,23 @@ def init_kvcached(
         _world_size = world_size
         return
 
+    if control_only:
+        _kvcached_initialized = True
+        _world_size = world_size
+        _pp_rank = pp_rank
+        _async_sched = async_sched
+        _is_worker = False
+        logger.info("kvcached initialized in control-only mode")
+        return
+
     if device is None:
         device = f"cuda:{torch.cuda.current_device()}"
-    device = normalize_gpu_device(device)
+    normalized_device = normalize_gpu_device(device)
 
-    _init_kvcached_impl(device, PAGE_SIZE, _contiguous_layout)
+    _init_kvcached_impl(normalized_device, PAGE_SIZE, _contiguous_layout)
     _kvcached_initialized = True
-    _kvcached_device = device
+    _kvcached_gpu_initialized = True
+    _kvcached_device = normalized_device
     _world_size = world_size
     _pp_rank = pp_rank
     _async_sched = async_sched
@@ -90,20 +125,28 @@ def init_kvcached(
     if is_worker:
         # start the listener thread for kv cache management regardless of TP size
         # because the vLLM EngineCore might need to reach this worker if PP > 1
-        start_worker_listener_thread(tp_rank, pp_rank)
+        start_worker_listener_thread(
+            tp_rank, pp_rank,
+            device_index=_cuda_device_index(normalized_device))
 
 
 def shutdown_kvcached() -> None:
-    global _kvcached_initialized, _kvcached_device, _async_sched
+    global _kvcached_initialized, _kvcached_gpu_initialized, _kvcached_device
+    global _async_sched, _world_size, _pp_rank, _is_worker
     if not _kvcached_initialized:
         clear_registered_kv_cache_pools(integration="vllm")
         return
 
-    _shutdown_kvcached_impl()
+    if _kvcached_gpu_initialized:
+        _shutdown_kvcached_impl()
     clear_registered_kv_cache_pools(integration="vllm")
     _kvcached_initialized = False
+    _kvcached_gpu_initialized = False
     _kvcached_device = None
     _async_sched = False
+    _world_size = 1
+    _pp_rank = 0
+    _is_worker = False
 
 
 def build_kv_views(
@@ -592,6 +635,7 @@ def get_kv_cache_manager(
         group_id=group_id,
         reserve_null_block=True,
         pool_name=pool_name,
+        worker_physical_admission=not _kvcached_gpu_initialized,
     )
     register_kv_cache_pool(
         manager,

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -977,11 +977,14 @@ class EngineCorePatch(VersionAwarePatch, BasePatch):
                 # within a single PP stage's TP group (w0.sock … w(tp-1).sock).
                 # Each PP stage manages its own KV memory independently, so
                 # cross-stage IPC is neither needed nor correct.
+                from kvcached.utils import ENGINECORE_NO_CUDA
+
                 init_kvcached(
                     tp_rank=0,
                     world_size=vllm_config.parallel_config.tensor_parallel_size,
                     is_worker=False,
                     async_sched=_should_enable_async_sched(vllm_config),
+                    control_only=ENGINECORE_NO_CUDA,
                 )
             return original_init(self, vllm_config, *args, **kwargs)
 
@@ -1074,11 +1077,14 @@ class KVCacheCoordinatorPatch(VersionAwarePatch, BasePatch):
             # Use tp_size (not TP*PP global world size) for the KVCacheManager world_size.
             # Each PP stage manages its own KV tensors independently. The IPC sockets
             # are registered per TP rank within each stage (w0.sock … w(tp_size-1).sock).
+            from kvcached.utils import ENGINECORE_NO_CUDA
+
             kvi.init_kvcached(
                 tp_rank=0,
                 world_size=tp_size,
                 is_worker=False,
                 async_sched=_should_enable_async_sched(getattr(self, "vllm_config", None)),
+                control_only=ENGINECORE_NO_CUDA,
             )
 
             # Import ElasticBlockPool from the patched module

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -69,6 +69,7 @@ class KVCacheManager:
         num_kv_buffers: int = 2,
         group_id: int = 0,
         pool_name: Optional[str] = None,
+        worker_physical_admission: bool = False,
     ):
         """
         Args:
@@ -87,6 +88,9 @@ class KVCacheManager:
                 Different groups have independent FTensors and page spaces.
             pool_name: Stable, low-cardinality name assigned by the engine
                 integration when this pool is created.
+            worker_physical_admission: Report logical capacity to the scheduler
+                and let the CUDA-owning workers perform final physical
+                admission while mapping pages.
         """
         self.num_blocks = num_blocks
         self.block_mem_size = block_size * cell_size
@@ -95,6 +99,7 @@ class KVCacheManager:
         self.reserve_null_block = reserve_null_block
         self.group_id = group_id
         self._pool_name = pool_name
+        self.worker_physical_admission = worker_physical_admission
 
         # The physical page size used by kvcached page allocator.
         self.page_size = PAGE_SIZE
@@ -129,7 +134,10 @@ class KVCacheManager:
             pp_rank=self.pp_rank,
             async_sched=async_sched,
             contiguous_layout=CONTIGUOUS_LAYOUT,
-            enable_page_prealloc=PAGE_PREALLOC_ENABLED,
+            # A control-only process must not let the C++ preallocation thread
+            # enter Python to reach remote workers.
+            enable_page_prealloc=(PAGE_PREALLOC_ENABLED and
+                                  not self.worker_physical_admission),
             num_kv_buffers=self.num_kv_buffers,
             group_id=self.group_id,
             ipc_name=DEFAULT_IPC_NAME,
@@ -657,9 +665,16 @@ class KVCacheManager:
             blocks_from_free_pages = 0
         else:
             virtual_free_pages = self.page_allocator.get_num_free_pages()
-            physical_free_pages = self.page_allocator.get_avail_physical_pages(
-            ) + self.page_allocator.get_num_reserved_pages()
-            free_pages = min(virtual_free_pages, physical_free_pages)
+            if not getattr(self, "worker_physical_admission", False):
+                physical_free_pages = (
+                    self.page_allocator.get_avail_physical_pages() +
+                    self.page_allocator.get_num_reserved_pages())
+                free_pages = min(virtual_free_pages, physical_free_pages)
+            else:
+                # EngineCore owns only logical KV state in control-only mode.
+                # The workers that own the CUDA contexts perform the final
+                # physical admission as part of transactional page mapping.
+                free_pages = virtual_free_pages
             blocks_from_free_pages = free_pages * InternalPage.get_num_blocks(
                 self.page_size, self.block_mem_size)
         return avail_blocks + blocks_from_free_pages

--- a/kvcached/tp_ipc_util.py
+++ b/kvcached/tp_ipc_util.py
@@ -7,7 +7,7 @@ import pickle
 import socket
 import threading
 import uuid
-from typing import Any, Dict, cast
+from typing import Any, Dict, Optional, cast
 
 from kvcached.utils import DEFAULT_IPC_NAME
 from kvcached.vmm_ops import kv_tensors_created, map_to_kv_tensors, unmap_from_kv_tensors
@@ -93,7 +93,19 @@ def recv_msg(sock: socket.socket) -> Message:
     return cast(Message, pickle.loads(data))
 
 
-def start_worker_listener_thread(rank: int, pp_rank: int = 0):
+def _set_listener_device(device_index: Optional[int]) -> None:
+    if device_index is None:
+        return
+
+    import torch
+
+    # CUDA's current device is thread-local. Restore the worker's initialized
+    # device before serving CUDA-backed map operations.
+    torch.cuda.set_device(device_index)
+
+
+def start_worker_listener_thread(rank: int, pp_rank: int = 0,
+                                 device_index: Optional[int] = None):
     """
     Start a thread that listens for messages on the worker socket.
     pp_rank is used to create a PP-stage-specific subdirectory so that
@@ -114,6 +126,7 @@ def start_worker_listener_thread(rank: int, pp_rank: int = 0):
     server_sock.listen()
 
     def listen_loop():
+        _set_listener_device(device_index)
         print(f"Worker {rank} IPC listener started at {socket_path}")
         while True:
             conn, _ = server_sock.accept()
@@ -137,7 +150,10 @@ def start_worker_listener_thread(rank: int, pp_rank: int = 0):
                     })
             except Exception as e:
                 print(f"Worker {rank} error processing message: {e}")
-                send_msg(conn, {"status": "error", "message": str(e)})
+                try:
+                    send_msg(conn, {"status": "error", "message": str(e)})
+                except (BrokenPipeError, ConnectionError, OSError):
+                    pass
             finally:
                 conn.close()
 

--- a/kvcached/utils.py
+++ b/kvcached/utils.py
@@ -136,6 +136,8 @@ PAGE_SIZE = _get_page_size()
 GPU_UTILIZATION = float(os.getenv("KVCACHED_GPU_UTILIZATION", "0.95"))
 PAGE_PREALLOC_ENABLED = os.getenv("KVCACHED_PAGE_PREALLOC_ENABLED",
                                   "true").lower() == "true"
+ENGINECORE_NO_CUDA = os.getenv("KVCACHED_ENGINECORE_NO_CUDA",
+                               "false").lower() == "true"
 MIN_RESERVED_PAGES = int(os.getenv("KVCACHED_MIN_RESERVED_PAGES", "5"))
 MAX_RESERVED_PAGES = int(os.getenv("KVCACHED_MAX_RESERVED_PAGES", "10"))
 MAX_CACHED_BLOCKS = int(os.getenv("KVCACHED_MAX_CACHED_BLOCKS", "1000"))

--- a/tests/manifests/cpu.txt
+++ b/tests/manifests/cpu.txt
@@ -1,5 +1,6 @@
 tests/test_alloc_rollback.py
 tests/test_bestfit_page_selection.py
+tests/test_enginecore_no_cuda.py
 tests/test_get_max_cached_blocks.py
 tests/test_ipc_name.py
 tests/test_ipc_timeout.py

--- a/tests/test_enginecore_no_cuda.py
+++ b/tests/test_enginecore_no_cuda.py
@@ -1,0 +1,275 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any, Dict
+
+
+def _load_manager_module(monkeypatch):
+    torch = types.ModuleType("torch")
+    torch.Tensor = type("Tensor", (), {})  # type: ignore[attr-defined]
+    torch.dtype = type("dtype", (), {})  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    vmm_ops = types.ModuleType("kvcached.vmm_ops")
+    vmm_ops.InternalPage = type(  # type: ignore[attr-defined]
+        "InternalPage",
+        (),
+        {"get_num_blocks": staticmethod(lambda page_size, block_size: 4)},
+    )
+    vmm_ops.PageAllocator = type("PageAllocator", (), {})  # type: ignore[attr-defined]
+    vmm_ops.kv_tensors_created = lambda *args, **kwargs: False  # type: ignore[attr-defined]
+    vmm_ops.map_to_kv_tensors = lambda *args, **kwargs: True  # type: ignore[attr-defined]
+    vmm_ops.unmap_from_kv_tensors = lambda *args, **kwargs: True  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", vmm_ops)
+
+    interfaces = types.ModuleType("kvcached.integration.vllm.interfaces")
+    interfaces.should_use_worker_ipc = lambda: False  # type: ignore[attr-defined]
+    monkeypatch.setitem(
+        sys.modules,
+        "kvcached.integration.vllm.interfaces",
+        interfaces,
+    )
+
+    module_path = Path(__file__).parents[1] / "kvcached" / "kv_cache_manager.py"
+    spec = importlib.util.spec_from_file_location(
+        "kvcached._test_kv_cache_manager", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_control_only_manager_uses_logical_capacity(monkeypatch):
+    manager_module = _load_manager_module(monkeypatch)
+    observed: Dict[str, Any] = {}
+
+    class FakePageAllocator:
+        def __init__(self, *args, **kwargs):
+            observed["constructor"] = kwargs
+
+        def set_use_worker_ipc(self, enabled):
+            observed["use_worker_ipc"] = enabled
+
+        def set_broadcast_map_callback(self, callback):
+            observed["map_callback"] = callback
+
+        def set_broadcast_unmap_callback(self, callback):
+            observed["unmap_callback"] = callback
+
+        def get_num_free_pages(self):
+            return 3
+
+        def get_num_reserved_pages(self):
+            raise AssertionError("control-only capacity queried CUDA state")
+
+        def get_avail_physical_pages(self):
+            raise AssertionError("control-only capacity queried CUDA state")
+
+    class FakeThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+    monkeypatch.setattr(manager_module, "PageAllocator", FakePageAllocator)
+    monkeypatch.setattr(manager_module.threading, "Thread", FakeThread)
+
+    manager = manager_module.KVCacheManager(
+        num_blocks=4,
+        block_size=1,
+        cell_size=1,
+        num_layers=1,
+        world_size=2,
+        worker_physical_admission=True,
+    )
+    manager.num_avail_blocks = 2
+    manager.reserved_blocks = [0]
+    manager.in_shrink = False
+
+    assert "worker_physical_admission" not in observed["constructor"]
+    assert observed["constructor"]["enable_page_prealloc"] is False
+    assert observed["use_worker_ipc"] is False
+    assert manager.available_size() == 15
+
+
+def test_default_manager_clamps_capacity_to_physical_pages(monkeypatch):
+    manager_module = _load_manager_module(monkeypatch)
+    manager = manager_module.KVCacheManager.__new__(manager_module.KVCacheManager)
+    manager.worker_physical_admission = False
+    manager._lock = manager_module.NoOpLock()
+    manager.num_avail_blocks = 0
+    manager.reserved_blocks = []
+    manager.in_shrink = False
+    manager.page_size = 16
+    manager.block_mem_size = 4
+    manager.page_allocator = types.SimpleNamespace(
+        get_num_free_pages=lambda: 5,
+        get_avail_physical_pages=lambda: 2,
+        get_num_reserved_pages=lambda: 1,
+    )
+
+    assert manager.available_size() == 12
+
+
+def test_control_only_initialization_does_not_touch_cuda(monkeypatch):
+    torch = types.ModuleType("torch")
+    torch.Tensor = type("Tensor", (), {})  # type: ignore[attr-defined]
+    torch.dtype = type("dtype", (), {})  # type: ignore[attr-defined]
+
+    def unexpected_cuda_call():
+        raise AssertionError("control-only initialization touched CUDA")
+
+    torch.cuda = types.SimpleNamespace(  # type: ignore[attr-defined]
+        current_device=unexpected_cuda_call)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    manager_module = types.ModuleType("kvcached.kv_cache_manager")
+    manager_module.KVCacheManager = type(  # type: ignore[attr-defined]
+        "KVCacheManager", (), {})
+    monkeypatch.setitem(sys.modules, "kvcached.kv_cache_manager", manager_module)
+
+    listeners = types.ModuleType("kvcached.tp_ipc_util")
+    listeners.start_worker_listener_thread = unexpected_cuda_call  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "kvcached.tp_ipc_util", listeners)
+
+    calls = []
+    vmm_ops = types.ModuleType("kvcached.vmm_ops")
+    vmm_ops.create_kv_tensors = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    vmm_ops.init_kvcached = lambda *args, **kwargs: calls.append("init")  # type: ignore[attr-defined]
+    vmm_ops.shutdown_kvcached = lambda *args, **kwargs: calls.append("shutdown")  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", vmm_ops)
+
+    module_path = (Path(__file__).parents[1] / "kvcached" / "integration" /
+                   "vllm" / "interfaces.py")
+    spec = importlib.util.spec_from_file_location(
+        "kvcached.integration.vllm._test_interfaces", module_path)
+    assert spec is not None and spec.loader is not None
+    interfaces = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(interfaces)
+
+    interfaces.init_kvcached(world_size=4, control_only=True)
+
+    assert interfaces._kvcached_initialized is True
+    assert interfaces._kvcached_gpu_initialized is False
+    assert calls == []
+
+
+def test_failed_gpu_initialization_does_not_mark_initialized(monkeypatch):
+    torch = types.ModuleType("torch")
+    torch.Tensor = type("Tensor", (), {})  # type: ignore[attr-defined]
+    torch.dtype = type("dtype", (), {})  # type: ignore[attr-defined]
+    torch.cuda = types.SimpleNamespace(  # type: ignore[attr-defined]
+        current_device=lambda: 0)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    manager_module = types.ModuleType("kvcached.kv_cache_manager")
+    manager_module.KVCacheManager = type(  # type: ignore[attr-defined]
+        "KVCacheManager", (), {})
+    monkeypatch.setitem(sys.modules, "kvcached.kv_cache_manager", manager_module)
+
+    listeners = types.ModuleType("kvcached.tp_ipc_util")
+    listeners.start_worker_listener_thread = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "kvcached.tp_ipc_util", listeners)
+
+    def fail_init(*args, **kwargs):
+        raise RuntimeError("CUDA initialization failed")
+
+    vmm_ops = types.ModuleType("kvcached.vmm_ops")
+    vmm_ops.create_kv_tensors = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    vmm_ops.init_kvcached = fail_init  # type: ignore[attr-defined]
+    vmm_ops.shutdown_kvcached = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", vmm_ops)
+
+    module_path = (Path(__file__).parents[1] / "kvcached" / "integration" /
+                   "vllm" / "interfaces.py")
+    spec = importlib.util.spec_from_file_location(
+        "kvcached.integration.vllm._test_failed_interfaces", module_path)
+    assert spec is not None and spec.loader is not None
+    interfaces = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(interfaces)
+
+    try:
+        interfaces.init_kvcached(device="cuda:0")
+    except RuntimeError as exc:
+        assert str(exc) == "CUDA initialization failed"
+    else:
+        raise AssertionError("GPU initialization failure was not propagated")
+
+    assert interfaces._kvcached_initialized is False
+    assert interfaces._kvcached_gpu_initialized is False
+
+
+def test_worker_listener_uses_explicit_initialized_device(monkeypatch):
+    torch = types.ModuleType("torch")
+    torch.Tensor = type("Tensor", (), {})  # type: ignore[attr-defined]
+    torch.dtype = type("dtype", (), {})  # type: ignore[attr-defined]
+
+    def unexpected_current_device():
+        raise AssertionError("explicit device should not query current_device")
+
+    torch.cuda = types.SimpleNamespace(  # type: ignore[attr-defined]
+        current_device=unexpected_current_device)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    manager_module = types.ModuleType("kvcached.kv_cache_manager")
+    manager_module.KVCacheManager = type(  # type: ignore[attr-defined]
+        "KVCacheManager", (), {})
+    monkeypatch.setitem(sys.modules, "kvcached.kv_cache_manager", manager_module)
+
+    listener_calls = []
+    listeners = types.ModuleType("kvcached.tp_ipc_util")
+    listeners.start_worker_listener_thread = (  # type: ignore[attr-defined]
+        lambda *args, **kwargs: listener_calls.append((args, kwargs)))
+    monkeypatch.setitem(sys.modules, "kvcached.tp_ipc_util", listeners)
+
+    vmm_ops = types.ModuleType("kvcached.vmm_ops")
+    vmm_ops.create_kv_tensors = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    vmm_ops.init_kvcached = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    vmm_ops.shutdown_kvcached = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", vmm_ops)
+
+    module_path = (Path(__file__).parents[1] / "kvcached" / "integration" /
+                   "vllm" / "interfaces.py")
+    spec = importlib.util.spec_from_file_location(
+        "kvcached.integration.vllm._test_device_interfaces", module_path)
+    assert spec is not None and spec.loader is not None
+    interfaces = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(interfaces)
+
+    interfaces.init_kvcached(is_worker=True, device="cuda:2")
+
+    assert listener_calls == [((0, 0), {"device_index": 2})]
+
+
+def test_worker_listener_restores_device_before_serving(monkeypatch):
+    selected = []
+    torch = types.ModuleType("torch")
+    torch.cuda = types.SimpleNamespace(  # type: ignore[attr-defined]
+        set_device=lambda device: selected.append(device))
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    utils = types.ModuleType("kvcached.utils")
+    utils.DEFAULT_IPC_NAME = "test"  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "kvcached.utils", utils)
+
+    vmm_ops = types.ModuleType("kvcached.vmm_ops")
+    vmm_ops.kv_tensors_created = lambda *args, **kwargs: True  # type: ignore[attr-defined]
+    vmm_ops.map_to_kv_tensors = lambda *args, **kwargs: True  # type: ignore[attr-defined]
+    vmm_ops.unmap_from_kv_tensors = lambda *args, **kwargs: True  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", vmm_ops)
+
+    module_path = Path(__file__).parents[1] / "kvcached" / "tp_ipc_util.py"
+    spec = importlib.util.spec_from_file_location(
+        "kvcached._test_tp_ipc_util", module_path)
+    assert spec is not None and spec.loader is not None
+    tp_ipc_util = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(tp_ipc_util)
+
+    tp_ipc_util._set_listener_device(2)
+
+    assert selected == [2]

--- a/tests/test_vllm_tp_world_size.py
+++ b/tests/test_vllm_tp_world_size.py
@@ -54,10 +54,14 @@ def test_get_world_size_rejects_uninitialized_state(monkeypatch, vllm_modules):
         interfaces.get_world_size()
 
 
+@pytest.mark.parametrize("control_only", [False, True])
 def test_engine_core_records_tp_world_size_before_original_init(
-    monkeypatch, vllm_modules
+    monkeypatch, vllm_modules, control_only
 ):
     interfaces, patches = vllm_modules
+    import kvcached.utils as utils
+
+    monkeypatch.setattr(utils, "ENGINECORE_NO_CUDA", control_only)
     monkeypatch.setattr(patches, "enable_kvcached", lambda: True)
     monkeypatch.setattr(patches, "_should_enable_async_sched", lambda cfg: True)
     init_kvcached = mock.Mock()
@@ -85,6 +89,7 @@ def test_engine_core_records_tp_world_size_before_original_init(
         world_size=4,
         is_worker=False,
         async_sched=True,
+        control_only=control_only,
     )
     original_init.assert_called_once()
 


### PR DESCRIPTION
> [!WARNING]
> Not ready to merge: the worker-owned admission design failed high-concurrency performance validation. See the [validation follow-up](https://github.com/ovg-project/kvcached/pull/416#issuecomment-5435093449). This remains a draft pending redesign and repeat validation, not just the merge of #418.

## Summary

Avoid creating a redundant CUDA context in vLLM's EngineCore process by moving physical KV admission to the CUDA-owning workers.

The behavior is opt-in through `KVCACHED_ENGINECORE_NO_CUDA=true`. The default vLLM and SGLang paths are unchanged.

## Why

In vLLM V1, the GPU workers already own model execution and KV tensor mapping, but kvcached also initialized CUDA/VMM state in EngineCore. That created an additional CUDA context even though EngineCore only needs to maintain logical KV state.

On a 4x RTX 4090 TP4 deployment, the redundant EngineCore context occupied 386 MiB. Removing it increased idle free memory on rank 0 by 409 MiB.

## Design

- EngineCore initializes kvcached in control-only mode and does not initialize CUDA/VMM state.
- EngineCore reports logical free pages to the scheduler. It does not cache or periodically query worker meminfo.
- When physical growth is required, the existing map request is sent to every TP worker in the current PP group. Each CUDA-owning worker performs admission and mapping for its own device.
- Already mapped page reuse does not enter this path.
- Page preallocation is disabled for the control-only manager so a C++ background thread cannot re-enter Python to reach remote workers.
- The listener thread explicitly restores the worker's initialized CUDA device before serving map/unmap operations because CUDA's current device is thread-local.

This PR deliberately does not add a representative-TP meminfo cache, a per-allocation meminfo RPC, or a cross-process file lock. CUDA remains the final physical admission authority. A failed multi-worker mapping must be reported as an allocation miss after transactional rollback, so this design depends on #418 (and uses the scheduling-miss behavior from #453).

## Cost and fallback

The feature flag provides a way to opt out; it does not guarantee low overhead when enabled:

- With `KVCACHED_ENGINECORE_NO_CUDA=false` (the default), no runtime behavior changes.
- With it enabled, there is no periodic polling and no additional scheduler IPC. Only the existing worker map/unmap IPC is used when physical pages grow.
- Disabling the variable restores the current EngineCore-owned path without a code rollback.

## Validation

- Exact candidate: `62c940d057f49297e6c9711b128ad53af53e8d8a`
- Full hosted-CPU manifest: `193 passed`
- Focused EngineCore/TP tests: `13 passed`
- Ruff, isort, codespell, clang-format, PyMarkdown, workflow lint, SPDX checks, and Linux-platform MyPy passed.
- Real-GPU smoke: Tesla T4, vLLM 0.18.0, Qwen2.5-0.5B-Instruct. The wheel and autopatch loaded, control-only initialization and the worker listener were observed, the server reached healthy state, and an OpenAI-compatible request returned exactly `OK`.

The startup smoke above does not establish high-concurrency performance acceptance. The later combined-path test completed requests successfully but reduced average output throughput by about 28.5% versus its control.
