### PR TITLE
ci: run the CPU-only pytest suite in GitHub Actions

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,52 @@
+name: Python Tests
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  pytest-cpu:
+    name: pytest (CPU-only)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+
+      - name: Install CPU-only PyTorch
+        run: pip install torch --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pyyaml numpy aiohttp
+
+      # Run the subset of the pytest suite that works without a GPU and
+      # without the compiled kvcached.vmm_ops extension (building vmm_ops
+      # requires a CUDA or ROCm PyTorch, which CI runners don't have).
+      #
+      # Excluded and why:
+      #   - test_ElasticMLAMemoryPool, test_kvcache_manager,
+      #     test_offline_serving, test_paged_allocator_aliasing,
+      #     test_alloc_kv_cache_alignment, test_hybrid_contiguous_layout,
+      #     test_ipc_timeout: import or exercise kvcached.vmm_ops
+      #   - test_sleep_manager: async tests that expect running
+      #     vLLM/SGLang server endpoints
+      - name: Run CPU-only pytest suite
+        run: |
+          python -m pytest tests/ -v \
+            --ignore=tests/test_ElasticMLAMemoryPool.py \
+            --ignore=tests/test_kvcache_manager.py \
+            --ignore=tests/test_offline_serving.py \
+            --ignore=tests/test_paged_allocator_aliasing.py \
+            --ignore=tests/test_alloc_kv_cache_alignment.py \
+            --ignore=tests/test_hybrid_contiguous_layout.py \
+            --ignore=tests/test_ipc_timeout.py \
+            --ignore=tests/test_sleep_manager.py


### PR DESCRIPTION
## Summary

Run the CPU-only pytest suite in GitHub Actions on every push and pull request.

Fixes #395.

## Problem

The only existing workflow (`pre-commit.yml`) runs lint/format/mypy and the C++ unit tests, but none of the Python tests under `tests/` run in CI, so regressions in the pure-Python paths are only caught when someone runs the right test by hand.

## Changes

- add `.github/workflows/python-tests.yml`: installs CPU-only PyTorch (`--index-url https://download.pytorch.org/whl/cpu`) plus `requirements.txt` and the test-only deps (`pyyaml`, `numpy`, `aiohttp`), with pip caching
- run `pytest tests/` with an explicit, commented ignore list for what cannot run on a CPU runner:
  - `test_ElasticMLAMemoryPool`, `test_kvcache_manager`, `test_offline_serving`, `test_paged_allocator_aliasing`, `test_alloc_kv_cache_alignment`, `test_hybrid_contiguous_layout`, `test_ipc_timeout` — import or exercise the compiled `kvcached.vmm_ops` extension, whose build requires a CUDA/ROCm PyTorch (`setup.py` raises on CPU-only builds)
  - `test_sleep_manager` — async tests that expect running vLLM/SGLang server endpoints

Everything else runs, including the `/dev/shm`-backed `test_shm_info_tracker` tests, which are Linux-only and cannot run on macOS dev machines at all.

## Validation

Verified on an actual `ubuntu-latest` runner via my fork before opening this PR: [green run](https://github.com/rishabhsinha17/kvcached/actions/runs/31072484068) — `81 passed, 1 skipped`.

Possible follow-ups: split the `vmm_ops`-dependent files so their pure-Python tests also run in CI, and add a GPU-runner job for the rest.

Related: #403 proposes a manifest-based classification approach to the same issue; this PR is the minimal single-workflow variant.
