### PR TITLE
fix: synchronize page allocator snapshots

### DIFF
--- a/csrc/inc/page_allocator.hpp
+++ b/csrc/inc/page_allocator.hpp
@@ -81,6 +81,10 @@ public:
 
   // Status queries
   int64_t get_num_free_pages() const;
+  // Approximate. Reads num_total_pages_ and num_free_pages_ as two separate
+  // relaxed loads, so a concurrent resize() can land between them; expansion
+  // bumps num_free_pages_ before num_total_pages_, which can make this return
+  // a negative. Use get_page_state() when the value has to be consistent.
   int64_t get_num_inuse_pages() const;
   int64_t get_num_total_pages() const;
   int64_t get_num_reserved_pages() const;

--- a/csrc/inc/page_allocator.hpp
+++ b/csrc/inc/page_allocator.hpp
@@ -28,6 +28,13 @@ using BroadcastMapCallback =
 using BroadcastUnmapCallback =
     std::function<void(int64_t, const std::vector<offset_t> &)>;
 
+struct PageState {
+  int64_t total_pages;
+  int64_t free_pages;
+  int64_t inuse_pages;
+  int64_t reserved_pages;
+};
+
 // Independent InternalPage class
 class InternalPage {
 public:
@@ -77,6 +84,7 @@ public:
   int64_t get_num_inuse_pages() const;
   int64_t get_num_total_pages() const;
   int64_t get_num_reserved_pages() const;
+  PageState get_page_state() const;
   int64_t get_avail_physical_pages() const;
 
   // Poll the shared-memory MemInfoStruct to see if an external controller
@@ -124,7 +132,9 @@ private:
   // Internal methods
   void map_pages(const std::vector<page_id_t> &page_ids);
   void unmap_pages(const std::vector<page_id_t> &page_ids);
-  void update_memory_usage();
+  int64_t get_num_inuse_pages_unlocked() const;
+  PageState get_page_state_unlocked() const;
+  void update_memory_usage_unlocked();
   void trigger_preallocation();
   void start_prealloc_thread_internal();
   void stop_prealloc_thread_internal();
@@ -144,8 +154,8 @@ private:
   double gpu_utilization_;
 
   // Memory tracking
-  int64_t num_free_pages_;
-  int64_t num_total_pages_;
+  std::atomic<int64_t> num_free_pages_;
+  std::atomic<int64_t> num_total_pages_;
 
   // Page lists
   std::deque<page_id_t> free_page_list_;

--- a/csrc/page_allocator.cpp
+++ b/csrc/page_allocator.cpp
@@ -117,13 +117,17 @@ PageAllocator::PageAllocator(int64_t num_layers, int64_t mem_size_per_layer,
       gpu_utilization_(GPU_UTILIZATION),
       num_free_pages_(mem_size_per_layer / page_size),
       num_total_pages_(mem_size_per_layer / page_size),
-      min_reserved_pages_(std::min(num_free_pages_, MIN_RESERVED_PAGES)),
-      max_reserved_pages_(std::min(num_free_pages_, MAX_RESERVED_PAGES)),
+      min_reserved_pages_(std::min(
+          num_free_pages_.load(std::memory_order_relaxed), MIN_RESERVED_PAGES)),
+      max_reserved_pages_(std::min(
+          num_free_pages_.load(std::memory_order_relaxed), MAX_RESERVED_PAGES)),
       prealloc_running_(false), prealloc_needed_(false),
       total_memory_size_(mem_size_per_layer * num_layers * num_kv_buffers) {
 
   // Initialize free page list
-  for (int64_t i = 0; i < num_free_pages_; ++i) {
+  const int64_t initial_free_pages =
+      num_free_pages_.load(std::memory_order_relaxed);
+  for (int64_t i = 0; i < initial_free_pages; ++i) {
     free_page_list_.push_back(i);
   }
 
@@ -172,7 +176,7 @@ std::shared_ptr<InternalPage> PageAllocator::alloc_page() {
     if (!reserved_page_list_.empty()) {
       page_id = reserved_page_list_.front();
       reserved_page_list_.pop_front();
-      num_free_pages_--;
+      num_free_pages_.fetch_sub(1, std::memory_order_relaxed);
 
       // Trigger preallocation to refill reserved pool if getting low
       if (reserved_page_list_.size() <
@@ -181,7 +185,7 @@ std::shared_ptr<InternalPage> PageAllocator::alloc_page() {
         cond_.notify_all();
       }
 
-      update_memory_usage();
+      update_memory_usage_unlocked();
       auto end_time = std::chrono::steady_clock::now();
       auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
           end_time - start_time);
@@ -196,11 +200,11 @@ std::shared_ptr<InternalPage> PageAllocator::alloc_page() {
     if (!free_page_list_.empty()) {
       page_id = free_page_list_.front();
       free_page_list_.pop_front();
-      num_free_pages_--;
+      num_free_pages_.fetch_sub(1, std::memory_order_relaxed);
       break;
     }
 
-    if (num_free_pages_ <= 0) {
+    if (num_free_pages_.load(std::memory_order_relaxed) <= 0) {
       throw std::runtime_error("No free pages left");
     }
 
@@ -220,7 +224,7 @@ std::shared_ptr<InternalPage> PageAllocator::alloc_page() {
   } catch (const std::exception &e) {
     std::lock_guard<std::mutex> guard(lock_);
     free_page_list_.push_front(page_id);
-    num_free_pages_++;
+    num_free_pages_.fetch_add(1, std::memory_order_relaxed);
     cond_.notify_all();
     throw std::runtime_error("Failed to map page " + std::to_string(page_id) +
                              ": " + e.what());
@@ -230,7 +234,10 @@ std::shared_ptr<InternalPage> PageAllocator::alloc_page() {
     trigger_preallocation();
   }
 
-  update_memory_usage();
+  {
+    std::lock_guard<std::mutex> lock(lock_);
+    update_memory_usage_unlocked();
+  }
   auto end_time = std::chrono::steady_clock::now();
   auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
       end_time - start_time);
@@ -242,12 +249,12 @@ std::shared_ptr<InternalPage> PageAllocator::alloc_page() {
 void PageAllocator::free_page(page_id_t page_id) {
   {
     std::lock_guard<std::mutex> lock(lock_);
-    num_free_pages_++;
+    num_free_pages_.fetch_add(1, std::memory_order_relaxed);
 
     if (reserved_page_list_.size() < static_cast<size_t>(max_reserved_pages_)) {
       // Fast path: reserve page
       reserved_page_list_.push_back(page_id);
-      update_memory_usage();
+      update_memory_usage_unlocked();
       cond_.notify_all();
       return;
     }
@@ -259,7 +266,7 @@ void PageAllocator::free_page(page_id_t page_id) {
   {
     std::lock_guard<std::mutex> lock(lock_);
     free_page_list_.push_back(page_id);
-    update_memory_usage();
+    update_memory_usage_unlocked();
     cond_.notify_all();
   }
 }
@@ -271,7 +278,8 @@ void PageAllocator::free_pages(const std::vector<page_id_t> &page_ids) {
 
   {
     std::lock_guard<std::mutex> lock(lock_);
-    num_free_pages_ += page_ids.size();
+    num_free_pages_.fetch_add(static_cast<int64_t>(page_ids.size()),
+                              std::memory_order_relaxed);
     int64_t num_to_reserve = max_reserved_pages_ - reserved_page_list_.size();
 
     if (num_to_reserve > 0) {
@@ -285,7 +293,7 @@ void PageAllocator::free_pages(const std::vector<page_id_t> &page_ids) {
       pages_to_unmap.assign(reserve_end, page_ids.end());
 
       if (pages_to_unmap.empty()) {
-        update_memory_usage();
+        update_memory_usage_unlocked();
         cond_.notify_all();
         return;
       }
@@ -301,7 +309,7 @@ void PageAllocator::free_pages(const std::vector<page_id_t> &page_ids) {
     std::lock_guard<std::mutex> lock(lock_);
     free_page_list_.insert(free_page_list_.end(), pages_to_unmap.begin(),
                            pages_to_unmap.end());
-    update_memory_usage();
+    update_memory_usage_unlocked();
     cond_.notify_all();
   }
 
@@ -320,14 +328,16 @@ bool PageAllocator::resize(int64_t new_mem_size) {
   {
     std::lock_guard<std::mutex> lock(lock_);
 
-    if (new_num_pages < get_num_inuse_pages()) {
+    if (new_num_pages < get_num_inuse_pages_unlocked()) {
       return false;
     }
 
-    if (new_num_pages == num_total_pages_) {
+    const int64_t current_total_pages =
+        num_total_pages_.load(std::memory_order_relaxed);
+    if (new_num_pages == current_total_pages) {
       return true;
-    } else if (new_num_pages > num_total_pages_) {
-      int64_t num_to_expand = new_num_pages - num_total_pages_;
+    } else if (new_num_pages > current_total_pages) {
+      int64_t num_to_expand = new_num_pages - current_total_pages;
 
       // Reuse previously reclaimed pages first
       int64_t num_to_reuse = std::min(
@@ -338,23 +348,23 @@ bool PageAllocator::resize(int64_t new_mem_size) {
           reclaimed_page_list_.pop_front();
         }
         num_to_expand -= num_to_reuse;
-        num_free_pages_ += num_to_reuse;
+        num_free_pages_.fetch_add(num_to_reuse, std::memory_order_relaxed);
       }
 
       // Allocate new pages if needed
       if (num_to_expand > 0) {
-        for (int64_t i = num_total_pages_; i < num_total_pages_ + num_to_expand;
-             ++i) {
+        for (int64_t i = current_total_pages;
+             i < current_total_pages + num_to_expand; ++i) {
           free_page_list_.push_back(i);
         }
-        num_free_pages_ += num_to_expand;
+        num_free_pages_.fetch_add(num_to_expand, std::memory_order_relaxed);
       }
-      num_total_pages_ = new_num_pages;
-      update_memory_usage();
+      num_total_pages_.store(new_num_pages, std::memory_order_relaxed);
+      update_memory_usage_unlocked();
       return true;
     } else {
       // Shrink path
-      int64_t num_to_reclaim = num_total_pages_ - new_num_pages;
+      int64_t num_to_reclaim = current_total_pages - new_num_pages;
 
       if (free_page_list_.size() < static_cast<size_t>(num_to_reclaim)) {
         // Need to trim reserved pages first
@@ -371,8 +381,8 @@ bool PageAllocator::resize(int64_t new_mem_size) {
           reclaimed_page_list_.push_back(free_page_list_.back());
           free_page_list_.pop_back();
         }
-        num_free_pages_ -= num_to_reclaim;
-        num_total_pages_ = new_num_pages;
+        num_free_pages_.fetch_sub(num_to_reclaim, std::memory_order_relaxed);
+        num_total_pages_.store(new_num_pages, std::memory_order_relaxed);
         return true;
       }
     }
@@ -383,11 +393,12 @@ bool PageAllocator::resize(int64_t new_mem_size) {
 
   {
     std::lock_guard<std::mutex> lock(lock_);
-    int64_t num_to_reclaim = num_total_pages_ - new_num_pages;
+    int64_t num_to_reclaim =
+        num_total_pages_.load(std::memory_order_relaxed) - new_num_pages;
 
     free_page_list_.insert(free_page_list_.end(), pages_to_unmap.begin(),
                            pages_to_unmap.end());
-    update_memory_usage();
+    update_memory_usage_unlocked();
 
     if (free_page_list_.size() < static_cast<size_t>(num_to_reclaim)) {
       return false;
@@ -397,8 +408,8 @@ bool PageAllocator::resize(int64_t new_mem_size) {
       reclaimed_page_list_.push_back(free_page_list_.back());
       free_page_list_.pop_back();
     }
-    num_free_pages_ -= num_to_reclaim;
-    num_total_pages_ = new_num_pages;
+    num_free_pages_.fetch_sub(num_to_reclaim, std::memory_order_relaxed);
+    num_total_pages_.store(new_num_pages, std::memory_order_relaxed);
   }
   return true;
 }
@@ -413,7 +424,7 @@ void PageAllocator::trim() {
     reserved_page_list_.clear();
 
     if (pages_to_unmap.empty()) {
-      update_memory_usage();
+      update_memory_usage_unlocked();
       return;
     }
   }
@@ -425,21 +436,44 @@ void PageAllocator::trim() {
     std::lock_guard<std::mutex> lock(lock_);
     free_page_list_.insert(free_page_list_.end(), pages_to_unmap.begin(),
                            pages_to_unmap.end());
-    update_memory_usage();
+    update_memory_usage_unlocked();
   }
 }
 
-int64_t PageAllocator::get_num_free_pages() const { return num_free_pages_; }
-
-int64_t PageAllocator::get_num_inuse_pages() const {
-  return num_total_pages_ - num_free_pages_;
+int64_t PageAllocator::get_num_free_pages() const {
+  return num_free_pages_.load(std::memory_order_relaxed);
 }
 
-int64_t PageAllocator::get_num_total_pages() const { return num_total_pages_; }
+int64_t PageAllocator::get_num_inuse_pages() const {
+  const int64_t total = num_total_pages_.load(std::memory_order_relaxed);
+  const int64_t free = num_free_pages_.load(std::memory_order_relaxed);
+  return total - free;
+}
+
+int64_t PageAllocator::get_num_total_pages() const {
+  return num_total_pages_.load(std::memory_order_relaxed);
+}
 
 int64_t PageAllocator::get_num_reserved_pages() const {
   std::lock_guard<std::mutex> lock(lock_);
   return reserved_page_list_.size();
+}
+
+PageState PageAllocator::get_page_state() const {
+  std::lock_guard<std::mutex> lock(lock_);
+  return get_page_state_unlocked();
+}
+
+int64_t PageAllocator::get_num_inuse_pages_unlocked() const {
+  return num_total_pages_.load(std::memory_order_relaxed) -
+         num_free_pages_.load(std::memory_order_relaxed);
+}
+
+PageState PageAllocator::get_page_state_unlocked() const {
+  const int64_t total = num_total_pages_.load(std::memory_order_relaxed);
+  const int64_t free = num_free_pages_.load(std::memory_order_relaxed);
+  return PageState{total, free, total - free,
+                   static_cast<int64_t>(reserved_page_list_.size())};
 }
 
 int64_t PageAllocator::get_avail_physical_pages() const {
@@ -611,7 +645,7 @@ void PageAllocator::prealloc_worker() {
         reserved_page_list_.insert(reserved_page_list_.end(),
                                    pages_to_reserve.begin(),
                                    pages_to_reserve.end());
-        update_memory_usage();
+        update_memory_usage_unlocked();
         cond_.notify_all();
         LOGGER(INFO, "Preallocated %ld pages, reserved=%ld",
                pages_to_reserve.size(), reserved_page_list_.size());
@@ -703,10 +737,10 @@ void PageAllocator::unmap_pages(const std::vector<page_id_t> &page_ids) {
          page_ids.size(), duration.count());
 }
 
-void PageAllocator::update_memory_usage() {
+void PageAllocator::update_memory_usage_unlocked() {
   // Calculate currently used physical memory (excluding preallocated pages)
-  int64_t used_phy_mem_size =
-      get_num_inuse_pages() * num_layers_ * page_size_ * num_kv_buffers_;
+  int64_t used_phy_mem_size = get_num_inuse_pages_unlocked() * num_layers_ *
+                              page_size_ * num_kv_buffers_;
   // Calculate physical memory occupied by preallocated pages
   int64_t prealloc_phy_mem_size =
       static_cast<int64_t>(reserved_page_list_.size()) * num_layers_ *

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -133,6 +133,21 @@ int64_t page_allocator_get_num_reserved_pages(
   return allocator->get_num_reserved_pages();
 }
 
+py::dict
+page_allocator_get_page_state(std::shared_ptr<PageAllocator> allocator) {
+  PageState state;
+  {
+    py::gil_scoped_release release;
+    state = allocator->get_page_state();
+  }
+  py::dict result;
+  result["total_pages"] = state.total_pages;
+  result["free_pages"] = state.free_pages;
+  result["inuse_pages"] = state.inuse_pages;
+  result["reserved_pages"] = state.reserved_pages;
+  return result;
+}
+
 int64_t page_allocator_get_avail_physical_pages(
     std::shared_ptr<PageAllocator> allocator) {
   return allocator->get_avail_physical_pages();
@@ -234,6 +249,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("get_num_total_pages", &kvcached::page_allocator_get_num_total_pages)
       .def("get_num_reserved_pages",
            &kvcached::page_allocator_get_num_reserved_pages)
+      .def("get_page_state", &kvcached::page_allocator_get_page_state)
       .def("get_avail_physical_pages",
            &kvcached::page_allocator_get_avail_physical_pages)
       .def("check_and_get_resize_target",

--- a/kvcached/observability.py
+++ b/kvcached/observability.py
@@ -76,9 +76,9 @@ class KVCachePoolSnapshot:
     * ``virtual_total_bytes`` -- the whole pool, i.e.
       ``virtual_per_layer_bytes * num_layers``.
 
-    Values are best-effort rather than a consistent point-in-time cut: the
-    C++ pre-allocation thread mutates page counters without taking the
-    manager lock, so fields may come from marginally different instants.
+    The page-count fields are captured atomically with respect to allocator
+    mutations. Other fields remain best-effort and may come from marginally
+    different instants.
     """
 
     schema_version: str
@@ -164,17 +164,35 @@ def build_kv_cache_pool_snapshot(
     """Build a read-only snapshot from a ``KVCacheManager``-like object."""
 
     allocator = manager.page_allocator
-    free_pages = _call_int(allocator, "get_num_free_pages")
-    reserved_pages = _call_int(allocator, "get_num_reserved_pages")
+    page_state_fn = getattr(allocator, "get_page_state", None)
+    page_state = page_state_fn() if callable(page_state_fn) else None
+    if page_state is None:
+        total_pages = _call_int(allocator, "get_num_total_pages")
+        free_pages = _call_int(allocator, "get_num_free_pages")
+        inuse_pages = _call_int(allocator, "get_num_inuse_pages")
+        reserved_pages = _call_int(allocator, "get_num_reserved_pages")
+    else:
+        total_pages = int(page_state["total_pages"])
+        free_pages = int(page_state["free_pages"])
+        inuse_pages = int(page_state["inuse_pages"])
+        reserved_pages = int(page_state["reserved_pages"])
     available_physical_pages = _call_int(allocator, "get_avail_physical_pages")
     if free_pages is None or reserved_pages is None or available_physical_pages is None:
         effective_free_pages = None
     else:
         effective_free_pages = min(free_pages, available_physical_pages + reserved_pages)
 
-    mapped_bytes = int(manager.get_mapped_memory_size("bytes"))
     num_layers = _int_attr(manager, "num_layers") or 0
     num_kv_buffers = _int_attr(manager, "num_kv_buffers") or 0
+    if page_state is None or inuse_pages is None:
+        mapped_bytes = int(manager.get_mapped_memory_size("bytes"))
+    else:
+        mapped_bytes = (
+            inuse_pages
+            * (_int_attr(manager, "page_size") or 0)
+            * num_layers
+            * num_kv_buffers
+        )
     # manager.mem_size is the virtual reservation for ONE KV buffer of ONE
     # layer -- K (or V) for MHA, the single combined buffer for MLA -- which
     # is why the total scales by both num_layers and num_kv_buffers. Scale by
@@ -184,11 +202,8 @@ def build_kv_cache_pool_snapshot(
     virtual_per_layer_bytes = virtual_bytes_per_buffer * num_kv_buffers
     block_size_bytes = _int_attr(manager, "block_mem_size") or 0
     bytes_per_block = block_size_bytes * num_layers * num_kv_buffers
-    # available_size() can transiently go negative: it derives from
-    # PageAllocator::get_num_free_pages(), which reads a mutable counter
-    # without holding the allocator mutex, so a concurrent snapshot may
-    # observe an intermediate value. A negative gauge is never meaningful to
-    # an exporter, so clamp at zero.
+    # Keep the clamp for compatibility with older native extensions and
+    # duck-typed managers that do not provide a coherent page-state snapshot.
     available_blocks = max(int(manager.available_size()), 0)
     allocated_blocks = max(int(manager._get_num_alloced_blocks()), 0)
     reserved_blocks = len(getattr(manager, "reserved_blocks", []))
@@ -214,9 +229,9 @@ def build_kv_cache_pool_snapshot(
         virtual_per_layer_bytes=virtual_per_layer_bytes,
         virtual_total_bytes=virtual_per_layer_bytes * num_layers,
         mapped_bytes=mapped_bytes,
-        total_pages=_call_int(allocator, "get_num_total_pages"),
+        total_pages=total_pages,
         free_pages=free_pages,
-        inuse_pages=_call_int(allocator, "get_num_inuse_pages"),
+        inuse_pages=inuse_pages,
         reserved_pages=reserved_pages,
         available_physical_pages=available_physical_pages,
         effective_free_pages=effective_free_pages,

--- a/kvcached/observability.py
+++ b/kvcached/observability.py
@@ -202,8 +202,11 @@ def build_kv_cache_pool_snapshot(
     virtual_per_layer_bytes = virtual_bytes_per_buffer * num_kv_buffers
     block_size_bytes = _int_attr(manager, "block_mem_size") or 0
     bytes_per_block = block_size_bytes * num_layers * num_kv_buffers
-    # Keep the clamp for compatibility with older native extensions and
-    # duck-typed managers that do not provide a coherent page-state snapshot.
+    # available_size() reads three allocator getters at three separate instants
+    # and never consults get_page_state(), so it can report an inconsistent
+    # total no matter which native extension is loaded. #436 also observed it
+    # returning a negative value, and that cause has not been established. A
+    # negative gauge is never meaningful to an exporter, so clamp at zero.
     available_blocks = max(int(manager.available_size()), 0)
     allocated_blocks = max(int(manager._get_num_alloced_blocks()), 0)
     reserved_blocks = len(getattr(manager, "reserved_blocks", []))

--- a/tests/manifests/gpu.txt
+++ b/tests/manifests/gpu.txt
@@ -2,4 +2,5 @@ tests/test_ElasticMLAMemoryPool.py
 tests/test_alloc_kv_cache_alignment.py
 tests/test_hybrid_contiguous_layout.py
 tests/test_kvcache_manager.py
+tests/test_page_allocator_snapshot.py
 tests/test_paged_allocator_aliasing.py

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -7,6 +7,7 @@ import json
 import sys
 import types
 from pathlib import Path
+from typing import Any
 
 if "torch" not in sys.modules and importlib.util.find_spec("torch") is None:
     sys.modules.setdefault("torch", types.ModuleType("torch"))
@@ -24,6 +25,17 @@ from kvcached.pool_registry import (  # noqa: E402
 
 
 class FakePageAllocator:
+    page_state_calls = 0
+
+    def get_page_state(self):
+        self.page_state_calls += 1
+        return {
+            "total_pages": 20,
+            "free_pages": 10,
+            "inuse_pages": 10,
+            "reserved_pages": 2,
+        }
+
     def get_num_free_pages(self):
         return 10
 
@@ -104,6 +116,7 @@ def test_runtime_snapshot_dict():
 
 
 def test_kv_cache_pool_snapshot_from_manager_like_object():
+    FakeManager.page_allocator.page_state_calls = 0
     snapshot = build_kv_cache_pool_snapshot(
         FakeManager(),
         integration="sglang",
@@ -124,15 +137,47 @@ def test_kv_cache_pool_snapshot_from_manager_like_object():
     assert data["null_block_reserved"] is True
     assert data["virtual_per_layer_bytes"] == 128 * 4096 * 2
     assert data["virtual_total_bytes"] == 128 * 4096 * 8 * 2
-    assert data["mapped_bytes"] == 6 * 8 * (2 * 1024 * 1024) * 2
+    assert data["mapped_bytes"] == 10 * 8 * (2 * 1024 * 1024) * 2
     assert data["total_pages"] == 20
     assert data["free_pages"] == 10
-    assert data["inuse_pages"] == 6
+    assert data["inuse_pages"] == 10
     assert data["reserved_pages"] == 2
     assert data["available_physical_pages"] == 4
     assert data["effective_free_pages"] == 6
     assert data["resize_target_bytes"] == 0
+    assert FakeManager.page_allocator.page_state_calls == 1
     json.dumps(data)
+
+
+def test_pool_snapshot_falls_back_for_older_page_allocator():
+    class LegacyPageAllocator:
+        def get_num_free_pages(self):
+            return 7
+
+        def get_num_inuse_pages(self):
+            return 5
+
+        def get_num_total_pages(self):
+            return 12
+
+        def get_num_reserved_pages(self):
+            return 1
+
+        def get_avail_physical_pages(self):
+            return 3
+
+        def get_resize_target(self):
+            return -1
+
+    class LegacyManager(FakeManager):
+        page_allocator: Any = LegacyPageAllocator()
+
+    data = build_kv_cache_pool_snapshot(LegacyManager()).to_dict()
+
+    assert data["total_pages"] == 12
+    assert data["free_pages"] == 7
+    assert data["inuse_pages"] == 5
+    assert data["reserved_pages"] == 1
 
 
 def test_pool_snapshot_clamps_negative_block_gauges():

--- a/tests/test_page_allocator_snapshot.py
+++ b/tests/test_page_allocator_snapshot.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import threading
+import time
+
+import pytest
+
+torch = pytest.importorskip("torch")
+if not torch.cuda.is_available():
+    pytest.skip("needs a CUDA build of the native extension", allow_module_level=True)
+
+from kvcached.vmm_ops import PageAllocator  # noqa: E402
+
+
+def test_page_state_stays_coherent_during_resize():
+    page_size = 2 * 1024 * 1024
+    lower_pages = 16
+    upper_pages = 32
+    allocator = PageAllocator(
+        num_layers=1,
+        mem_size_per_layer=upper_pages * page_size,
+        page_size=page_size,
+        world_size=1,
+        pp_rank=0,
+        async_sched=False,
+        contiguous_layout=True,
+        enable_page_prealloc=False,
+        num_kv_buffers=1,
+        group_id=os.getpid(),
+        ipc_name=f"/kvcached-page-state-{os.getpid()}",
+    )
+
+    stop_snapshot = threading.Event()
+    resize_done = threading.Event()
+    snapshot_done = threading.Event()
+    failures = []
+
+    def resize_repeatedly():
+        try:
+            for _ in range(1_000):
+                assert allocator.resize(lower_pages * page_size)
+                assert allocator.resize(upper_pages * page_size)
+        except BaseException as exc:
+            failures.append(exc)
+        finally:
+            resize_done.set()
+
+    def snapshot_repeatedly():
+        try:
+            while not stop_snapshot.is_set():
+                state = allocator.get_page_state()
+                total_pages = state["total_pages"]
+                free_pages = state["free_pages"]
+                inuse_pages = state["inuse_pages"]
+                assert total_pages in (lower_pages, upper_pages)
+                assert 0 <= free_pages <= total_pages
+                assert inuse_pages == total_pages - free_pages
+                assert state["reserved_pages"] == 0
+                time.sleep(0)
+        except BaseException as exc:
+            failures.append(exc)
+        finally:
+            snapshot_done.set()
+
+    resize_thread = threading.Thread(target=resize_repeatedly, daemon=True)
+    snapshot_thread = threading.Thread(target=snapshot_repeatedly, daemon=True)
+    snapshot_thread.start()
+    resize_thread.start()
+
+    assert resize_done.wait(timeout=20), "resize deadlocked with page-state snapshots"
+    stop_snapshot.set()
+    assert snapshot_done.wait(timeout=10), "page-state snapshot did not finish"
+    resize_thread.join(timeout=0)
+    snapshot_thread.join(timeout=0)
+    assert failures == []


### PR DESCRIPTION
## Summary

- make individual `PageAllocator` page-count getters data-race-free with relaxed atomic counters
- add one coherent page-state snapshot under the allocator lock for observability consumers
- keep explicit lock-held helpers for allocator internals to avoid recursive locking
- preserve compatibility with older native extensions in the Python observability layer

## Why

The page counters were mutated under `PageAllocator::lock_`, but three public getters read them without synchronization. Concurrent metrics collection could therefore race with allocation or resize, and separate getter calls could combine values from different allocator states.

The individual getters are used by serving-side capacity checks, so they remain lock-free relaxed atomic reads. Monitoring uses a single short locked snapshot when it needs a coherent total/free/in-use tuple.

## Implementation comparison

The PR was amended after measuring the mutex-based hot-getter implementation. Both uploaded revisions remain available for direct inspection:

- [mutex-based hot getters (`d3cd87cf`)](https://github.com/shipiyouniao/kvcached/commit/d3cd87cfb981b00ce8e1fd46d02f367a20aa6ad8)
- [relaxed atomic getters + locked coherent snapshot (`f5715f69`)](https://github.com/shipiyouniao/kvcached/commit/f5715f6985ed1b53d3dd7c2dd578dade7819eb44)
- [code diff between the two implementations](https://github.com/shipiyouniao/kvcached/compare/d3cd87cfb981b00ce8e1fd46d02f367a20aa6ad8...f5715f6985ed1b53d3dd7c2dd578dade7819eb44)

## Validation

- native extension built against PyTorch 2.10.0 + CUDA 12.9 on a Tesla T4
- concurrent resize/snapshot regression: 1,000 shrink/expand cycles, coherent invariants preserved
- focused native and observability tests: `10 passed`
- hosted CPU test manifest: `121 passed`
- GPU-free C++ unit tests: passed
- ruff, isort, clang-format, and codespell: passed

T4 serving A/B used Qwen2.5-3B, `C64/N256`, `I512/O128`, one equal-size warmup, then three measured rounds. The table reports the median of those rounds:

| Variant | Median req/s | Median total tok/s | Median TTFT P90 | Median TPOT P90 |
| --- | ---: | ---: | ---: | ---: |
| Unsynchronized baseline | 3.91 | 2501.87 | 6191.03 ms | 116.12 ms |
| Mutex on hot getters | 3.84 | 2458.83 | 6260.08 ms | 119.82 ms |
| Relaxed atomic getters + locked snapshot | 3.91 | 2504.00 | 6203.53 ms | 116.33 ms |

A separate 1-second polling run confirmed the snapshot reader operated inside the EngineCore process with one registered pool. It did not add measurable contention beyond the getter implementation itself.

Fixes #436