### PR TITLE
fix(vllm): keep prefix caching enabled for small positive KVCACHED_MAX_CACHED_TOKENS

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -306,12 +306,16 @@ def _get_max_cached_blocks(block_size: int) -> int:
 
     Returns -1 (unlimited) when MAX_CACHED_TOKENS < 0.
     Returns 0  (disabled — evict on free) when MAX_CACHED_TOKENS == 0.
-    Otherwise returns MAX_CACHED_TOKENS // block_size.
+    Otherwise returns MAX_CACHED_TOKENS // block_size, floored at 1 so that a
+    positive token budget smaller than block_size still keeps prefix caching
+    enabled instead of silently disabling it.
     """
     from kvcached.utils import MAX_CACHED_TOKENS
     if MAX_CACHED_TOKENS < 0:
         return -1
-    return MAX_CACHED_TOKENS // block_size
+    if MAX_CACHED_TOKENS == 0:
+        return 0
+    return max(1, MAX_CACHED_TOKENS // block_size)
 
 
 def _make_cache_key(block_hash: Any, group_id: int) -> bytes:

--- a/tests/test_max_cached_blocks.py
+++ b/tests/test_max_cached_blocks.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``_get_max_cached_blocks`` (prefix-cache block budget).
+
+GPU-free: ``_get_max_cached_blocks`` is a module-level function in
+``kvcached.integration.vllm.patches`` and needs neither the ``vmm_ops``
+extension, a GPU, nor an installed vLLM. It guards the low-boundary fix: a
+positive ``KVCACHED_MAX_CACHED_TOKENS`` smaller than ``block_size`` used to
+truncate to 0, which silently disabled prefix caching (0 means "evict on
+free").
+"""
+import pytest
+
+import kvcached.utils
+from kvcached.integration.vllm.patches import _get_max_cached_blocks
+
+
+def _set_max_cached_tokens(monkeypatch, value: int) -> None:
+    # The function re-imports MAX_CACHED_TOKENS from kvcached.utils on each
+    # call, so patching the module attribute is sufficient.
+    monkeypatch.setattr(kvcached.utils, "MAX_CACHED_TOKENS", value)
+
+
+def test_negative_means_unlimited(monkeypatch):
+    _set_max_cached_tokens(monkeypatch, -1)
+    assert _get_max_cached_blocks(block_size=16) == -1
+
+
+def test_zero_means_disabled(monkeypatch):
+    _set_max_cached_tokens(monkeypatch, 0)
+    assert _get_max_cached_blocks(block_size=16) == 0
+
+
+def test_exact_multiple(monkeypatch):
+    _set_max_cached_tokens(monkeypatch, 16000)
+    assert _get_max_cached_blocks(block_size=16) == 1000
+
+
+def test_rounds_down_to_whole_blocks(monkeypatch):
+    _set_max_cached_tokens(monkeypatch, 100)
+    assert _get_max_cached_blocks(block_size=16) == 6
+
+
+@pytest.mark.parametrize("tokens", [1, 8, 15])
+def test_small_positive_budget_keeps_caching_enabled(monkeypatch, tokens):
+    """Regression: tokens < block_size must not truncate to 0 (disabled)."""
+    _set_max_cached_tokens(monkeypatch, tokens)
+    assert _get_max_cached_blocks(block_size=16) == 1


### PR DESCRIPTION
## Summary

Keep prefix caching enabled when `KVCACHED_MAX_CACHED_TOKENS` is positive but smaller than `block_size`.

Fixes #343.

## Root cause

`_get_max_cached_blocks()` computes `MAX_CACHED_TOKENS // block_size`. A positive budget smaller than `block_size` (e.g. `KVCACHED_MAX_CACHED_TOKENS=8` with `block_size=16`) integer-divides to `0`, which is indistinguishable from the `== 0` "disabled — evict on free" sentinel, so prefix caching is silently turned off even though the user asked for a small positive budget.

## Changes

- floor the positive-budget result at one block: `max(1, MAX_CACHED_TOKENS // block_size)`, as suggested in the issue
- the `< 0` (unlimited) and `== 0` (explicitly disabled) sentinels are unchanged
- add `tests/test_max_cached_blocks.py`, a CPU-only unit test in the same style as `tests/test_make_cache_key.py` (no vLLM, no `vmm_ops` extension): sentinel passthrough, exact multiples, rounding down, and the regression cases `1, 8, 15` tokens with `block_size=16` → `1` block (previously `0`)

## Validation

```bash
python -m pytest tests/test_max_cached_blocks.py -q  # 7 passed
```

`ruff check` and `isort --check-only` pass on the changed files.

Related: #380 and #405 also address this issue.
