### PR TITLE
fix(vllm): accept prepend kwarg in ElasticBlockPool.free_blocks

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -768,7 +768,13 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
             def free_blocks(
                 self,
                 ordered_blocks: Iterable[KVCacheBlock],
+                prepend: bool = False,
             ) -> None:
+                # vLLM >= 0.23 passes ``prepend`` to put freed blocks at the
+                # front of its free queue for reuse priority. kvcached has no
+                # linear free queue: reuse order is governed by
+                # KVCacheManager's page-affine allocation, so the hint is
+                # accepted for signature compatibility and unused (#438).
                 if not self.enable_prefix_cache:
                     block_ids = [
                         block.block_id

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -611,6 +611,33 @@ class TestEdgeCases:
         assert len(pool._evictable_blocks) == 2
         assert mgr.available_size() == initial_free - 2  # 2 held by pool
 
+    def test_free_blocks_accepts_prepend_kwarg(self, pool_and_manager):
+        """vLLM >= 0.23 calls free_blocks(..., prepend=...); must not raise
+        and must free identically for both values (#438)."""
+        pool, mgr = pool_and_manager
+        initial_free = mgr.available_size()
+
+        blocks = pool.get_new_blocks(2)
+        for block in blocks:
+            block.ref_cnt = 1
+        pool.free_blocks(blocks, prepend=True)
+        assert mgr.available_size() == initial_free
+
+        blocks = pool.get_new_blocks(2)
+        for block in blocks:
+            block.ref_cnt = 1
+        pool.free_blocks(blocks, prepend=False)
+        assert mgr.available_size() == initial_free
+
+    def test_free_blocks_prepend_with_caching_disabled(self, pool_factory):
+        """The caching-disabled fast path must accept prepend too (#438)."""
+        pool, mgr = pool_factory(enable_caching=False)
+        initial_free = mgr.available_size()
+
+        blocks = pool.get_new_blocks(3)
+        pool.free_blocks(blocks, prepend=True)
+        assert mgr.available_size() == initial_free
+
     def test_get_usage(self, pool_factory):
         """get_usage reflects the fraction of blocks in use."""
         pool, mgr = pool_factory(100)


### PR DESCRIPTION
## Summary

Accept the `prepend` keyword in `ElasticBlockPool.free_blocks()` so kvcached survives the newer vLLM `BlockPool.free_blocks(ordered_blocks, prepend=...)` signature.

Fixes #438.

## Root cause

vLLM's `BlockPool.free_blocks()` grew `prepend: bool = False` (present in 0.23.0): freed blocks go to the front of vLLM's free queue for reuse priority. kvcached's injected `ElasticBlockPool` did not accept the kwarg, so engine startup on vLLM 0.23 dies during warmup:

```
TypeError: ElasticBlockPoolPatch.inject_elastic_block_pool.<locals>.ElasticBlockPool.free_blocks() got an unexpected keyword argument 'prepend'
```

## Changes

- `free_blocks()` accepts `prepend: bool = False`. The hint is intentionally unused: kvcached has no linear free queue, reuse order is governed by `KVCacheManager`'s page-affine allocation (`_pick_avail_page`), so there is nothing meaningful to prepend to. Comment in code records this.
- Older vLLMs that call without the kwarg are unaffected.
- Same drift class as the SGLang-side allocator fix in #411.

## Validation

- `tests/test_prefix_cache.py`: two new CPU-only tests, `prepend=True/False` on both the caching and caching-disabled paths; 32 passed.
- On unfixed main, `pool.free_blocks(blocks, prepend=True)` raises the TypeError above; with this patch it frees normally.
- GPU check on the #438 repro (A100, vLLM 0.23.0, `google/gemma-4-12B-it`, `KVCACHED_CONTIGUOUS_LAYOUT=false`): startup now proceeds past the block-pool TypeError. Result of the full run posted below once complete (the model may still hit later incompatibilities on 0.23; this PR scopes to the free_blocks drift).
- `ruff`, `isort`, mypy: no new findings (identical baseline to main).
