### PR TITLE
test: make test_sleep_manager.py runnable under pytest via pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,10 @@ dev = [
     "wheel",
 ]
 
+[tool.pytest.ini_options]
+# Run `async def` tests and fixtures on asyncio without per-test markers.
+asyncio_mode = "auto"
+
 [tool.setuptools]
 include-package-data = true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ setuptools>=64
 wheel
 wrapt
 pytest
+pytest-asyncio
 posix_ipc>=1.0

--- a/tests/manifests/cpu.txt
+++ b/tests/manifests/cpu.txt
@@ -10,6 +10,7 @@ tests/test_prefix_cache.py
 tests/test_resize_reserved_order.py
 tests/test_sglang_allocator_patch.py
 tests/test_shm_info_tracker.py
+tests/test_sleep_manager.py
 tests/test_test_classification.py
 tests/test_vllm_nixl_compat.py
 tests/test_vllm_tp_world_size.py

--- a/tests/manifests/integration.txt
+++ b/tests/manifests/integration.txt
@@ -1,6 +1,5 @@
 tests/test_elastic_serving.py
 tests/test_offline_serving.py
 tests/test_prealloc_gil_deadlock.py
-tests/test_sleep_manager.py
 tests/test_traffic_monitor.py
 tests/test_utils.py

--- a/tests/test_sleep_manager.py
+++ b/tests/test_sleep_manager.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from typing import Dict, List
 
+import pytest
+
 # Add the controller directory to the path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 sys.path.insert(0, str(Path(__file__).parent.parent / "controller"))
@@ -20,6 +22,17 @@ from test_utils import load_example_config
 from controller.sleep_manager import SleepConfig, SleepManager
 from controller.traffic_monitor import TrafficMonitor
 from controller.utils import extract_models_mapping
+
+
+def _make_manager() -> SleepManager:
+    return SleepManager(SleepConfig(), traffic_monitor=TrafficMonitor())
+
+
+@pytest.fixture
+def manager() -> SleepManager:
+    """Fresh SleepManager for each test (the script path in main() shares one
+    manager across steps instead)."""
+    return _make_manager()
 
 
 def load_config_models():
@@ -54,10 +67,7 @@ async def test_basic_functionality():
     """Test basic SleepManager functionality"""
     print("=== Testing Basic Functionality ===")
 
-    # Create sleep manager with default config
-    config = SleepConfig()
-    traffic_monitor = TrafficMonitor()
-    manager = SleepManager(config, traffic_monitor=traffic_monitor)
+    manager = _make_manager()
 
     print("✓ SleepManager created successfully")
     print(f"  Auto sleep enabled: {manager.config.auto_sleep_enabled}")
@@ -65,7 +75,10 @@ async def test_basic_functionality():
     print(f"  Wake on request: {manager.config.wakeup_on_request}")
     print(f"  Min sleep duration: {manager.config.min_sleep_duration}s")
 
-    return manager
+    assert manager.config.auto_sleep_enabled is False
+    assert manager.config.idle_threshold_seconds == 300
+    assert manager.config.wakeup_on_request is True
+    assert manager.config.min_sleep_duration == 60
 
 
 async def test_real_vllm_instances(manager):
@@ -85,7 +98,9 @@ async def test_real_vllm_instances(manager):
     for model_name, config in models.items():
         print(f"  {model_name}: {config['host']}:{config['port']}")
 
-    return models
+    assert len(models) == len(vllm_models)
+    for model_info in vllm_models:
+        assert model_info["name"] in models
 
 
 async def test_sglang_configuration(manager):
@@ -105,14 +120,16 @@ async def test_sglang_configuration(manager):
     for model_name, config in sglang_models.items():
         print(f"  {model_name}: {config['host']}:{config['port']}")
 
+    assert len(sglang_models) == len(sglang_models_config)
+
     # Test removing a model (but don't remove the one we need for testing)
     test_remove_model = 'test-remove-model'
     manager.add_sglang_model(test_remove_model, 'localhost', '30001')
+    assert test_remove_model in manager.get_sglang_models()
     manager.remove_sglang_model(test_remove_model)
     sglang_models = manager.get_sglang_models()
     print(f"✓ After removal test, {len(sglang_models)} SGLang models remain")
-
-    return sglang_models
+    assert test_remove_model not in sglang_models
 
 
 async def test_sleep_wake_functionality(manager):
@@ -125,6 +142,8 @@ async def test_sleep_wake_functionality(manager):
         print("⚠ No vLLM models found in config, skipping sleep/wake test")
         return
 
+    for model_info in vllm_models:
+        manager.add_vllm_model(model_info["name"], model_info["host"], model_info["port"])
     test_model = vllm_models[0]["name"]
 
     print(f"Testing sleep/wake cycle for {test_model}")
@@ -187,6 +206,8 @@ async def test_sglang_sleep_wake_functionality(manager):
         print("⚠ No SGLang models found in config, skipping SGLang sleep/wake test")
         return
 
+    for model_info in sglang_models:
+        manager.add_sglang_model(model_info["name"], model_info["host"], model_info["port"])
     test_model = sglang_models[0]["name"]
 
     print(f"Testing SGLang sleep/wake cycle for {test_model}")
@@ -243,9 +264,10 @@ async def test_sleep_state_tracking(manager):
     """Test sleep state tracking functionality"""
     print("\n=== Testing Sleep State Tracking ===")
 
-    # Get sleeping models
+    # Get sleeping models (none on a manager that has not slept anything)
     sleeping_models = manager.get_sleeping_models()
     print(f"✓ Currently sleeping models: {len(sleeping_models)}")
+    assert isinstance(sleeping_models, dict)
 
     if sleeping_models:
         for model_name, info in sleeping_models.items():
@@ -277,31 +299,28 @@ async def test_config_updates(manager):
     print(f"  Idle threshold: {manager.config.idle_threshold_seconds}s")
     print(f"  Min sleep duration: {manager.config.min_sleep_duration}s")
 
+    assert manager.config.auto_sleep_enabled is True
+    assert manager.config.idle_threshold_seconds == 600
+    assert manager.config.min_sleep_duration == 120
+
 
 async def test_api_methods_simulation(manager):
     """Test API method signatures without making actual HTTP calls"""
     print("\n=== Testing API Method Signatures ===")
 
     # These methods would make HTTP calls in real usage
-    # Here we just test that they can be called without syntax errors
-    print("✓ vLLM sleep/wake API methods are properly defined:")
-    print(
-        f"  _call_vllm_sleep_api: {hasattr(manager, '_call_vllm_sleep_api')}")
-    print(f"  _call_vllm_wake_api: {hasattr(manager, '_call_vllm_wake_api')}")
+    # Here we just test that they are properly defined
+    print("✓ vLLM sleep/wake API methods are properly defined")
+    assert hasattr(manager, '_call_vllm_sleep_api')
+    assert hasattr(manager, '_call_vllm_wakeup_api')
 
-    print("✓ SGLang API methods are properly defined:")
-    print(
-        f"  _call_sglang_release_api: {hasattr(manager, '_call_sglang_release_api')}"
-    )
-    print(
-        f"  _call_sglang_resume_api: {hasattr(manager, '_call_sglang_resume_api')}"
-    )
+    print("✓ SGLang API methods are properly defined")
+    assert hasattr(manager, '_call_sglang_release_api')
+    assert hasattr(manager, '_call_sglang_resume_api')
 
-    print("✓ Common API methods:")
-    print(
-        f"  check_model_sleep_status: {hasattr(manager, 'check_model_sleep_status')}"
-    )
-    print(f"  handle_model_wakeup: {hasattr(manager, 'handle_model_wakeup')}")
+    print("✓ Common API methods")
+    assert hasattr(manager, 'check_model_sleep_status')
+    assert hasattr(manager, 'handle_model_wakeup_on_request')
 
 
 async def test_sglang_api_methods_simulation(manager):
@@ -310,17 +329,21 @@ async def test_sglang_api_methods_simulation(manager):
 
     # Test configuration methods
     print("✓ SGLang model management methods:")
-    print(f"  add_sglang_model: {hasattr(manager, 'add_sglang_model')}")
-    print(f"  remove_sglang_model: {hasattr(manager, 'remove_sglang_model')}")
-    print(f"  get_sglang_models: {hasattr(manager, 'get_sglang_models')}")
+    assert hasattr(manager, 'add_sglang_model')
+    assert hasattr(manager, 'remove_sglang_model')
+    assert hasattr(manager, 'get_sglang_models')
 
     # Test model detection logic
     sglang_models = MODELS_CONFIG["sglang"]
     if sglang_models:
+        for model_info in sglang_models:
+            manager.add_sglang_model(model_info["name"], model_info["host"],
+                                     model_info["port"])
         test_model = sglang_models[0]["name"]
         print(f"\n✓ Model type detection for '{test_model}':")
         is_sglang = test_model in manager.config.sglang_models_config
         print(f"  Detected as SGLang model: {is_sglang}")
+        assert is_sglang
     else:
         print("\n⚠ No SGLang models found in config, skipping model detection test")
 
@@ -332,7 +355,8 @@ async def main():
 
     try:
         # Run all tests
-        manager = await test_basic_functionality()
+        await test_basic_functionality()
+        manager = _make_manager()
 
         # Test vLLM functionality
         await test_real_vllm_instances(manager)


### PR DESCRIPTION
## Summary

Make `tests/test_sleep_manager.py` actually runnable under pytest: `9 passed` where every environment previously got `1 failed, 8 errors`.

Fixes #431.

## Problem

The file is written as a sequential live-server script (`main()` shares one `SleepManager` across steps), but pytest also collects its `async def test_*` functions. Without an async plugin the first test fails with "async def functions are not natively supported", and the step functions' `manager` parameter is resolved as a nonexistent fixture, erroring the other eight. As a result `controller/sleep_manager.py` has zero automated coverage, and async behavior has to be tested through workarounds — #409 wraps `asyncio.gather` in `asyncio.run()` inside a sync test for exactly this reason.

## Changes

- add `pytest-asyncio` to `requirements.txt` and configure `asyncio_mode = "auto"` in `pyproject.toml`, so plain `async def` tests and fixtures run without per-test markers (and future PRs like #409 can write native async tests)
- add a `manager` fixture providing a fresh `SleepManager` per test; `main()` keeps its own shared manager, so the live-server script mode is unchanged
- make each step self-contained: the sleep/wake and detection tests register their own models from `example-config.yaml` instead of relying on state left behind by earlier steps (`SleepManager`'s HTTP helpers already catch connection failures and return `False`, so these degrade gracefully and quickly when no live endpoint is reachable; the fresh-manager path previously crashed with `TypeError: argument of type 'NoneType' is not iterable` in the SGLang detection step)
- convert deterministic print-only checks into assertions (config defaults, model registry add/remove, config updates, API-method presence). This surfaced that two of the printed "checks" referenced methods that do not exist — `_call_vllm_wake_api` and `handle_model_wakeup` printed `False` and could never fail; the assertions now cover the real `_call_vllm_wakeup_api` and `handle_model_wakeup_on_request`

## Validation

```bash
python -m pytest tests/test_sleep_manager.py -q   # 9 passed in 1.86s   (before: 1 failed, 8 errors)
python tests/test_sleep_manager.py                # script mode intact, exit 0
```

The full CPU-only suite passes with `asyncio_mode = "auto"` enabled (82 passed, 1 skipped — the 73 previously-passing tests plus these 9). No live vLLM/SGLang endpoints are required; with servers configured, the script path exercises the real sleep/wake cycle exactly as before. `ruff check`, `isort --check-only`, and mypy pass on the changed files.

Once this and #428 (or #403) land, the CPU CI job can stop excluding this file.
