### PR TITLE
fix(sglang): move free indices to CPU before torch.unique in paged allocator free path

### DIFF
--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -27,6 +27,24 @@ def _is_supported_gpu_device(device: str) -> bool:
     return device_str.startswith("cuda") or device_str.startswith("hip")
 
 
+def _free_page_ids(free_index: Any, page_size: int) -> List[int]:
+    """Derive the unique page ids covered by ``free_index`` as Python ints.
+
+    The allocator backend only needs page-id integers for bookkeeping, so the
+    tensor is moved to CPU *before* the unique/int conversion. Running
+    ``torch.unique`` on a GPU ``free_index`` would couple free bookkeeping to
+    CUDA execution and synchronization behavior, which is fragile on
+    high-concurrency serving paths.
+
+    Module-level (rather than a method on the injected allocator class) so it
+    is unit-testable without an installed SGLang or a GPU.
+    """
+    import torch
+
+    free_index_cpu = free_index.cpu()
+    return torch.unique(free_index_cpu // page_size).tolist()
+
+
 class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
     """Inject ElasticTokenToKVPoolAllocator into SGLang's allocator module"""
 
@@ -283,12 +301,9 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
                         return
 
                     if self.is_not_in_free_group:
-                        page_ids = torch.unique(free_index // self.page_size)
-                        try:
-                            indices: list[int] = page_ids.cpu().numpy().tolist()
-                        except Exception:
-                            indices = list(page_ids)
-                        return self.kvcached_allocator.free(indices)
+                        return self.kvcached_allocator.free(
+                            _free_page_ids(free_index, self.page_size)
+                        )
                     else:
                         self.free_group.append(free_index)
 

--- a/tests/test_free_page_ids.py
+++ b/tests/test_free_page_ids.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``_free_page_ids`` (SGLang paged-allocator free path).
+
+GPU-free: ``_free_page_ids`` is a module-level function in
+``kvcached.integration.sglang.patches`` and needs neither an installed SGLang
+nor a GPU. It guards the CPU-conversion fix: unique page ids must be derived
+from CPU data so allocator free bookkeeping does not couple to CUDA device
+execution and synchronization (issue #382).
+"""
+import pytest
+import torch
+
+from kvcached.integration.sglang.patches import _free_page_ids
+
+
+def test_single_page():
+    assert _free_page_ids(torch.tensor([0, 1, 2, 3]), page_size=4) == [0]
+
+
+def test_multiple_pages_deduplicated_and_sorted():
+    free_index = torch.tensor([9, 8, 0, 1, 17, 16, 3])
+    assert _free_page_ids(free_index, page_size=4) == [0, 2, 4]
+
+
+def test_partial_page_indices():
+    # Freeing only some tokens of a page still yields that page id once.
+    assert _free_page_ids(torch.tensor([5, 6], dtype=torch.int64), page_size=4) == [1]
+
+
+def test_empty_tensor():
+    assert _free_page_ids(torch.empty((0,), dtype=torch.int64), page_size=4) == []
+
+
+def test_returns_python_ints():
+    """Bookkeeping needs plain ints, not tensor scalars."""
+    result = _free_page_ids(torch.tensor([4, 5]), page_size=4)
+    assert all(type(page_id) is int for page_id in result)
+
+
+@pytest.mark.parametrize("page_size", [1, 2, 16, 64])
+def test_page_size_division(page_size):
+    free_index = torch.arange(3 * page_size)
+    assert _free_page_ids(free_index, page_size) == [0, 1, 2]
+
+
+def test_result_derived_from_cpu_tensor():
+    """The unique/int conversion must happen on a CPU copy of the input."""
+    calls = []
+
+    class SpyTensor(torch.Tensor):
+
+        def cpu(self):
+            calls.append("cpu")
+            return torch.Tensor.cpu(self)
+
+    spy = torch.tensor([0, 5, 9]).as_subclass(SpyTensor)
+    assert _free_page_ids(spy, page_size=4) == [0, 1, 2]
+    assert calls == ["cpu"]


### PR DESCRIPTION
## Summary

Derive free page ids from CPU data in the SGLang paged allocator free path.

Fixes #382.

## Root cause

`ElasticPagedTokenToKVPoolAllocator.free()` ran `torch.unique(free_index // self.page_size)` on the possibly-GPU `free_index` tensor and only then converted the result to Python ints. That couples allocator free bookkeeping to CUDA device execution and synchronization behavior, which is fragile on high-concurrency SGLang serving paths. The allocator backend only needs page-id integers for bookkeeping.

## Changes

- move the tensor to CPU before deriving unique page ids:

  ```python
  free_index_cpu = free_index.cpu()
  return torch.unique(free_index_cpu // page_size).tolist()
  ```

- host the conversion in a module-level `_free_page_ids(free_index, page_size)` helper rather than inline in the injected class, so it is unit-testable without an installed SGLang or a GPU — the same pattern the vLLM integration uses for `_make_cache_key`
- drop the previous broad `try/except` int-conversion fallback: a CPU tensor's `.tolist()` is the single well-defined path

## Validation

Added `tests/test_free_page_ids.py` (CPU-only): dedup + sorted page ids across pages, partial-page frees, empty input, plain-`int` results, `page_size` ∈ {1, 2, 16, 64}, and a spy-tensor test asserting the conversion happens on a `.cpu()` copy of the input.

```bash
python -m pytest tests/test_free_page_ids.py -q  # 10 passed
```

`ruff check` and `isort --check-only` pass on the changed files.

Related: #384 also addresses this issue.
