### PR TITLE
Fix vLLM padded KV page allocation and strides

### DIFF
--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -106,6 +106,41 @@ def shutdown_kvcached() -> None:
     _async_sched = False
 
 
+def _resolve_page_geometry(
+    logical_page_size_bytes: int,
+    padded_page_size_bytes: Optional[int],
+    num_k_or_v: int,
+    dtype: torch.dtype,
+    kernel_blocks_per_page: int,
+) -> Tuple[int, int]:
+    """Return the physical page and per-buffer block sizes in bytes."""
+    page_size_bytes = (
+        logical_page_size_bytes
+        if padded_page_size_bytes is None
+        else padded_page_size_bytes
+    )
+    if page_size_bytes < logical_page_size_bytes:
+        raise ValueError(
+            f"physical page size ({page_size_bytes}) is smaller than the "
+            f"logical KV page ({logical_page_size_bytes})")
+    if page_size_bytes % num_k_or_v != 0:
+        raise ValueError(
+            f"physical page size ({page_size_bytes}) is not divisible by "
+            f"the K/V count ({num_k_or_v})")
+
+    block_mem_bytes = page_size_bytes // num_k_or_v
+    if block_mem_bytes % dtype.itemsize != 0:
+        raise ValueError(
+            f"per-buffer block size ({block_mem_bytes}) is not aligned to "
+            f"dtype size ({dtype.itemsize})")
+    if (page_size_bytes != logical_page_size_bytes
+            and kernel_blocks_per_page > 1):
+        raise NotImplementedError(
+            "kvcached cannot represent a padded virtual KV page that is split "
+            "into multiple kernel blocks with one strided tensor view")
+    return page_size_bytes, block_mem_bytes
+
+
 def build_kv_views(
     raw_kv_tensors: List[torch.Tensor],
     kvcache_shape: Tuple[int, ...],
@@ -116,6 +151,7 @@ def build_kv_views(
     gpu_mem_bytes_per_layer_k_or_v: int,
     num_layers: int,
     kernel_block_size: Optional[int] = None,
+    padded_page_size_bytes: Optional[int] = None,
 ) -> Tuple[List[torch.Tensor], int]:
     """Reinterpret already-allocated raw KV pools as per-layer KV views.
 
@@ -133,7 +169,8 @@ def build_kv_views(
     shape/stride from that one uniform block stride. The one exception is
     ``contiguous`` + ``kernel_block_size != block_size``, which raises: that
     branch reshapes at virtual-block granularity and has no kernel-block form
-    yet.
+    yet. ``padded_page_size_bytes`` is vLLM's unified physical page size;
+    when omitted, the logical tensor geometry is unchanged.
     """
     is_mla = attention_type == "MLA"
     unified_pool = attention_type == "HYBRID_LINEAR"
@@ -161,9 +198,16 @@ def build_kv_views(
     actual_kvcache_shape: List[int] = list(kvcache_shape)
     actual_kvcache_shape[blocks_dim_idx] = num_blocks_per_layer
 
-    page_size_bytes = math.prod(
+    logical_page_size_bytes = math.prod(
         actual_kvcache_shape[:blocks_dim_idx] + actual_kvcache_shape[blocks_dim_idx + 1:]
     ) * dtype.itemsize
+    page_size_bytes, block_mem_bytes = _resolve_page_geometry(
+        logical_page_size_bytes,
+        padded_page_size_bytes,
+        num_k_or_v,
+        dtype,
+        ratio,
+    )
 
     kernel_kvcache_shape: List[int] = list(actual_kvcache_shape)
     if ratio > 1:
@@ -174,11 +218,19 @@ def build_kv_views(
     if not _contiguous_layout:
         kv_tensors: List[torch.Tensor] = []
         if is_mla:
-            num_eles = math.prod(kernel_kvcache_shape)
-            kv_tensors = [
-                t.view(dtype=dtype)[:num_eles].view(kernel_kvcache_shape)
-                for t in raw_kv_tensors
-            ]
+            if page_size_bytes == logical_page_size_bytes:
+                num_eles = math.prod(kernel_kvcache_shape)
+                kv_tensors = [
+                    t.view(dtype=dtype)[:num_eles].view(kernel_kvcache_shape)
+                    for t in raw_kv_tensors
+                ]
+            else:
+                strides = list(torch.empty(kernel_kvcache_shape).stride())
+                strides[blocks_dim_idx] = block_mem_bytes // dtype.itemsize
+                kv_tensors = [
+                    torch.as_strided(t.view(dtype=dtype), kernel_kvcache_shape, strides)
+                    for t in raw_kv_tensors
+                ]
         else:
             shape = list(kernel_kvcache_shape)
             strides = [0] * len(shape)
@@ -186,6 +238,11 @@ def build_kv_views(
             for i in range(len(shape) - 2, 1, -1):
                 strides[i] = strides[i + 1] * shape[i + 1]
             hidden_size_eles = strides[2] * shape[2]
+            block_stride_eles = (
+                block_mem_bytes // dtype.itemsize
+                if page_size_bytes != logical_page_size_bytes
+                else hidden_size_eles
+            )
             if unified_pool:
                 if blocks_dim_idx == 1:
                     strides[1] = 2 * hidden_size_eles
@@ -196,10 +253,10 @@ def build_kv_views(
             else:
                 v_offset_eles = gpu_mem_bytes_per_layer_k_or_v // dtype.itemsize
                 if blocks_dim_idx == 1:
-                    strides[1] = hidden_size_eles
+                    strides[1] = block_stride_eles
                     strides[0] = v_offset_eles
                 else:
-                    strides[0] = hidden_size_eles
+                    strides[0] = block_stride_eles
                     strides[1] = v_offset_eles
             for t in raw_kv_tensors:
                 kv_tensors.append(
@@ -221,13 +278,38 @@ def build_kv_views(
                 f"layout do not support kernel_block_size ({kernel_block_size}) "
                 f"!= block_size ({block_size}). Re-launch with "
                 "KVCACHED_CONTIGUOUS_LAYOUT=false.")
-        layer_elem_shape = actual_kvcache_shape[:blocks_dim_idx] + actual_kvcache_shape[blocks_dim_idx + 1:]
-        contiguous_shape = [num_blocks_per_layer, num_layers] + layer_elem_shape
-        num_eles = math.prod(contiguous_shape)
-        contiguous_tensor = raw_kv_tensors[0].view(dtype=dtype)[:num_eles].view(contiguous_shape)
-        kv_tensors = [
-            contiguous_tensor[:, i].permute(*permute_order) for i in range(num_layers)
-        ]
+        if page_size_bytes == logical_page_size_bytes:
+            layer_elem_shape = actual_kvcache_shape[:blocks_dim_idx] + actual_kvcache_shape[blocks_dim_idx + 1:]
+            contiguous_shape = [num_blocks_per_layer, num_layers] + layer_elem_shape
+            num_eles = math.prod(contiguous_shape)
+            contiguous_tensor = raw_kv_tensors[0].view(dtype=dtype)[:num_eles].view(contiguous_shape)
+            kv_tensors = [
+                contiguous_tensor[:, i].permute(*permute_order) for i in range(num_layers)
+            ]
+        else:
+            shape = list(kernel_kvcache_shape)
+            strides = list(torch.empty(shape).stride())
+            page_stride_eles = page_size_bytes // dtype.itemsize
+            block_stride_eles = num_layers * page_stride_eles
+            kv_stride_eles = block_mem_bytes // dtype.itemsize
+            if is_mla:
+                strides[blocks_dim_idx] = block_stride_eles
+            elif blocks_dim_idx == 1:
+                strides[1] = block_stride_eles
+                strides[0] = kv_stride_eles
+            else:
+                strides[0] = block_stride_eles
+                strides[1] = kv_stride_eles
+            flat = raw_kv_tensors[0].view(dtype=dtype)
+            kv_tensors = [
+                torch.as_strided(
+                    flat,
+                    shape,
+                    strides,
+                    storage_offset=i * page_stride_eles,
+                )
+                for i in range(num_layers)
+            ]
 
     return kv_tensors, page_size_bytes
 
@@ -272,6 +354,7 @@ def alloc_kv_cache(
     group_id: int = 0,
     kernel_block_size: Optional[int] = None,
     return_meta: bool = False,
+    padded_page_size_bytes: Optional[int] = None,
 ) -> List[torch.Tensor]:
     """Allocate KV cache tensors for all supported attention types.
 
@@ -286,6 +369,9 @@ def alloc_kv_cache(
       - FlashInfer: (num_blocks, 2, block_size, head_num, head_dim)
     For MLA, kvcache_shape is expected to be:
       - (num_blocks, block_size, head_size)
+
+    ``padded_page_size_bytes`` must be provided when vLLM pads attention pages
+    during page-size unification. It controls both capacity and block strides.
 
     ``attention_type="HYBRID_LINEAR"`` selects the layout for hybrid
     models that mix full attention with linear attention (mamba/SSM).
@@ -362,7 +448,7 @@ def alloc_kv_cache(
             )
         blocks_dim_idx = 0
         permute_order = list(range(len(kvcache_shape)))
-        block_mem_bytes = math.prod(kvcache_shape[1:]) * dtype.itemsize
+        logical_page_size_bytes = math.prod(kvcache_shape[1:]) * dtype.itemsize
     else:
         # MHA/GQA shape with K/V dimension
         if (len(kvcache_shape) <= 3
@@ -381,7 +467,17 @@ def alloc_kv_cache(
         else:
             raise ValueError(f"Unsupported kv cache shape: {kvcache_shape}")
 
-        block_mem_bytes = math.prod(kvcache_shape[2:]) * dtype.itemsize
+        logical_page_size_bytes = math.prod(
+            kvcache_shape[:blocks_dim_idx] + kvcache_shape[blocks_dim_idx + 1:]
+        ) * dtype.itemsize
+
+    page_size_bytes, block_mem_bytes = _resolve_page_geometry(
+        logical_page_size_bytes,
+        padded_page_size_bytes,
+        num_k_or_v,
+        dtype,
+        ratio,
+    )
 
     requested_num_blocks = kvcache_shape[blocks_dim_idx]
 
@@ -431,10 +527,6 @@ def alloc_kv_cache(
     actual_kvcache_shape: List[int] = list(kvcache_shape)
     actual_kvcache_shape[blocks_dim_idx] = num_blocks_per_layer
 
-    page_size_bytes = math.prod(
-        actual_kvcache_shape[:blocks_dim_idx] + actual_kvcache_shape[blocks_dim_idx + 1:]
-    ) * dtype.itemsize
-
     # Build a second shape expressed at kernel-block granularity. vLLM's zero
     # kernel and attention kernels index the KV tensor using ``kernel_bs``-
     # token blocks; each virtual block is ``ratio`` contiguous kernel blocks.
@@ -450,11 +542,19 @@ def alloc_kv_cache(
     if not _contiguous_layout:
         kv_tensors: List[torch.Tensor] = []
         if is_mla:
-            num_eles = math.prod(kernel_kvcache_shape)
-            kv_tensors = [
-                t.view(dtype=dtype)[:num_eles].view(kernel_kvcache_shape)
-                for t in raw_kv_tensors
-            ]
+            if page_size_bytes == logical_page_size_bytes:
+                num_eles = math.prod(kernel_kvcache_shape)
+                kv_tensors = [
+                    t.view(dtype=dtype)[:num_eles].view(kernel_kvcache_shape)
+                    for t in raw_kv_tensors
+                ]
+            else:
+                strides = list(torch.empty(kernel_kvcache_shape).stride())
+                strides[blocks_dim_idx] = block_mem_bytes // dtype.itemsize
+                kv_tensors = [
+                    torch.as_strided(t.view(dtype=dtype), kernel_kvcache_shape, strides)
+                    for t in raw_kv_tensors
+                ]
         else:
             # Build attention view with as_strided. Two modes:
             #   split-half (default): K occupies [0, v_offset), V occupies
@@ -472,6 +572,11 @@ def alloc_kv_cache(
                 strides[i] = strides[i + 1] * shape[i + 1]
             # hidden_size_eles uses kernel_block_size (shape[2]), not block_size.
             hidden_size_eles = strides[2] * shape[2]  # = kernel_bs * h * d
+            block_stride_eles = (
+                block_mem_bytes // dtype.itemsize
+                if page_size_bytes != logical_page_size_bytes
+                else hidden_size_eles
+            )
             if unified_pool:
                 # Block-interleaved at kernel granularity: inter-(kernel-)block
                 # stride = 2*hidden_size; K/V dim stride = hidden_size.
@@ -484,10 +589,10 @@ def alloc_kv_cache(
             else:
                 v_offset_eles = gpu_mem_bytes_per_layer_k_or_v // dtype.itemsize
                 if blocks_dim_idx == 1:          # FlashAttn (2, N*ratio, ...)
-                    strides[1] = hidden_size_eles
+                    strides[1] = block_stride_eles
                     strides[0] = v_offset_eles
                 else:                             # FlashInfer (N*ratio, 2, ...)
-                    strides[0] = hidden_size_eles
+                    strides[0] = block_stride_eles
                     strides[1] = v_offset_eles
             for t in raw_kv_tensors:
                 kv_tensors.append(
@@ -519,13 +624,37 @@ def alloc_kv_cache(
                              storage_offset=i * 2 * hidden_size_eles)
             for i in range(num_layers)
         ]
-    else:
+    elif page_size_bytes == logical_page_size_bytes:
         layer_elem_shape = actual_kvcache_shape[:blocks_dim_idx] + actual_kvcache_shape[blocks_dim_idx + 1:]
         contiguous_shape = [num_blocks_per_layer, num_layers] + layer_elem_shape
         num_eles = math.prod(contiguous_shape)
         contiguous_tensor = raw_kv_tensors[0].view(dtype=dtype)[:num_eles].view(contiguous_shape)
         kv_tensors = [
             contiguous_tensor[:, i].permute(*permute_order) for i in range(num_layers)
+        ]
+    else:
+        shape = list(kernel_kvcache_shape)
+        strides = list(torch.empty(shape).stride())
+        page_stride_eles = page_size_bytes // dtype.itemsize
+        block_stride_eles = num_layers * page_stride_eles
+        kv_stride_eles = block_mem_bytes // dtype.itemsize
+        if is_mla:
+            strides[blocks_dim_idx] = block_stride_eles
+        elif blocks_dim_idx == 1:
+            strides[1] = block_stride_eles
+            strides[0] = kv_stride_eles
+        else:
+            strides[0] = block_stride_eles
+            strides[1] = kv_stride_eles
+        flat = raw_kv_tensors[0].view(dtype=dtype)
+        kv_tensors = [
+            torch.as_strided(
+                flat,
+                shape,
+                strides,
+                storage_offset=i * page_stride_eles,
+            )
+            for i in range(num_layers)
         ]
 
     meta = {
@@ -534,6 +663,7 @@ def alloc_kv_cache(
         "gpu_mem_bytes_per_layer_k_or_v": gpu_mem_bytes_per_layer_k_or_v,
         "num_layers": num_layers,
         "dtype": dtype,
+        "page_size_bytes": page_size_bytes,
     }
 
     if not unified_pool:

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -1396,6 +1396,8 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 num_layers,
                 attention_type=attention_type,
                 kv_layout="NHD",
+                padded_page_size_bytes=getattr(
+                    kv_cache_spec, "page_size_padded", None),
             )
             layer_id = 0
             for kv_cache_group in kv_cache_config.kv_cache_groups:
@@ -1622,6 +1624,8 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 kv_layout="NHD",
                 kernel_block_size=kernel_block_size,
                 return_meta=is_hetero,
+                padded_page_size_bytes=getattr(
+                    kv_cache_spec, "page_size_padded", None),
             )
 
             if attention_type == "HYBRID_LINEAR":
@@ -1656,6 +1660,8 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                         attention_type, meta["num_blocks_per_layer"],
                         meta["gpu_mem_bytes_per_layer_k_or_v"], meta["num_layers"],
                         kernel_block_size=gkbs,
+                        padded_page_size_bytes=getattr(
+                            gspec, "page_size_padded", None),
                     )
                     for pool_idx, layer_name in enumerate(grp.layer_names):
                         layer_views[layer_name] = gviews[pool_idx]

--- a/tests/manifests/cpu.txt
+++ b/tests/manifests/cpu.txt
@@ -14,5 +14,6 @@ tests/test_shm_info_tracker.py
 tests/test_sleep_manager.py
 tests/test_test_classification.py
 tests/test_vllm_nixl_compat.py
+tests/test_vllm_padded_page_size.py
 tests/test_vllm_pool_exhaustion.py
 tests/test_vllm_tp_world_size.py

--- a/tests/test_vllm_padded_page_size.py
+++ b/tests/test_vllm_padded_page_size.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for vLLM attention pages padded by ``unify_page_size``."""
+
+import importlib
+import sys
+import types
+
+import pytest
+import torch
+
+
+def _install_fake_vmm_ops(monkeypatch=None):
+    """Allow the tensor-layout tests to run without the compiled extension."""
+
+    class _PageAllocator:
+        pass
+
+    class _InternalPage:
+        pass
+
+    fake = types.ModuleType("kvcached.vmm_ops")
+    fake.PageAllocator = _PageAllocator  # type: ignore[attr-defined]
+    fake.InternalPage = _InternalPage  # type: ignore[attr-defined]
+    fake.create_kv_tensors = lambda *args, **kwargs: []  # type: ignore[attr-defined]
+    fake.init_kvcached = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    fake.shutdown_kvcached = lambda: None  # type: ignore[attr-defined]
+    fake.kv_tensors_created = lambda *args, **kwargs: True  # type: ignore[attr-defined]
+    fake.map_to_kv_tensors = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    fake.unmap_from_kv_tensors = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+    if monkeypatch is None:
+        sys.modules["kvcached.vmm_ops"] = fake
+    else:
+        monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", fake)
+
+
+try:
+    import kvcached.vmm_ops  # noqa: F401
+except Exception:  # noqa: BLE001 - any import failure means no GPU build
+    _install_fake_vmm_ops()
+
+from kvcached.utils import PAGE_SIZE  # noqa: E402
+
+BLOCK_SIZE = 16
+DTYPE = torch.float16
+NUM_LAYERS = 2
+FLASH_ATTN_SHAPE = (2, 4, BLOCK_SIZE, 1, 4)
+FLASH_INFER_SHAPE = (4, 2, BLOCK_SIZE, 1, 4)
+LOGICAL_PAGE_BYTES = 256
+PADDED_PAGE_BYTES = 512
+
+
+class _FakeProps:
+
+    def __init__(self, total_memory: int):
+        self.total_memory = total_memory
+
+
+@pytest.fixture()
+def interfaces(monkeypatch):
+    _install_fake_vmm_ops(monkeypatch)
+    monkeypatch.delitem(
+        sys.modules, "kvcached.integration.vllm.interfaces", raising=False
+    )
+    import kvcached.integration.vllm as vllm_integration
+
+    monkeypatch.delattr(vllm_integration, "interfaces", raising=False)
+    mod = importlib.import_module("kvcached.integration.vllm.interfaces")
+    monkeypatch.setattr(mod, "_kvcached_initialized", True, raising=False)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(
+        torch.cuda,
+        "get_device_properties",
+        lambda _device=None: _FakeProps(8 * PAGE_SIZE),
+    )
+
+    def _cpu_create(ftensor_bytes_per_layer, _itemsize, _device, num_layers,
+                    **_kwargs):
+        return [
+            torch.empty(ftensor_bytes_per_layer, dtype=torch.uint8)
+            for _ in range(num_layers)
+        ]
+
+    monkeypatch.setattr(mod, "create_kv_tensors", _cpu_create)
+    return mod
+
+
+def _raw_pools(num_blocks: int = 4):
+    # Split-half MHA stores K and V in two halves of every per-layer FTensor.
+    bytes_per_pool = 2 * num_blocks * PADDED_PAGE_BYTES
+    return [
+        torch.empty(bytes_per_pool, dtype=torch.uint8)
+        for _ in range(NUM_LAYERS)
+    ]
+
+
+@pytest.mark.parametrize(
+    ("shape", "blocks_dim", "kv_dim"),
+    [
+        (FLASH_ATTN_SHAPE, 1, 0),
+        (FLASH_INFER_SHAPE, 0, 1),
+    ],
+)
+def test_noncontiguous_views_use_padded_block_stride(
+    interfaces, monkeypatch, shape, blocks_dim, kv_dim
+):
+    monkeypatch.setattr(interfaces, "_contiguous_layout", False)
+    views, page_size = interfaces.build_kv_views(
+        _raw_pools(),
+        shape,
+        BLOCK_SIZE,
+        DTYPE,
+        "MHA",
+        num_blocks_per_layer=4,
+        gpu_mem_bytes_per_layer_k_or_v=4 * PADDED_PAGE_BYTES,
+        num_layers=NUM_LAYERS,
+        padded_page_size_bytes=PADDED_PAGE_BYTES,
+    )
+
+    assert page_size == PADDED_PAGE_BYTES
+    assert views[0].stride(blocks_dim) == PADDED_PAGE_BYTES // 2 // DTYPE.itemsize
+    assert views[0].stride(kv_dim) == 4 * PADDED_PAGE_BYTES // DTYPE.itemsize
+
+
+@pytest.mark.parametrize(
+    ("shape", "blocks_dim", "kv_dim"),
+    [
+        (FLASH_ATTN_SHAPE, 1, 0),
+        (FLASH_INFER_SHAPE, 0, 1),
+    ],
+)
+def test_contiguous_views_use_padded_page_and_layer_strides(
+    interfaces, monkeypatch, shape, blocks_dim, kv_dim
+):
+    monkeypatch.setattr(interfaces, "_contiguous_layout", True)
+    raw = [torch.empty(4 * NUM_LAYERS * PADDED_PAGE_BYTES, dtype=torch.uint8)]
+    views, page_size = interfaces.build_kv_views(
+        raw,
+        shape,
+        BLOCK_SIZE,
+        DTYPE,
+        "MHA",
+        num_blocks_per_layer=4,
+        gpu_mem_bytes_per_layer_k_or_v=4 * PADDED_PAGE_BYTES,
+        num_layers=NUM_LAYERS,
+        padded_page_size_bytes=PADDED_PAGE_BYTES,
+    )
+
+    page_stride = PADDED_PAGE_BYTES // DTYPE.itemsize
+    assert page_size == PADDED_PAGE_BYTES
+    assert views[0].stride(blocks_dim) == NUM_LAYERS * page_stride
+    assert views[0].stride(kv_dim) == page_stride // 2
+    assert views[0].storage_offset() == 0
+    assert views[1].storage_offset() == page_stride
+
+
+def test_alloc_uses_padded_page_size_for_block_count(interfaces, monkeypatch):
+    monkeypatch.setattr(interfaces, "_contiguous_layout", False)
+    _views, meta = interfaces.alloc_kv_cache(
+        FLASH_INFER_SHAPE,
+        BLOCK_SIZE,
+        DTYPE,
+        "cuda:0",
+        NUM_LAYERS,
+        attention_type="MHA",
+        return_meta=True,
+        padded_page_size_bytes=PADDED_PAGE_BYTES,
+    )
+
+    bytes_per_layer_per_kv = (8 * PAGE_SIZE) // NUM_LAYERS // 2
+    assert meta["num_blocks_per_layer"] == (
+        bytes_per_layer_per_kv // (PADDED_PAGE_BYTES // 2)
+    )
+    assert meta["page_size_bytes"] == PADDED_PAGE_BYTES
+
+
+def test_unpadded_page_keeps_legacy_stride(interfaces, monkeypatch):
+    monkeypatch.setattr(interfaces, "_contiguous_layout", False)
+    kwargs = dict(
+        raw_kv_tensors=_raw_pools(),
+        kvcache_shape=FLASH_INFER_SHAPE,
+        block_size=BLOCK_SIZE,
+        dtype=DTYPE,
+        attention_type="MHA",
+        num_blocks_per_layer=4,
+        gpu_mem_bytes_per_layer_k_or_v=4 * PADDED_PAGE_BYTES,
+        num_layers=NUM_LAYERS,
+    )
+    legacy, _ = interfaces.build_kv_views(**kwargs)
+    explicit, _ = interfaces.build_kv_views(
+        **kwargs,
+        padded_page_size_bytes=LOGICAL_PAGE_BYTES,
+    )
+
+    assert legacy[0].shape == explicit[0].shape
+    assert legacy[0].stride() == explicit[0].stride()
+    assert legacy[0].storage_offset() == explicit[0].storage_offset()
+
+
+def test_unpadded_page_keeps_kernel_block_stride(interfaces, monkeypatch):
+    monkeypatch.setattr(interfaces, "_contiguous_layout", False)
+    views, _ = interfaces.build_kv_views(
+        _raw_pools(),
+        FLASH_INFER_SHAPE,
+        BLOCK_SIZE,
+        DTYPE,
+        "MHA",
+        num_blocks_per_layer=4,
+        gpu_mem_bytes_per_layer_k_or_v=4 * PADDED_PAGE_BYTES,
+        num_layers=NUM_LAYERS,
+        kernel_block_size=BLOCK_SIZE // 2,
+    )
+
+    kernel_block_elements = (BLOCK_SIZE // 2) * FLASH_INFER_SHAPE[3] * FLASH_INFER_SHAPE[4]
+    assert views[0].stride(0) == kernel_block_elements
+
+
+def test_padded_page_with_multiple_kernel_blocks_fails_loud(interfaces):
+    with pytest.raises(NotImplementedError, match="padded virtual KV page"):
+        interfaces.build_kv_views(
+            _raw_pools(),
+            FLASH_INFER_SHAPE,
+            BLOCK_SIZE,
+            DTYPE,
+            "MHA",
+            num_blocks_per_layer=4,
+            gpu_mem_bytes_per_layer_k_or_v=4 * PADDED_PAGE_BYTES,
+            num_layers=NUM_LAYERS,
+            kernel_block_size=BLOCK_SIZE // 2,
+            padded_page_size_bytes=PADDED_PAGE_BYTES,
+        )


### PR DESCRIPTION
## Summary

- propagate vLLM's `page_size_padded` into kvcached KV allocation and view construction
- use the padded physical page size for both block-capacity calculation and tensor block strides
- preserve the existing unpadded path and fail loudly when padding is combined with multiple kernel blocks per virtual page

## Validation

- `python3 -m pytest -q tests/test_vllm_padded_page_size.py tests/test_hybrid_contiguous_layout.py tests/test_alloc_kv_cache_alignment.py tests/test_vllm_nixl_compat.py` (`70 passed` in a GPU-enabled Linux container)
- Ruff, codespell, isort, clang-format, PyMarkdown, actionlint, and trailing-whitespace hooks passed
- mypy passed for all changed Python files in Linux

Fixes #399
