### PR TITLE
fix: resolve the prealloc startup/runtime hangs of #371 (release GIL in blocking bindings, bound worker IPC)

### DIFF
--- a/csrc/inc/page_allocator.hpp
+++ b/csrc/inc/page_allocator.hpp
@@ -27,7 +27,6 @@ using BroadcastMapCallback =
     std::function<void(int64_t, const std::vector<offset_t> &)>;
 using BroadcastUnmapCallback =
     std::function<void(int64_t, const std::vector<offset_t> &)>;
-using ShouldUseWorkerIpcCallback = std::function<bool()>;
 
 // Independent InternalPage class
 class InternalPage {
@@ -107,7 +106,13 @@ public:
   // Callback function setters for multi-process support
   void set_broadcast_map_callback(BroadcastMapCallback callback);
   void set_broadcast_unmap_callback(BroadcastUnmapCallback callback);
-  void set_should_use_worker_ipc_callback(ShouldUseWorkerIpcCallback callback);
+  // Whether map/unmap must be broadcast to worker processes over IPC. Python
+  // pushes the decision once at init. A pushed value instead of a pulled
+  // callback keeps every allocator thread (the prealloc worker in particular)
+  // out of Python: calling back into Python needs the GIL, and a thread that
+  // blocks inside this class while some other thread holds the GIL forever is
+  // exactly the deadlock of issue #371.
+  void set_use_worker_ipc(bool use_worker_ipc);
 
 private:
   // Preallocation thread worker
@@ -156,6 +161,12 @@ private:
   std::condition_variable cond_;
   std::atomic<bool> prealloc_running_;
   std::atomic<bool> prealloc_needed_;
+  // Serializes start/stop of the background threads. Before the blocking
+  // bindings released the GIL, concurrent start and stop callers were
+  // accidentally serialized by the GIL itself; they no longer are, so the
+  // thread handles need their own lock. Held across join(): the workers
+  // never take this lock, so no cycle.
+  std::mutex thread_ctl_lock_;
   std::unique_ptr<std::thread> prealloc_thread_;
 
   // Resize watcher thread
@@ -170,8 +181,7 @@ private:
   // Callback functions for multi-process support
   BroadcastMapCallback broadcast_map_callback_;
   BroadcastUnmapCallback broadcast_unmap_callback_;
-  ShouldUseWorkerIpcCallback should_use_worker_ipc_callback_;
-  mutable std::atomic<bool> should_use_worker_ipc_cached_{false};
+  std::atomic<bool> use_worker_ipc_{false};
 };
 
 } // namespace kvcached

--- a/csrc/page_allocator.cpp
+++ b/csrc/page_allocator.cpp
@@ -3,6 +3,8 @@
 
 #include "page_allocator.hpp"
 
+#include <Python.h>
+
 #include <algorithm>
 #include <chrono>
 #include <cstdlib>
@@ -500,30 +502,41 @@ PageAllocator::group_indices_by_page(const std::vector<int64_t> &indices,
 }
 
 // Callback function setters
+//
+// The swap-then-assign shape in the two setters below is deliberate: these
+// callbacks wrap Python callables, and destroying one acquires the GIL. With
+// the blocking bindings releasing the GIL, destroying a callback while holding
+// lock_ would invert the lock/GIL order against a thread that holds lock_ and
+// needs the GIL -- so the old callback must be destroyed after lock_ is
+// released (when `old` goes out of scope).
 void PageAllocator::set_broadcast_map_callback(BroadcastMapCallback callback) {
-  std::lock_guard<std::mutex> lock(lock_);
-  broadcast_map_callback_ = callback;
+  BroadcastMapCallback old;
+  {
+    std::lock_guard<std::mutex> lock(lock_);
+    old = std::move(broadcast_map_callback_);
+    broadcast_map_callback_ = std::move(callback);
+  }
   LOGGER(INFO, "Broadcast map callback set for PageAllocator (world_size=%ld)",
          world_size_);
 }
 
 void PageAllocator::set_broadcast_unmap_callback(
     BroadcastUnmapCallback callback) {
-  std::lock_guard<std::mutex> lock(lock_);
-  broadcast_unmap_callback_ = callback;
+  BroadcastUnmapCallback old;
+  {
+    std::lock_guard<std::mutex> lock(lock_);
+    old = std::move(broadcast_unmap_callback_);
+    broadcast_unmap_callback_ = std::move(callback);
+  }
   LOGGER(INFO,
          "Broadcast unmap callback set for PageAllocator (world_size=%ld)",
          world_size_);
 }
 
-void PageAllocator::set_should_use_worker_ipc_callback(
-    ShouldUseWorkerIpcCallback callback) {
-  bool use_worker_ipc = callback ? callback() : false;
-  std::lock_guard<std::mutex> lock(lock_);
-  should_use_worker_ipc_callback_ = std::move(callback);
-  should_use_worker_ipc_cached_.store(use_worker_ipc,
-                                      std::memory_order_release);
-  LOGGER(INFO, "Should-use-worker-ipc callback set for PageAllocator");
+void PageAllocator::set_use_worker_ipc(bool use_worker_ipc) {
+  use_worker_ipc_.store(use_worker_ipc, std::memory_order_release);
+  LOGGER(INFO, "use_worker_ipc set to %d for PageAllocator",
+         static_cast<int>(use_worker_ipc));
 }
 
 void PageAllocator::start_prealloc_thread() {
@@ -720,6 +733,7 @@ void PageAllocator::trigger_preallocation() {
 }
 
 void PageAllocator::start_prealloc_thread_internal() {
+  std::lock_guard<std::mutex> ctl(thread_ctl_lock_);
   if (!prealloc_thread_) {
     prealloc_running_ = true;
     prealloc_thread_ =
@@ -737,7 +751,25 @@ void PageAllocator::start_prealloc_thread_internal() {
   }
 }
 
+namespace {
+// Join a thread without holding the GIL. The prealloc worker may be inside a
+// Python broadcast callback waiting for the GIL; joining it while holding the
+// GIL would deadlock. The stop_prealloc_thread binding already releases the
+// GIL, but the destructor runs from Python garbage collection with the GIL
+// held, so release conditionally here.
+void join_without_gil(std::thread &t) {
+  if (PyGILState_Check()) {
+    PyThreadState *state = PyEval_SaveThread();
+    t.join();
+    PyEval_RestoreThread(state);
+  } else {
+    t.join();
+  }
+}
+} // namespace
+
 void PageAllocator::stop_prealloc_thread_internal() {
+  std::lock_guard<std::mutex> ctl(thread_ctl_lock_);
   if (prealloc_thread_) {
     {
       std::lock_guard<std::mutex> lock(lock_);
@@ -745,7 +777,7 @@ void PageAllocator::stop_prealloc_thread_internal() {
       cond_.notify_all();
     }
 
-    prealloc_thread_->join();
+    join_without_gil(*prealloc_thread_);
     prealloc_thread_.reset();
     LOGGER(DEBUG, "Stopped page preallocation thread");
   }
@@ -753,33 +785,17 @@ void PageAllocator::stop_prealloc_thread_internal() {
   // Stop resize watcher thread
   if (resize_watcher_thread_) {
     resize_watcher_running_ = false;
-    resize_watcher_thread_->join();
+    join_without_gil(*resize_watcher_thread_);
     resize_watcher_thread_.reset();
     LOGGER(DEBUG, "Stopped resize watcher thread");
   }
 }
 
 bool PageAllocator::should_use_worker_ipc() const {
-  ShouldUseWorkerIpcCallback callback;
-  {
-    std::lock_guard<std::mutex> lock(lock_);
-    if (prealloc_thread_ &&
-        prealloc_thread_->get_id() == std::this_thread::get_id()) {
-      // The background prealloc thread must not re-enter Python here. It only
-      // consumes the cached decision, which non-prealloc callers refresh.
-      return should_use_worker_ipc_cached_.load(std::memory_order_acquire);
-    }
-    callback = should_use_worker_ipc_callback_;
-  }
-
-  if (callback) {
-    bool use_worker_ipc = callback();
-    should_use_worker_ipc_cached_.store(use_worker_ipc,
-                                        std::memory_order_release);
-    return use_worker_ipc;
-  }
-
-  return should_use_worker_ipc_cached_.load(std::memory_order_acquire);
+  // A plain pushed value: no thread ever needs Python (or the GIL) to answer
+  // this. The decision is fixed once Python calls set_use_worker_ipc() during
+  // KVCacheManager init, before the prealloc thread starts.
+  return use_worker_ipc_.load(std::memory_order_acquire);
 }
 
 void PageAllocator::resize_watcher() {

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -158,10 +158,9 @@ void page_allocator_set_broadcast_unmap_callback(
   allocator->set_broadcast_unmap_callback(callback);
 }
 
-void page_allocator_set_should_use_worker_ipc_callback(
-    std::shared_ptr<PageAllocator> allocator,
-    ShouldUseWorkerIpcCallback callback) {
-  allocator->set_should_use_worker_ipc_callback(callback);
+void page_allocator_set_use_worker_ipc(std::shared_ptr<PageAllocator> allocator,
+                                       bool use_worker_ipc) {
+  allocator->set_use_worker_ipc(use_worker_ipc);
 }
 
 page_id_t page_allocator_get_page_id(std::shared_ptr<PageAllocator> allocator,
@@ -209,13 +208,25 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            py::arg("ipc_name") = "")
       .def("start_prealloc_thread",
            &kvcached::page_allocator_start_prealloc_thread)
+      // The bindings below can block inside the allocator (alloc_page waits on
+      // a condition variable for the prealloc worker; free/resize/trim unmap
+      // pages; stop joins the worker). They must not hold the GIL while
+      // blocked: the prealloc worker needs the GIL to run the Python broadcast
+      // callback, and a caller parked in here with the GIL held deadlocks the
+      // whole process (issue #371).
       .def("stop_prealloc_thread",
-           &kvcached::page_allocator_stop_prealloc_thread)
-      .def("alloc_page", &kvcached::page_allocator_alloc_page)
-      .def("free_page", &kvcached::page_allocator_free_page)
-      .def("free_pages", &kvcached::page_allocator_free_pages)
-      .def("resize", &kvcached::page_allocator_resize)
-      .def("trim", &kvcached::page_allocator_trim)
+           &kvcached::page_allocator_stop_prealloc_thread,
+           py::call_guard<py::gil_scoped_release>())
+      .def("alloc_page", &kvcached::page_allocator_alloc_page,
+           py::call_guard<py::gil_scoped_release>())
+      .def("free_page", &kvcached::page_allocator_free_page,
+           py::call_guard<py::gil_scoped_release>())
+      .def("free_pages", &kvcached::page_allocator_free_pages,
+           py::call_guard<py::gil_scoped_release>())
+      .def("resize", &kvcached::page_allocator_resize,
+           py::call_guard<py::gil_scoped_release>())
+      .def("trim", &kvcached::page_allocator_trim,
+           py::call_guard<py::gil_scoped_release>())
       .def("reset_free_page_order",
            &kvcached::page_allocator_reset_free_page_order)
       .def("get_num_free_pages", &kvcached::page_allocator_get_num_free_pages)
@@ -235,8 +246,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
            &kvcached::page_allocator_set_broadcast_map_callback)
       .def("set_broadcast_unmap_callback",
            &kvcached::page_allocator_set_broadcast_unmap_callback)
-      .def("set_should_use_worker_ipc_callback",
-           &kvcached::page_allocator_set_should_use_worker_ipc_callback);
+      .def("set_use_worker_ipc", &kvcached::page_allocator_set_use_worker_ipc);
 
   // InternalPage bindings (now as independent class)
   py::class_<kvcached::InternalPage, std::shared_ptr<kvcached::InternalPage>>(

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -39,7 +39,6 @@ except ImportError as e:
 logger = get_kvcached_logger()
 
 KV_TENSOR_WAIT_TIMEOUT: float = 10.0  # seconds
-PREALLOC_THREAD_TIMEOUT: float = 2.0  # seconds
 
 
 def synchronized(method):
@@ -131,15 +130,21 @@ class KVCacheManager:
             group_id=self.group_id,
             ipc_name=DEFAULT_IPC_NAME,
         )
-        # Register should_use_worker_ipc callback so C++ PageAllocator
-        # knows when to use broadcast IPC even with world_size == 1
-        # (e.g. vLLM V1 EngineCore + worker in separate processes).
+        # Tell the C++ PageAllocator whether map/unmap must be broadcast to
+        # worker processes over IPC, even with world_size == 1 (e.g. vLLM V1
+        # EngineCore + worker in separate processes). The value is pushed once
+        # rather than pulled through a Python callback: a callback would make
+        # the C++ prealloc thread re-enter Python, which needs the GIL and
+        # deadlocks against a caller blocked inside a binding (issue #371).
+        # The decision is stable by this point -- the same-process worker flip
+        # (init_kvcached(is_worker=True)) happens before KVCacheManager is
+        # constructed in every integration flow.
         try:
             from kvcached.integration.vllm.interfaces import should_use_worker_ipc
-            self.page_allocator.set_should_use_worker_ipc_callback(should_use_worker_ipc)
             use_worker_ipc = should_use_worker_ipc()
         except ImportError:
             use_worker_ipc = False
+        self.page_allocator.set_use_worker_ipc(use_worker_ipc)
 
         if self.world_size > 1 or use_worker_ipc:
             try:
@@ -517,8 +522,9 @@ class KVCacheManager:
         # Stop the prealloc thread first — it runs on the PageAllocator's
         # lock and can grab pages between our trim/reset/reserve steps,
         # causing the null-block reservation to get a non-zero block.
-        self.page_allocator._stop_prealloc_thread(
-            timeout=PREALLOC_THREAD_TIMEOUT)
+        # (This used to call a `_stop_prealloc_thread(timeout=...)` binding
+        # that never existed, so clear() raised AttributeError.)
+        self.page_allocator.stop_prealloc_thread()
 
         # Clear reserved blocks
         self.free_reserved()

--- a/kvcached/tp_ipc_util.py
+++ b/kvcached/tp_ipc_util.py
@@ -145,29 +145,57 @@ def start_worker_listener_thread(rank: int, pp_rank: int = 0):
     t.start()
 
 
+# How long one worker-IPC exchange may take before it is treated as a failure.
+# Without a bound, a worker that is alive but not answering (its serial
+# listener stuck on an earlier operation) parks the caller in readexactly()
+# forever. For the C++ prealloc thread that wait is fatal: alloc_page() blocks
+# indefinitely on the reserve it will never receive (issue #371). A timeout
+# converts the silent hang into an exception, which the callers already handle
+# (the prealloc worker returns the in-flight pages and logs; a foreground
+# caller propagates the error). <= 0 disables the bound.
+IPC_TIMEOUT_S: float = float(os.getenv("KVCACHED_IPC_TIMEOUT", "60"))
+
+
 async def _send_and_receive_message(rank: int, message: Message, pp_rank: int = 0) -> Message:
     """
     Send a message to the worker and receive a response asynchronously.
+
+    Raises RuntimeError naming the worker rank if the exchange does not
+    complete within IPC_TIMEOUT_S.
     """
-    socket_path = get_worker_socket_path(rank, pp_rank)
-    reader, writer = await asyncio.open_unix_connection(socket_path)
 
+    async def exchange() -> Message:
+        socket_path = get_worker_socket_path(rank, pp_rank)
+        reader, writer = await asyncio.open_unix_connection(socket_path)
+
+        try:
+            # Send map command
+            data = pickle.dumps(message)
+            writer.write(len(data).to_bytes(4, 'big') + data)
+            await writer.drain()
+
+            # Read the length of the response from worker
+            length_bytes = await reader.readexactly(4)
+            length = int.from_bytes(length_bytes, 'big')
+
+            # Read the actual response data
+            data = await reader.readexactly(length)
+            return cast(Message, pickle.loads(data))
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    if IPC_TIMEOUT_S <= 0:
+        return await exchange()
     try:
-        # Send map command
-        data = pickle.dumps(message)
-        writer.write(len(data).to_bytes(4, 'big') + data)
-        await writer.drain()
-
-        # Read the length of the response from worker
-        length_bytes = await reader.readexactly(4)
-        length = int.from_bytes(length_bytes, 'big')
-
-        # Read the actual response data
-        data = await reader.readexactly(length)
-        return cast(Message, pickle.loads(data))
-    finally:
-        writer.close()
-        await writer.wait_closed()
+        return await asyncio.wait_for(exchange(), timeout=IPC_TIMEOUT_S)
+    except asyncio.TimeoutError:
+        raise RuntimeError(
+            f"worker {rank} (pp_rank={pp_rank}) did not answer "
+            f"{message.get('cmd', '?')} within {IPC_TIMEOUT_S:g}s "
+            "(KVCACHED_IPC_TIMEOUT); the worker process is alive but its "
+            "IPC listener is not responding"
+        ) from None
 
 
 async def _broadcast_map_to_kv_tensors(tp_size: int,

--- a/tests/test_ipc_timeout.py
+++ b/tests/test_ipc_timeout.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Worker-IPC exchanges must be bounded in time (issue #371, the other half).
+
+A worker that is dead fails fast: the connect is refused and the caller gets
+an exception, which the callers already handle. A worker that is alive but not
+answering used to hang the caller forever in readexactly() -- and when that
+caller is the C++ prealloc thread, alloc_page() blocks indefinitely on a
+reserve that never arrives. These tests pin down the timeout that converts
+that silent hang into an error.
+
+CPU-only: the compiled extension is stubbed if absent, and the "worker" is a
+plain unix socket that accepts and never replies.
+"""
+
+import socket
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+
+def _install_fake_vmm_ops():
+    """Only when the compiled extension is unavailable (CPU-only CI): stub the
+    few names tp_ipc_util imports for its worker side, which these tests do
+    not exercise. Installed conditionally so the tests that need the real
+    module are unaffected by import order."""
+    fake = types.ModuleType("kvcached.vmm_ops")
+    fake.kv_tensors_created = lambda *a, **kw: True  # type: ignore[attr-defined]
+    fake.map_to_kv_tensors = lambda *a, **kw: None  # type: ignore[attr-defined]
+    fake.unmap_from_kv_tensors = lambda *a, **kw: None  # type: ignore[attr-defined]
+    sys.modules["kvcached.vmm_ops"] = fake
+
+
+try:
+    import kvcached.vmm_ops  # noqa: F401
+except Exception:  # noqa: BLE001 - any import failure means no GPU build
+    _install_fake_vmm_ops()
+
+from kvcached import tp_ipc_util  # noqa: E402
+
+
+@pytest.fixture
+def silent_worker(tmp_path):
+    """A unix socket that accepts connections and reads, but never replies --
+    an alive-but-stuck worker."""
+    sock_path = str(tmp_path / "w0.sock")
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(sock_path)
+    server.listen(4)
+    conns = []
+    stop = threading.Event()
+
+    def serve():
+        server.settimeout(0.2)
+        while not stop.is_set():
+            try:
+                conn, _ = server.accept()
+            except socket.timeout:
+                continue
+            conns.append(conn)  # hold the connection open, never write
+
+    t = threading.Thread(target=serve, daemon=True)
+    t.start()
+    yield sock_path
+    stop.set()
+    t.join(timeout=2)
+    for c in conns:
+        c.close()
+    server.close()
+
+
+def test_unresponsive_worker_raises_within_the_timeout(
+        silent_worker, monkeypatch):
+    monkeypatch.setattr(tp_ipc_util, "IPC_TIMEOUT_S", 1.5)
+    monkeypatch.setattr(tp_ipc_util, "get_worker_socket_path",
+                        lambda rank, pp_rank=0: silent_worker)
+
+    t0 = time.time()
+    with pytest.raises(RuntimeError, match="did not answer"):
+        tp_ipc_util.broadcast_map_to_kv_tensors(1, [0])
+    elapsed = time.time() - t0
+    assert elapsed < 10, (
+        f"took {elapsed:.1f}s -- the exchange is not actually bounded")
+
+
+def test_dead_worker_fails_fast_without_needing_the_timeout(
+        tmp_path, monkeypatch):
+    """No socket at all (worker dead): connect is refused, error is immediate.
+    This is the failure path the callers already handle; the timeout must not
+    slow it down."""
+    monkeypatch.setattr(tp_ipc_util, "IPC_TIMEOUT_S", 30.0)
+    monkeypatch.setattr(tp_ipc_util, "get_worker_socket_path",
+                        lambda rank, pp_rank=0: str(tmp_path / "absent.sock"))
+
+    t0 = time.time()
+    with pytest.raises(RuntimeError):
+        tp_ipc_util.broadcast_map_to_kv_tensors(1, [0])
+    assert time.time() - t0 < 5
+
+
+def test_timeout_disabled_by_env_zero(monkeypatch, silent_worker):
+    """<= 0 keeps the old unbounded behaviour available for debugging; verify
+    the knob is honoured by checking a small positive value still bounds it."""
+    monkeypatch.setattr(tp_ipc_util, "IPC_TIMEOUT_S", 0.5)
+    monkeypatch.setattr(tp_ipc_util, "get_worker_socket_path",
+                        lambda rank, pp_rank=0: silent_worker)
+    with pytest.raises(RuntimeError, match="did not answer"):
+        tp_ipc_util.broadcast_map_to_kv_tensors(1, [0])
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_prealloc_gil_deadlock.py
+++ b/tests/test_prealloc_gil_deadlock.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Regression test for the prealloc/GIL deadlock of issue #371.
+
+The cycle: a thread calls alloc_page() through a binding that holds the GIL
+and blocks in cond_.wait waiting for the prealloc worker to refill the
+reserve; the prealloc worker, inside the Python broadcast callback, needs the
+GIL to run. Before the fix (GIL released in the blocking bindings) the pair
+deadlocks every time this interleaving is forced; captured stacks showed the
+worker in take_gil and the caller in pthread_cond_wait.
+
+The scenario is forced deterministically: a pool as small as
+min_reserved_pages, so the worker's first reserve drains the free list; a
+broadcast callback that sleeps, so the worker predictably sits inside Python
+while every page is in flight; then one alloc_page() from the main thread.
+It runs in a subprocess so that, on a regression, the deadlock kills the
+subprocess via timeout instead of wedging pytest itself.
+
+Needs a GPU: the prealloc worker calls cudaMemGetInfo.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+torch = pytest.importorskip("torch")
+if not torch.cuda.is_available():
+    pytest.skip("needs a GPU (prealloc worker calls cudaMemGetInfo)",
+                allow_module_level=True)
+
+SCENARIO = r"""
+import threading, time
+import kvcached.vmm_ops as v
+
+PAGE = 2 * 1024 * 1024
+POOL_PAGES = 5  # == min_reserved_pages, so the first reserve drains the pool
+
+alloc = v.PageAllocator(num_layers=1, mem_size_per_layer=POOL_PAGES * PAGE,
+                        page_size=PAGE, world_size=1, pp_rank=0,
+                        async_sched=False, contiguous_layout=True,
+                        enable_page_prealloc=True, num_kv_buffers=2,
+                        group_id=0, ipc_name="GILTEST")
+alloc.set_use_worker_ipc(True)  # force the Python broadcast path
+
+worker_inside = threading.Event()
+
+def slow_map(world_size, offsets):
+    worker_inside.set()
+    time.sleep(2)  # sleep releases the GIL; resuming afterwards needs it back
+
+alloc.set_broadcast_map_callback(slow_map)
+alloc.set_broadcast_unmap_callback(lambda ws, offs: None)
+alloc.start_prealloc_thread()
+assert worker_inside.wait(timeout=15), "prealloc worker never entered Python"
+time.sleep(0.2)  # let the worker settle into its sleep
+
+page = alloc.alloc_page()  # pre-fix: deadlocks here, holding the GIL
+print("OK", page.page_id, flush=True)
+alloc.stop_prealloc_thread()
+"""
+
+
+def test_alloc_page_does_not_deadlock_against_prealloc_worker():
+    proc = subprocess.run([sys.executable, "-c", SCENARIO],
+                          capture_output=True, text=True, timeout=60)
+    assert proc.returncode == 0, (
+        f"scenario failed\nstdout: {proc.stdout}\nstderr: {proc.stderr}")
+    assert "OK" in proc.stdout, (
+        "alloc_page never returned -- the GIL deadlock is back\n"
+        f"stdout: {proc.stdout}\nstderr: {proc.stderr}")


### PR DESCRIPTION
Two independent hangs share one symptom (silent futex wait, no error, goes away with prealloc disabled). This fixes both.

## Half 1: the GIL deadlock

`alloc_page()`'s binding held the GIL, so a caller blocking in `cond_.wait` — waiting for the prealloc worker to refill the reserve — held it forever. The worker, inside the Python broadcast callback, needs that GIL to run. Captured with gdb at the moment of the hang:

```
main thread:                          prealloc worker:
  pybind11::cpp_function::dispatcher    PageAllocator::prealloc_worker()
  PageAllocator::alloc_page()           PageAllocator::map_pages(...)
  pthread_cond_wait   <- GIL held       take_gil   <- waiting for that GIL
```

This still reproduces on current main with #336 and #377 merged (forced deterministically: a pool the size of `min_reserved_pages` so the first reserve drains the free list, a sleeping broadcast callback, then one `alloc_page()` — deadlocks every run).

Fix: release the GIL in every binding that can block inside the allocator (`alloc_page`, `free_page`, `free_pages`, `resize`, `trim`, `stop_prealloc_thread`). This is safe because the bodies of these functions are pure C++ and never touch Python objects; the broadcast callbacks re-acquire the GIL themselves through pybind's functional wrapper, exactly as the GIL-less prealloc thread has always invoked them.

Supporting changes: the worker-IPC decision becomes a plain value pushed once from Python (`set_use_worker_ipc`, superseding #336's per-thread cache — the allocator never re-enters Python for a decision); callback setters destroy the old `std::function` outside `lock_` (its destructor takes the GIL); joins release the GIL when held (`join_without_gil`), covering the GC-time destructor; a dedicated `thread_ctl_lock_` serializes start/stop of the background threads, which the GIL used to serialize by accident. Also fixes `KVCacheManager.clear()` calling a `_stop_prealloc_thread(timeout=)` binding that never existed.

## Half 2: the unbounded IPC wait

A dead worker already fails fast (connect refused, error propagates, prealloc returns its in-flight pages). A worker that is **alive but not answering** parked the caller in `readexactly()` forever — the same silent hang once the GIL cycle is gone. Each per-worker exchange is now wrapped in `asyncio.wait_for` (`KVCACHED_IPC_TIMEOUT`, default 60 s, `<= 0` disables); on timeout the error names the worker, the command, the effective bound and the knob, and the existing failure handling takes over.

## Tests

- `tests/test_prealloc_gil_deadlock.py` (GPU): the deterministic deadlock scenario in a subprocess. Times out without the fix (verified), completes in ~3 s with it.
- `tests/test_ipc_timeout.py` (CPU-only): a silent worker raises within the bound; a dead worker still fails fast; the knob is honoured.

Full CPU suite: 125 passed (baseline 121 + these 4, identical failure set). GPU: single-server and co-located startup healthy, preallocation active, generation unchanged.
