### PR TITLE
docs: refresh the supported models table

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ GPT-OSS support in SGLang updated to **v0.5.9**.
 
 | Engine | Versions | Attention types | Example models |
 |--------|----------|-----------------|----------------|
-| SGLang | ≥ v0.4.9 (tested up to v0.5.15) | MHA / GQA / MLA | Llama 3.1/3.3, Qwen 2.5, DeepSeek-V3, openai/gpt-oss-20b, etc. |
-| vLLM | ≥ v0.8.4 (tested up to v0.24.0) | MHA / GQA / MLA | Llama 3.1/3.3, Qwen 2.5, DeepSeek-V3, openai/gpt-oss-20b |
+| SGLang | ≥ v0.4.9 (tested up to v0.5.15) | MHA / GQA / MLA / sliding window / hybrid | DeepSeek-V3, Qwen3-8B, GPT-OSS-20B, Qwen3.5-9B, Gemma-4-E2B-it, Gemma-4-12B-it |
+| vLLM | ≥ v0.8.4 (tested up to v0.24.0) | MHA / GQA / MLA / sliding window / hybrid | DeepSeek-V3, Qwen3-8B, GPT-OSS-20B, Qwen3.5-9B, Gemma-4-E2B-it, Gemma-4-12B-it |
+
+See [#425](https://github.com/ovg-project/kvcached/issues/425) for per-model results on each engine and KV layout.
 
 ## Example use cases
 


### PR DESCRIPTION
Replaces the Llama 3.1/3.3 and Qwen 2.5 examples, which predate the architectures kvcached actually has to handle, with the five in the #425 support matrix plus DeepSeek-V3 for MLA. Adds sliding window and hybrid to the attention types, and links #425 for the per-model results on each engine and KV layout.