### PR TITLE
fix(vllm): build per-token-head scale views from the KV tensor, not raw storage

### DIFF
--- a/kvcached/integration/vllm/autopatch.py
+++ b/kvcached/integration/vllm/autopatch.py
@@ -18,6 +18,7 @@ from kvcached.integration.vllm.patches import (
     GPUWorkerPatch,
     KVCacheCoordinatorPatch,
     KVCacheManagerPatch,
+    TritonAttentionPatch,
 )
 from kvcached.utils import get_kvcached_logger
 
@@ -46,6 +47,7 @@ def _patch_vllm(_vllm: types.ModuleType) -> None:
             (GPUWorkerPatch(), VLLM_ALL_RANGE),
             (KVCacheCoordinatorPatch(), VLLM_V9_PLUS_RANGE),
             (KVCacheManagerPatch(), VLLM_V8_RANGE),
+            (TritonAttentionPatch(), VLLM_V9_PLUS_RANGE),
         ]
     )
 

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -358,22 +358,6 @@ def _get_kv_cache_shape_compat(attn_backend: Any, num_blocks: int,
                                            num_kv_heads, head_size)
 
 
-def _kv_cache_uses_inline_scales(cache_dtype_str: Optional[str]) -> bool:
-    """Whether this KV cache dtype inlines per-token-head scales in the page.
-
-    Prefers vLLM's own predicate when available; falls back to a string
-    heuristic on versions that do not expose it.
-    """
-    if not cache_dtype_str:
-        return False
-    try:
-        from vllm.utils.torch_utils import kv_cache_uses_per_token_head_scales
-        return bool(kv_cache_uses_per_token_head_scales(cache_dtype_str))
-    except ImportError:
-        pass
-    return "per_token_head" in cache_dtype_str or cache_dtype_str == "nvfp4"
-
-
 def _make_cache_key(block_hash: Any, group_id: int) -> bytes:
     """Pack block_hash + group_id into a composite cache key.
 
@@ -1432,20 +1416,6 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 cache_dtype,
             )
 
-            from kvcached.utils import CONTIGUOUS_LAYOUT
-            if CONTIGUOUS_LAYOUT and _kv_cache_uses_inline_scales(cache_dtype):
-                # Verified on an L40S (vLLM 0.20, TRITON_ATTN, Qwen3-0.6B):
-                # with inline scales the widened K+V block bytes no longer
-                # divide the physical page size, the contiguous layout's
-                # linear block math breaks, and output is garbled even when
-                # the widened shape above is correct. The non-contiguous
-                # layout produces output identical to vLLM without kvcached.
-                raise NotImplementedError(
-                    "kvcached contiguous layout does not support per-token-"
-                    f"head KV cache quantization (kv_cache_dtype="
-                    f"{cache_dtype}). Re-launch with "
-                    "KVCACHED_CONTIGUOUS_LAYOUT=false.")
-
             if attention_type == "HYBRID_LINEAR":
                 # The unified-pool layout math (both layouts; load-bearing for
                 # contiguous ratio>1 linearity) assumes the spec's page is
@@ -1842,4 +1812,67 @@ class GPUWorkerPatch(VersionAwarePatch, BasePatch):
 
         self._mark_as_patched(_patched_init_device, "init_device")
         Worker.init_device = _patched_init_device  # type: ignore[assignment]
+        return True
+
+
+class TritonAttentionPatch(VersionAwarePatch, BasePatch):
+    """Build the per-token-head scale views from the KV tensor, not raw storage.
+
+    ``TritonAttentionImpl._ensure_scale_caches`` carves the per-head scale
+    planes out of ``kv_cache.untyped_storage()`` under a hard-coded dense
+    layout, ignoring both ``stride()`` and ``storage_offset()``. Every kvcached
+    KV tensor is a strided view: K and V occupy separate halves of the layer
+    buffer, and in the contiguous layout each layer is a slice of one shared
+    buffer at a non-zero offset. The computed addresses are therefore wrong --
+    below the K/V split they land on some other block's scale padding (a
+    consistent, harmless relabeling), above it they land on KV data and corrupt
+    it, and in the contiguous layout every layer's scale plane collapses onto
+    layer 0's.
+
+    Slicing the tensor carries the strides and the storage offset along, so the
+    addresses follow whatever layout is actually in use. For vLLM's own dense
+    tensors this yields exactly the same views as upstream. See #424 / #434.
+    """
+
+    library = "vllm"
+    target_module = "vllm.v1.attention.backends.triton_attn"
+    target_class = "TritonAttentionImpl"
+    patch_name = "triton_attention_scales"
+
+    def apply(self, triton_attn_mod: types.ModuleType) -> bool:
+        if not self.initialize_version_info():
+            return False
+        return self.patch_ensure_scale_caches(triton_attn_mod)
+
+    @version_range(VLLM_V9_PLUS_RANGE)
+    def patch_ensure_scale_caches(self,
+                                  triton_attn_mod: types.ModuleType) -> bool:
+        impl_cls = self._get_target_class(triton_attn_mod)
+        if impl_cls is None:
+            return False
+        if not hasattr(impl_cls, "_ensure_scale_caches"):
+            # vLLM without per-token-head KV quantization: nothing to patch.
+            self.logger.debug("TritonAttentionImpl has no _ensure_scale_caches")
+            return True
+        if self._is_already_patched(impl_cls, "ensure_scale_caches"):
+            return True
+
+        def _ensure_scale_caches(self, kv_cache: Any) -> None:
+            import torch
+
+            if self._k_scale_cache is not None:
+                return
+            # kv_cache is (num_blocks, 2, block_size, num_kv_heads, padded_hs);
+            # the last ``scale_pad`` elements of each head hold one float32.
+            padded_hs = kv_cache.shape[-1]
+            head_size = padded_hs - 4 // kv_cache.element_size()
+            self._k_scale_cache = (kv_cache[:, 0, :, :, head_size:].view(
+                torch.float32).squeeze(-1))
+            self._v_scale_cache = (kv_cache[:, 1, :, :, head_size:].view(
+                torch.float32).squeeze(-1))
+            self._k_scale_cache.fill_(1.0)
+            self._v_scale_cache.fill_(1.0)
+
+        self._mark_as_patched(impl_cls, "ensure_scale_caches")
+        impl_cls._ensure_scale_caches = _ensure_scale_caches
         return True

--- a/tests/test_kv_cache_shape_compat.py
+++ b/tests/test_kv_cache_shape_compat.py
@@ -9,12 +9,14 @@ must be forwarded to ``get_kv_cache_shape`` on vLLM versions that accept it
 (the widened head_size inlines per-head scales into the KV page), and must be
 omitted on older versions whose signature does not declare it.
 """
+import ast
+import pathlib
 from types import SimpleNamespace
 
+import kvcached.integration.vllm.patches as patches
 from kvcached.integration.vllm.patches import (
     _cache_dtype_str,
     _get_kv_cache_shape_compat,
-    _kv_cache_uses_inline_scales,
 )
 
 # Widening applied by per-token-head modes in the fake backend below.
@@ -82,11 +84,20 @@ def test_cache_dtype_str_absent_returns_none():
     assert _cache_dtype_str(SimpleNamespace()) is None
 
 
-def test_inline_scales_detection():
-    assert _kv_cache_uses_inline_scales("fp8_per_token_head")
-    assert _kv_cache_uses_inline_scales("int8_per_token_head")
-    assert _kv_cache_uses_inline_scales("nvfp4")
-    assert not _kv_cache_uses_inline_scales("auto")
-    assert not _kv_cache_uses_inline_scales("fp8")
-    assert not _kv_cache_uses_inline_scales(None)
-    assert not _kv_cache_uses_inline_scales("")
+def test_no_direct_get_kv_cache_shape_calls():
+    """Every call site must route through the compat helper, so the #424 fix
+    cannot be reverted at one of them while the helper stays behind."""
+    tree = ast.parse(pathlib.Path(patches.__file__).read_text())
+    # The helper itself is the one place allowed to call the backend directly.
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.FunctionDef)
+                and node.name == "_get_kv_cache_shape_compat"):
+            node.body = []
+    direct = [
+        n.lineno for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "get_kv_cache_shape"
+    ]
+    assert not direct, (
+        "get_kv_cache_shape must be called via _get_kv_cache_shape_compat so "
+        f"cache_dtype_str is forwarded (#424); direct calls at lines {direct}")


### PR DESCRIPTION
## What

Patches `TritonAttentionImpl._ensure_scale_caches` so vLLM finds the per-token-head KV scales by reading the tensor's layout instead of guessing it, and removes the contiguous-layout guard from #433, which is no longer needed.

Closes #434.

## Why #433 wasn't enough

#433 fixed the *shape*: `get_kv_cache_shape` now receives `cache_dtype_str`, so kvcached allocates `(…, 132)` rather than `(…, 128)`. That part is correct and stays.

The problem is one level down. With `fp8_per_token_head` each head is padded 128 → 132 bytes and the 4 extra bytes hold that head's scale. To reach those scattered slots, `_ensure_scale_caches` builds an address map out of two assumptions:

```python
raw = kv_cache.untyped_storage()         # assumes storage_offset == 0
full_block_f32 = 2 * kv_half_bytes // 4  # assumes K and V of one block are adjacent
```

Both hold for the tensor vLLM allocates itself. Neither holds for kvcached's, which puts all of K before all of V, and in the contiguous layout gives every layer a slice of one shared buffer.

**Contiguous** trips the first assumption and fails at once: dropping `storage_offset` puts all 28 layers' scale planes at the same address, so they overwrite each other. The scale is computed per `(token, head)` from that layer's own activations, so the values genuinely differ, measured spread on Qwen3-0.6B is 144x across layers and 13–27x between heads within one layer, and a layer reading back another layer's scale dequantizes with a badly wrong factor. This is the garbling in #434.

Note this is *not* the block/page divisibility the guard's comment blamed. With `KVCACHED_PAGE_SIZE_MB=66` the block bytes divide the page exactly, with no straddling block at all, and the output is still garbled byte-for-byte identically to the 2 MiB run. A write/read-back probe over every allocated block reports 0 mismatches out of 11,200 (layer, block) pairs in both layouts.

**Non-contiguous** trips the second one and is more dangerous, because it hides. vLLM steps 33,792 bytes per block; kvcached's real block stride is 16,896, exactly half, so block `b` lands on block `2b`'s scale slot. Wrong slot, but one-to-one, still inside the scale padding, and the same map serves the write and the read, so output is correct and the bug is invisible. **It stops being harmless once `2b` runs off the end of the K region**: that region holds 50,269.09 blocks, not a whole number, so the V region starts 84 bytes off the head grid and the addresses land on real KV data.

## The fix

```python
head_size = kv_cache.shape[-1] - 4 // kv_cache.element_size()
self._k_scale_cache = kv_cache[:, 0, :, :, head_size:].view(torch.float32).squeeze(-1)
self._v_scale_cache = kv_cache[:, 1, :, :, head_size:].view(torch.float32).squeeze(-1)
```

Slicing carries the strides and the offset along. For vLLM's own dense tensors this produces exactly the same views as upstream.

## Changes

- add `TritonAttentionPatch`, registered for `VLLM_V9_PLUS_RANGE`
- remove the `NotImplementedError` guard and `_kv_cache_uses_inline_scales` from #433 — the contiguous layout works now, and nothing calls the predicate any more
- replace `test_inline_scales_detection`, which failed on any machine with vLLM installed, with a check that no call site bypasses `_get_kv_cache_shape_compat`

## Evidence

vLLM 0.24.0 / L40 / `TRITON_ATTN` / Qwen3-0.6B / greedy, compared token by token. `main` needs the guard bypassed to run the contiguous layout at all.

| setup | main | this branch |
|---|---|---|
| contiguous, 3 short prompts | garbled | token-identical to a run with kvcached disabled |
| non-contiguous, 3 short prompts | token-identical | token-identical |
| non-contiguous, 500 × 1000-token requests (pool filled) | 7 of 10 runs died with an illegal memory access; the runs that finished differ from this branch in **333 and 334 of 500** requests | 3 of 3 finish, all three bit-identical to each other |

The last row is the case #433 could not have caught. Non-contiguous looks correct at small sizes because the wrong addresses still land on scale padding — a consistent `block b -> block 2b` relabeling used for both the write and the read. Above block id 25,135 of a 25,630-block pool they stop landing on padding and start landing on real KV data, which is reachable once the cache fills. 

`tests/test_kv_cache_shape_compat.py` goes from 7 passed / 1 failed to 8 passed on a machine with vLLM installed. 

## Reproducing the bug — CPU, no model, no GPU, no kvcached

```python
import torch
from vllm.v1.attention.backends.triton_attn import TritonAttentionImpl

NB, BS, H, HS, PAD = 8, 16, 8, 128, 132   # head padded 128 -> 132; last 4 bytes = scale

class Stub:
    _k_scale_cache = _v_scale_cache = None

def check(kv):
    s = Stub()
    TritonAttentionImpl._ensure_scale_caches(s, kv)
    return [s._k_scale_cache[b, 0, 0].data_ptr() == kv[b, 0, 0, 0, HS].data_ptr()
            for b in range(4)]

# A. what vLLM builds for itself
print("A dense   ", check(torch.zeros(NB, 2, BS, H, PAD, dtype=torch.uint8)))

# B. what kvcached hands over: all of K, then all of V
half = NB * BS * H * PAD
print("B kvcached", check(torch.as_strided(
    torch.zeros(2 * half, dtype=torch.uint8),
    (NB, 2, BS, H, PAD), (BS*H*PAD, half, H*PAD, PAD, 1))))

# C. kvcached contiguous: every layer is a slice of one shared buffer
LAYERS, per_layer = 4, 2 * BS * H * PAD
shared = torch.zeros(LAYERS * NB * per_layer, dtype=torch.uint8)
addrs = []
for i in range(LAYERS):
    s = Stub()
    TritonAttentionImpl._ensure_scale_caches(s, torch.as_strided(
        shared, (NB, 2, BS, H, PAD), (LAYERS*per_layer, BS*H*PAD, H*PAD, PAD, 1),
        storage_offset=i*per_layer))
    addrs.append(s._k_scale_cache.data_ptr())
print("C layers  ", len(set(addrs)), "distinct address(es) for", LAYERS, "layers")
```

```
A dense    [True, True, True, True]
B kvcached [True, False, False, False]
C layers   1 distinct address(es) for 4 layers
```

## Scope

| backend | quantized KV dtypes | affected |
|---|---|---|
| FlashAttention | none | no |
| Triton | `fp8_per_token_head`, `int8_per_token_head` | **yes — fixed here** |
| FlashInfer | `nvfp4` | no evidence of it |

Not a regression between vLLM versions: 0.20's `_ensure_scale_caches` is the same code as 0.24's.