### PR TITLE
fix(vllm): support per-token-head KV quantization (fp8_per_token_head) via cache_dtype_str forwarding

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -7,6 +7,7 @@ vLLM-specific patches using unified patch infrastructure.
 
 from __future__ import annotations
 
+import inspect
 import types
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Iterable, Optional
@@ -312,6 +313,65 @@ def _get_max_cached_blocks(block_size: int) -> int:
     if MAX_CACHED_TOKENS < 0:
         return -1
     return MAX_CACHED_TOKENS // block_size
+
+
+def _cache_dtype_str(model_runner: Any) -> Optional[str]:
+    """Extract the KV cache dtype string from a GPUModelRunner, if available."""
+    cache_config = getattr(model_runner, "cache_config", None)
+    if cache_config is None:
+        vllm_config = getattr(model_runner, "vllm_config", None)
+        cache_config = getattr(vllm_config, "cache_config", None)
+    return getattr(cache_config, "cache_dtype", None)
+
+
+def _get_kv_cache_shape_compat(attn_backend: Any, num_blocks: int,
+                               block_size: int, num_kv_heads: int,
+                               head_size: int,
+                               cache_dtype_str: Optional[str]) -> Any:
+    """Call ``get_kv_cache_shape``, forwarding ``cache_dtype_str`` when the
+    backend's signature accepts it.
+
+    Per-token-head quantization modes (fp8_per_token_head,
+    int8_per_token_head, nvfp4) widen ``head_size`` by a few elements to
+    inline per-head scales into the KV page. Omitting ``cache_dtype_str``
+    makes the backend compute the un-widened shape, so every page stride is
+    wrong and output is garbled (#424). Older vLLM versions do not take the
+    parameter, so it is only forwarded when declared.
+
+    Module-level so it is unit-testable without an installed vLLM or a GPU.
+    """
+    if cache_dtype_str is not None:
+        try:
+            declares_dtype = "cache_dtype_str" in inspect.signature(
+                attn_backend.get_kv_cache_shape).parameters
+        except (TypeError, ValueError):
+            declares_dtype = False
+        if declares_dtype:
+            return attn_backend.get_kv_cache_shape(
+                num_blocks,
+                block_size,
+                num_kv_heads,
+                head_size,
+                cache_dtype_str=cache_dtype_str,
+            )
+    return attn_backend.get_kv_cache_shape(num_blocks, block_size,
+                                           num_kv_heads, head_size)
+
+
+def _kv_cache_uses_inline_scales(cache_dtype_str: Optional[str]) -> bool:
+    """Whether this KV cache dtype inlines per-token-head scales in the page.
+
+    Prefers vLLM's own predicate when available; falls back to a string
+    heuristic on versions that do not expose it.
+    """
+    if not cache_dtype_str:
+        return False
+    try:
+        from vllm.utils.torch_utils import kv_cache_uses_per_token_head_scales
+        return bool(kv_cache_uses_per_token_head_scales(cache_dtype_str))
+    except ImportError:
+        pass
+    return "per_token_head" in cache_dtype_str or cache_dtype_str == "nvfp4"
 
 
 def _make_cache_key(block_hash: Any, group_id: int) -> bytes:
@@ -1245,11 +1305,13 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             dtype = kv_cache_spec.dtype
             num_blocks = tensor_config.size // kv_cache_spec.page_size_bytes
             assert num_blocks >= kv_cache_config.num_blocks
-            kv_cache_shape = self.attn_backend.get_kv_cache_shape(
+            kv_cache_shape = _get_kv_cache_shape_compat(
+                self.attn_backend,
                 num_blocks,
                 kv_cache_spec.block_size,
                 kv_cache_spec.num_kv_heads,
                 kv_cache_spec.head_size,
+                _cache_dtype_str(self),
             )
 
             kv_cache_buffers = kvi.alloc_kv_cache(
@@ -1360,12 +1422,29 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
 
                 set_kv_cache_layout(selected_layout)
 
-            kv_cache_shape = attn_backend_cls.get_kv_cache_shape(
+            cache_dtype = _cache_dtype_str(self)
+            kv_cache_shape = _get_kv_cache_shape_compat(
+                attn_backend_cls,
                 num_blocks,
                 kv_cache_spec.block_size,
                 kv_cache_spec.num_kv_heads,
                 kv_cache_spec.head_size,
+                cache_dtype,
             )
+
+            from kvcached.utils import CONTIGUOUS_LAYOUT
+            if CONTIGUOUS_LAYOUT and _kv_cache_uses_inline_scales(cache_dtype):
+                # Verified on an L40S (vLLM 0.20, TRITON_ATTN, Qwen3-0.6B):
+                # with inline scales the widened K+V block bytes no longer
+                # divide the physical page size, the contiguous layout's
+                # linear block math breaks, and output is garbled even when
+                # the widened shape above is correct. The non-contiguous
+                # layout produces output identical to vLLM without kvcached.
+                raise NotImplementedError(
+                    "kvcached contiguous layout does not support per-token-"
+                    f"head KV cache quantization (kv_cache_dtype="
+                    f"{cache_dtype}). Re-launch with "
+                    "KVCACHED_CONTIGUOUS_LAYOUT=false.")
 
             if attention_type == "HYBRID_LINEAR":
                 # The unified-pool layout math (both layouts; load-bearing for
@@ -1505,9 +1584,10 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                     gbackend = patch_instance._get_version_specific_attention_backend(
                         self, kv_cache_group_id=gid
                     )
-                    gshape = gbackend.get_kv_cache_shape(
-                        num_blocks, gspec.block_size, gspec.num_kv_heads,
-                        gspec.head_size,
+                    gshape = _get_kv_cache_shape_compat(
+                        gbackend, num_blocks, gspec.block_size,
+                        gspec.num_kv_heads, gspec.head_size,
+                        _cache_dtype_str(self),
                     )
                     gkbs = (kernel_block_sizes[gid]
                             if kernel_block_sizes is not None

--- a/tests/test_kv_cache_shape_compat.py
+++ b/tests/test_kv_cache_shape_compat.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ``_get_kv_cache_shape_compat`` (issue #424).
+
+GPU-free: the helpers are module-level functions in
+``kvcached.integration.vllm.patches`` and need neither an installed vLLM nor
+a GPU. They guard the per-token-head quantization fix: ``cache_dtype_str``
+must be forwarded to ``get_kv_cache_shape`` on vLLM versions that accept it
+(the widened head_size inlines per-head scales into the KV page), and must be
+omitted on older versions whose signature does not declare it.
+"""
+from types import SimpleNamespace
+
+from kvcached.integration.vllm.patches import (
+    _cache_dtype_str,
+    _get_kv_cache_shape_compat,
+    _kv_cache_uses_inline_scales,
+)
+
+# Widening applied by per-token-head modes in the fake backend below.
+_SCALE_ELEMS = 4
+
+
+class ModernBackend:
+    """Mimics vLLM >= 0.19 FlashAttention: accepts cache_dtype_str."""
+
+    @staticmethod
+    def get_kv_cache_shape(num_blocks, block_size, num_kv_heads, head_size,
+                           cache_dtype_str="auto"):
+        if cache_dtype_str and cache_dtype_str.endswith("per_token_head"):
+            head_size += _SCALE_ELEMS
+        return (2, num_blocks, block_size, num_kv_heads, head_size)
+
+
+class LegacyBackend:
+    """Mimics older vLLM: no cache_dtype_str parameter at all."""
+
+    @staticmethod
+    def get_kv_cache_shape(num_blocks, block_size, num_kv_heads, head_size):
+        return (2, num_blocks, block_size, num_kv_heads, head_size)
+
+
+def test_forwards_dtype_to_modern_backend():
+    shape = _get_kv_cache_shape_compat(ModernBackend, 8, 16, 4, 128,
+                                       "fp8_per_token_head")
+    assert shape == (2, 8, 16, 4, 128 + _SCALE_ELEMS)
+
+
+def test_auto_dtype_leaves_shape_unwidened():
+    shape = _get_kv_cache_shape_compat(ModernBackend, 8, 16, 4, 128, "auto")
+    assert shape == (2, 8, 16, 4, 128)
+
+
+def test_none_dtype_is_not_forwarded():
+    shape = _get_kv_cache_shape_compat(ModernBackend, 8, 16, 4, 128, None)
+    assert shape == (2, 8, 16, 4, 128)
+
+
+def test_legacy_backend_does_not_receive_kwarg():
+    """Must not raise TypeError on signatures without cache_dtype_str."""
+    shape = _get_kv_cache_shape_compat(LegacyBackend, 8, 16, 4, 128,
+                                       "fp8_per_token_head")
+    assert shape == (2, 8, 16, 4, 128)
+
+
+def test_cache_dtype_str_from_cache_config():
+    runner = SimpleNamespace(
+        cache_config=SimpleNamespace(cache_dtype="fp8_per_token_head"))
+    assert _cache_dtype_str(runner) == "fp8_per_token_head"
+
+
+def test_cache_dtype_str_via_vllm_config():
+    runner = SimpleNamespace(
+        cache_config=None,
+        vllm_config=SimpleNamespace(
+            cache_config=SimpleNamespace(cache_dtype="fp8")),
+    )
+    assert _cache_dtype_str(runner) == "fp8"
+
+
+def test_cache_dtype_str_absent_returns_none():
+    assert _cache_dtype_str(SimpleNamespace()) is None
+
+
+def test_inline_scales_detection():
+    assert _kv_cache_uses_inline_scales("fp8_per_token_head")
+    assert _kv_cache_uses_inline_scales("int8_per_token_head")
+    assert _kv_cache_uses_inline_scales("nvfp4")
+    assert not _kv_cache_uses_inline_scales("auto")
+    assert not _kv_cache_uses_inline_scales("fp8")
+    assert not _kv_cache_uses_inline_scales(None)
+    assert not _kv_cache_uses_inline_scales("")


### PR DESCRIPTION
## Summary

Fixes #424 for the non-contiguous layout, and fails loud on the contiguous layout where a second, independent bug remains.

With this PR, `--kv-cache-dtype fp8_per_token_head` + kvcached (`KVCACHED_CONTIGUOUS_LAYOUT=false`) produces output **identical to vLLM without kvcached**. The default contiguous layout raises a clear `NotImplementedError` at startup instead of silently garbling.

## Root cause (as diagnosed in #424)

Per-token-head quantization modes (`fp8_per_token_head`, `int8_per_token_head`, `nvfp4`) widen `head_size` to inline per-token-head fp32 scales into the KV page (e.g. 128 → 132 for fp8). kvcached called `get_kv_cache_shape` without `cache_dtype_str`, computing the un-widened shape, so every page stride was wrong.

## Changes

- forward `cache_config.cache_dtype` at all three `get_kv_cache_shape` call sites, through a new module-level `_get_kv_cache_shape_compat()` that inspects the backend's signature and omits the argument on older vLLM versions that do not declare it (it exists since vLLM 0.20)
- `_cache_dtype_str()` extracts the dtype string from the model runner (`cache_config` directly or via `vllm_config`)
- **contiguous-layout guard**: with inline-scale modes the widened K+V block bytes (e.g. 33,792) no longer divide the physical page size, and the contiguous layout's linear block math breaks *independently of the tensor strides* — output stays garbled even with the corrected shape (details below). Until that math is scale-aware, raise `NotImplementedError` pointing at `KVCACHED_CONTIGUOUS_LAYOUT=false`, mirroring the existing HYBRID_LINEAR page-identity guard. Detection prefers vLLM's own `kv_cache_uses_per_token_head_scales` with a string-heuristic fallback.

## Verification (L40S, vLLM 0.20.0, `VLLM_ATTENTION_BACKEND=TRITON_ATTN`, Qwen3-0.6B, greedy)

| Run | kvcached | Layout | Result |
|---|---|---|---|
| baseline | off | — | clean |
| main | on | non-contiguous | garbled (`" Paris!!!!!!!…"`) |
| **this PR** | on | non-contiguous | **clean — token-identical to baseline** |
| main / shape-fix only | on | contiguous | garbled (identical junk in both, i.e. independent of the shape fix) |
| **this PR** | on | contiguous | loud `NotImplementedError` at startup |
| this PR, `auto` | on | contiguous | clean (regression) |
| this PR, `fp8` per-tensor | on | contiguous | clean (regression) |

Debug instrumentation during the investigation confirmed the widened shape is correctly computed and bound on this PR (`raw0.shape=(50269, 2, 16, 8, 132)`, contiguous inner strides `(…, 1056, 132, 1)`), which is how the contiguous-layout failure was isolated as a separate bug: the garbled output there is byte-identical with and without the widened binding.

The contiguous-layout root cause is worth its own issue — the widened block size is the only supported mode where K+V block bytes are not a power of two (33,792 vs 32,768/65,536), so blocks straddle physical page boundaries in the linear layout. I can file it with the evidence above.

## Tests

`tests/test_kv_cache_shape_compat.py` (CPU-only, no vLLM needed): forwarding to modern signatures, fallback on legacy signatures without `TypeError`, `None`/`auto` passthrough, dtype-string extraction paths, and inline-scale detection for all mode strings.

```
$ python -m pytest tests/test_kv_cache_shape_compat.py -q
8 passed
```

`ruff check`, `isort --check-only`, and the full CPU-only suite pass on the changed files.
