### PR TITLE
fix: roll back partial allocation when alloc_page() fails in KVCacheManager.alloc()

### DIFF
--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -282,42 +282,47 @@ class KVCacheManager:
             self.reserved_blocks = self.reserved_blocks[num_from_reserved:]
             remaining_need -= num_from_reserved
 
-        try:
-            while remaining_need > 0:  # Allocate the remaining blocks from pages
-                if not self.avail_pages:
+        while remaining_need > 0:  # Allocate the remaining blocks from pages
+            if not self.avail_pages:
+                # Only alloc_page() is recoverable here. available_size() saw
+                # enough logical capacity, but another instance sharing the
+                # physical pool consumed pages before we reached this call, so
+                # roll back and report an allocation miss instead of leaking
+                # blocks or crashing. Anything else raising in this loop is an
+                # invariant failure (e.g. InternalPage.alloc()'s "Not enough
+                # free blocks in page", raised after _pick_avail_page() has
+                # already removed the page from avail_pages and before its
+                # blocks reach ret_index, which rollback therefore cannot
+                # restore) and must stay fail-loud.
+                try:
                     page = self.page_allocator.alloc_page()
                     page.init(self.block_mem_size)
-                    # A page may have zero usable blocks when block_mem_size is
-                    # large (e.g. HYBRID_LINEAR) and every aligned block would
-                    # straddle the page boundary. Park it in full_pages so it's
-                    # not re-handed-out but stays lookupable by free().
-                    if page.num_free_blocks() == 0:
-                        self.full_pages[page.page_id] = page
-                        continue
-                    self.num_avail_blocks += page.num_free_blocks()
-                else:
-                    page = self._pick_avail_page(remaining_need)
-                num_from_page = min(page.num_free_blocks(), remaining_need)
-                alloced_index = page.alloc(num_from_page)
-                ret_index.extend(alloced_index)
-                if page.full():
+                except RuntimeError as e:
+                    self._rollback_partial_alloc(ret_index, num_from_reserved)
+                    logger.warning(
+                        f"alloc_page() failed after partially allocating "
+                        f"{len(ret_index)}/{need_size} blocks; rolled back: {e}")
+                    return None
+                # A page may have zero usable blocks when block_mem_size is
+                # large (e.g. HYBRID_LINEAR) and every aligned block would
+                # straddle the page boundary. Park it in full_pages so it's
+                # not re-handed-out but stays lookupable by free().
+                if page.num_free_blocks() == 0:
                     self.full_pages[page.page_id] = page
-                else:
-                    self.avail_pages[page.page_id] = page
+                    continue
+                self.num_avail_blocks += page.num_free_blocks()
+            else:
+                page = self._pick_avail_page(remaining_need)
+            num_from_page = min(page.num_free_blocks(), remaining_need)
+            alloced_index = page.alloc(num_from_page)
+            ret_index.extend(alloced_index)
+            if page.full():
+                self.full_pages[page.page_id] = page
+            else:
+                self.avail_pages[page.page_id] = page
 
-                self.num_avail_blocks -= num_from_page
-                remaining_need -= num_from_page
-        except RuntimeError as e:
-            # available_size() saw enough logical capacity, but another
-            # instance sharing the physical pool consumed pages before we
-            # reached alloc_page(). Roll back the partial allocation and
-            # report an allocation miss so the caller's existing miss
-            # handling applies instead of leaking blocks or crashing.
-            self._rollback_partial_alloc(ret_index, num_from_reserved)
-            logger.warning(
-                f"alloc_page() failed after partially allocating "
-                f"{len(ret_index)}/{need_size} blocks; rolled back: {e}")
-            return None
+            self.num_avail_blocks -= num_from_page
+            remaining_need -= num_from_page
 
         return ret_index
 

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -274,6 +274,7 @@ class KVCacheManager:
 
         remaining_need = need_size
 
+        num_from_reserved = 0
         if self.reserved_blocks:  # Try to allocate from reserved blocks first
             num_from_reserved = min(len(self.reserved_blocks), remaining_need)
             # ret_index is empty before so we directly assign it
@@ -281,32 +282,60 @@ class KVCacheManager:
             self.reserved_blocks = self.reserved_blocks[num_from_reserved:]
             remaining_need -= num_from_reserved
 
-        while remaining_need > 0:  # Allocate the remaining blocks from pages
-            if not self.avail_pages:
-                page = self.page_allocator.alloc_page()
-                page.init(self.block_mem_size)
-                # A page may have zero usable blocks when block_mem_size is
-                # large (e.g. HYBRID_LINEAR) and every aligned block would
-                # straddle the page boundary. Park it in full_pages so it's
-                # not re-handed-out but stays lookupable by free().
-                if page.num_free_blocks() == 0:
+        try:
+            while remaining_need > 0:  # Allocate the remaining blocks from pages
+                if not self.avail_pages:
+                    page = self.page_allocator.alloc_page()
+                    page.init(self.block_mem_size)
+                    # A page may have zero usable blocks when block_mem_size is
+                    # large (e.g. HYBRID_LINEAR) and every aligned block would
+                    # straddle the page boundary. Park it in full_pages so it's
+                    # not re-handed-out but stays lookupable by free().
+                    if page.num_free_blocks() == 0:
+                        self.full_pages[page.page_id] = page
+                        continue
+                    self.num_avail_blocks += page.num_free_blocks()
+                else:
+                    page = self._pick_avail_page(remaining_need)
+                num_from_page = min(page.num_free_blocks(), remaining_need)
+                alloced_index = page.alloc(num_from_page)
+                ret_index.extend(alloced_index)
+                if page.full():
                     self.full_pages[page.page_id] = page
-                    continue
-                self.num_avail_blocks += page.num_free_blocks()
-            else:
-                page = self._pick_avail_page(remaining_need)
-            num_from_page = min(page.num_free_blocks(), remaining_need)
-            alloced_index = page.alloc(num_from_page)
-            ret_index.extend(alloced_index)
-            if page.full():
-                self.full_pages[page.page_id] = page
-            else:
-                self.avail_pages[page.page_id] = page
+                else:
+                    self.avail_pages[page.page_id] = page
 
-            self.num_avail_blocks -= num_from_page
-            remaining_need -= num_from_page
+                self.num_avail_blocks -= num_from_page
+                remaining_need -= num_from_page
+        except RuntimeError as e:
+            # available_size() saw enough logical capacity, but another
+            # instance sharing the physical pool consumed pages before we
+            # reached alloc_page(). Roll back the partial allocation and
+            # report an allocation miss so the caller's existing miss
+            # handling applies instead of leaking blocks or crashing.
+            self._rollback_partial_alloc(ret_index, num_from_reserved)
+            logger.warning(
+                f"alloc_page() failed after partially allocating "
+                f"{len(ret_index)}/{need_size} blocks; rolled back: {e}")
+            return None
 
         return ret_index
+
+    def _rollback_partial_alloc(self, ret_index: List[int],
+                                num_from_reserved: int) -> None:
+        """Return partially allocated blocks after a mid-alloc failure.
+
+        The first ``num_from_reserved`` entries of ``ret_index`` came off the
+        reservation ledger and are prepended back onto it; the rest came from
+        pages and go back through the regular free() path (safe to call here:
+        the lock is re-entrant).
+        """
+        page_blocks = ret_index[num_from_reserved:]
+        if page_blocks:
+            self.free(page_blocks)
+        reserved_blocks = ret_index[:num_from_reserved]
+        if reserved_blocks:
+            self.reserved_blocks = reserved_blocks + self.reserved_blocks
 
     def _pick_avail_page(self, remaining_need: int) -> InternalPage:
         """Pick the available page this allocation fits into best.

--- a/tests/manifests/cpu.txt
+++ b/tests/manifests/cpu.txt
@@ -1,3 +1,4 @@
+tests/test_alloc_rollback.py
 tests/test_bestfit_page_selection.py
 tests/test_ipc_name.py
 tests/test_ipc_timeout.py

--- a/tests/test_alloc_rollback.py
+++ b/tests/test_alloc_rollback.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for KVCacheManager partial-allocation rollback (issue #364).
+
+GPU-free: ``kvcached.vmm_ops`` is stubbed with pure-Python fakes when the
+compiled extension is unavailable, so these tests run without a GPU or a
+built C++ extension. They cover the multi-instance race where
+``available_size()`` reports enough logical capacity but the shared physical
+pool is exhausted by the time ``PageAllocator.alloc_page()`` runs: ``alloc()``
+must roll back partially consumed reserved blocks and page blocks and return
+``None`` (allocation miss) instead of leaking them.
+"""
+import sys
+import threading
+import types
+from typing import Dict, List, Optional
+
+BLOCKS_PER_PAGE = 4
+
+
+class FakePage:
+    """Pure-Python stand-in for kvcached_cpp.InternalPage."""
+
+    def __init__(self, page_id: int):
+        self.page_id = page_id
+        self.free_list: List[int] = []
+
+    def init(self, block_mem_size: int) -> None:
+        start = self.page_id * BLOCKS_PER_PAGE
+        self.free_list = list(range(start, start + BLOCKS_PER_PAGE))
+
+    def num_free_blocks(self) -> int:
+        return len(self.free_list)
+
+    def alloc(self, num: int) -> List[int]:
+        out, self.free_list = self.free_list[:num], self.free_list[num:]
+        return out
+
+    def free_batch(self, idxs: List[int]) -> None:
+        self.free_list.extend(idxs)
+
+    def full(self) -> bool:
+        return not self.free_list
+
+    def empty(self) -> bool:
+        return len(self.free_list) == BLOCKS_PER_PAGE
+
+    @staticmethod
+    def get_num_blocks(page_size: int, block_mem_size: int) -> int:
+        return page_size // block_mem_size
+
+
+class FakePageAllocator:
+    """Reports ample capacity but fails alloc_page() after ``fail_after``
+    pages, mimicking another instance draining the shared physical pool."""
+
+    def __init__(self, fail_after: int):
+        self.fail_after = fail_after
+        self.num_allocated = 0
+        self.freed_pages: List[int] = []
+
+    def alloc_page(self) -> FakePage:
+        if self.num_allocated >= self.fail_after:
+            raise RuntimeError("physical page pool exhausted")
+        page = FakePage(self.num_allocated)
+        self.num_allocated += 1
+        return page
+
+    def free_pages(self, page_ids: List[int]) -> None:
+        self.freed_pages.extend(page_ids)
+
+    def group_indices_by_page(self, indices: List[int],
+                              block_mem_size: int) -> Dict[int, List[int]]:
+        grouped: Dict[int, List[int]] = {}
+        for idx in indices:
+            grouped.setdefault(idx // BLOCKS_PER_PAGE, []).append(idx)
+        return grouped
+
+    def get_resize_target(self) -> int:
+        return 0
+
+    def get_num_free_pages(self) -> int:
+        return 100  # Logical capacity always looks ample (the race).
+
+    def get_avail_physical_pages(self) -> int:
+        return 100
+
+    def get_num_reserved_pages(self) -> int:
+        return 0
+
+
+def _install_vmm_ops_stub() -> None:
+    stub = types.ModuleType("kvcached.vmm_ops")
+    stub.PageAllocator = FakePageAllocator  # type: ignore[attr-defined]
+    stub.InternalPage = FakePage  # type: ignore[attr-defined]
+    stub.kv_tensors_created = (  # type: ignore[attr-defined]
+        lambda group_id=0: True)
+    stub.map_to_kv_tensors = (  # type: ignore[attr-defined]
+        lambda *args, **kwargs: None)
+    stub.unmap_from_kv_tensors = (  # type: ignore[attr-defined]
+        lambda *args, **kwargs: None)
+    sys.modules["kvcached.vmm_ops"] = stub
+
+
+try:
+    import kvcached.vmm_ops  # noqa: F401
+except ImportError:
+    _install_vmm_ops_stub()
+
+from kvcached.kv_cache_manager import KVCacheManager  # noqa: E402
+from kvcached.locks import NoOpLock  # noqa: E402
+
+
+def make_manager(fail_after: int,
+                 reserved_blocks: Optional[List[int]] = None) -> KVCacheManager:
+    """Build a KVCacheManager around fakes without running __init__ (which
+    needs the C++ extension, KV tensors, and background threads)."""
+    manager = object.__new__(KVCacheManager)
+    manager.page_size = BLOCKS_PER_PAGE
+    manager.block_mem_size = 1
+    manager.page_allocator = FakePageAllocator(fail_after)
+    manager.num_avail_blocks = 0
+    manager.avail_pages = {}
+    manager.full_pages = {}
+    manager.reserved_blocks = list(reserved_blocks or [])
+    manager.null_block = None
+    manager.in_shrink = False
+    manager.target_num_blocks = None
+    manager._lock = NoOpLock()
+    manager._post_init_done = threading.Event()
+    manager._post_init_done.set()
+    return manager
+
+
+def test_successful_alloc_unchanged():
+    manager = make_manager(fail_after=2)
+    assert manager.alloc(6) == [0, 1, 2, 3, 4, 5]
+    assert manager.num_avail_blocks == 2
+
+
+def test_miss_with_no_partial_state_is_clean():
+    manager = make_manager(fail_after=1)
+    assert manager.alloc(BLOCKS_PER_PAGE) == [0, 1, 2, 3]
+    # Second alloc needs a fresh page and fails immediately; nothing partial.
+    assert manager.alloc(BLOCKS_PER_PAGE) is None
+    assert manager.num_avail_blocks == 0
+    assert list(manager.full_pages) == [0]
+    assert manager.avail_pages == {}
+
+
+def test_page_blocks_rolled_back_and_reusable():
+    manager = make_manager(fail_after=1)
+    assert manager.alloc(2) == [0, 1]
+    # Consumes the page's remaining [2, 3], then alloc_page() fails.
+    assert manager.alloc(4) is None
+    # The two page blocks must be back and allocatable again.
+    assert manager.num_avail_blocks == 2
+    assert 0 in manager.avail_pages
+    assert manager.alloc(2) == [2, 3]
+
+
+def test_reserved_blocks_restored_on_miss():
+    manager = make_manager(fail_after=0, reserved_blocks=[10, 11])
+    assert manager.alloc(4) is None
+    assert manager.reserved_blocks == [10, 11]
+
+
+def test_mixed_reserved_and_page_blocks_restored():
+    manager = make_manager(fail_after=1, reserved_blocks=[10, 11])
+    # Takes 2 reserved + all 4 blocks of page 0, then fails needing a 2nd page.
+    assert manager.alloc(8) is None
+    assert manager.reserved_blocks == [10, 11]
+    # Page 0 went fully free again, so it was returned to the page allocator.
+    assert manager.page_allocator.freed_pages == [0]
+    assert manager.num_avail_blocks == 0
+    assert manager.avail_pages == {}
+    assert manager.full_pages == {}
+
+
+def test_alloc_after_rollback_succeeds_when_pool_recovers():
+    manager = make_manager(fail_after=1, reserved_blocks=[10])
+    assert manager.alloc(6) is None
+    # Another instance released memory: the next attempt must see the
+    # restored reserved block and succeed from a clean state.
+    manager.page_allocator.fail_after = 10
+    result = manager.alloc(5)
+    assert result is not None
+    assert result[0] == 10  # reserved block reused first
+    assert len(result) == 5


### PR DESCRIPTION
## Summary

Roll back partial allocations when `PageAllocator.alloc_page()` fails mid-alloc, and return an allocation miss instead of leaking blocks.

Fixes #364.

## Root cause

`KVCacheManager._alloc()` consumes reserved blocks and blocks from existing pages before it needs a new physical page. Under multi-instance pressure, `available_size()` can report enough logical capacity while another instance drains the shared physical pool, so `alloc_page()` raises `RuntimeError` after the allocation has already been partially served. Those blocks were removed from `reserved_blocks` and page free lists with no owner — leaked.

## Changes

On `RuntimeError` from the page-consuming loop:

- blocks taken from pages are returned through the regular `free()` path — safe to call re-entrantly, since `_lock` is a `threading.RLock`/`NoOpLock` and `try_to_reserve()` already nests synchronized calls the same way. This also releases a page back to the shared physical pool if the rollback empties it, which is exactly the resource the competing instance is starved of
- blocks taken off the reservation ledger are prepended back onto `reserved_blocks`, so a `try_to_reserve()` caller does not silently lose its reservation
- `alloc()` returns `None`, so the caller's existing allocation-miss handling applies

The success path is unchanged: the loop body is identical, only indented into the `try`.

## Validation

`kv_cache_manager.py` hard-imports the compiled `kvcached.vmm_ops` extension, so the added `tests/test_alloc_rollback.py` stubs it with pure-Python `FakePage`/`FakePageAllocator` in `sys.modules` (only when the real extension is unavailable) and constructs the manager without `__init__` — the same approach as the regression test merged in #407. The fake allocator reports ample capacity but fails `alloc_page()` after N pages, reproducing the race in the issue. Covered: clean miss with no partial state, page blocks rolled back and immediately reusable, reserved blocks restored, mixed reserved + page blocks with the emptied page returned to the physical pool, allocation succeeding after the pool recovers, and a success-path regression guard.

The tests fail on the unfixed code (5 of 6; the passing one is the success-path guard):

```bash
git stash push kvcached/kv_cache_manager.py && python -m pytest tests/test_alloc_rollback.py -q  # 5 failed, 1 passed
git stash pop && python -m pytest tests/test_alloc_rollback.py -q                                # 6 passed
```

The full CPU-only suite passes with the stub in place. `ruff check`, `isort --check-only`, and the mypy 3.9–3.13 matrix pass. I have not run the GPU-backed `tests/test_kvcache_manager.py`, as this machine has no CUDA device.

Related: #365 also addresses this issue with a different rollback strategy (it keeps emptied pages held by the instance and does not restore the reservation ledger; this PR releases emptied pages to the shared pool and restores reservations).
