### PR TITLE
fix: qwen3.5  on sglang 0.5.14 and 0.5.15

### DIFF
--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -872,8 +872,23 @@ class ElasticMambaPoolPatch(VersionAwarePatch, BasePatch):
                     mamba_layer_ids: Optional[List[int]] = None,
                     enable_memory_saver: bool = False,
                     speculative_num_draft_tokens: Optional[int] = None,
+                    speculative_eagle_topk: Optional[int] = None,
+                    enable_linear_replayssm: bool = False,
+                    linear_replayssm_cache_len: int = 16,
+                    envelope_layout: bool = False,
                 ) -> None:
                     import kvcached.integration.sglang.interfaces as kvi
+
+                    if enable_linear_replayssm:
+                        raise NotImplementedError(
+                            "ElasticMambaPool does not support SGLang "
+                            "linear ReplaySSM buffers yet."
+                        )
+                    if envelope_layout:
+                        raise NotImplementedError(
+                            "ElasticMambaPool uses the kvcached mamba state "
+                            "layout and does not support SGLang envelope_layout."
+                        )
 
                     # Resolve TP/PP rank the same way ElasticMHATokenToKVPool
                     # does so the IPC socket naming matches.
@@ -909,6 +924,10 @@ class ElasticMambaPoolPatch(VersionAwarePatch, BasePatch):
 
                     self.size = size
                     self.device = device
+                    self.enable_linear_replayssm = False
+                    self.linear_replayssm_cache_len = linear_replayssm_cache_len
+                    self.replayssm_is_kda = False
+                    self.replayssm_write_pos = None
                     # SGLang passes the layer list as either a mamba_layer_ids
                     # kwarg or cache_params.layers, depending on version.
                     if mamba_layer_ids is not None:


### PR DESCRIPTION
## Summary

 #425  Qwen/Qwen3.5-9B crashes with SGLang v0.5.14 and v0.5.15 when kvcached patches MambaPool.

  The root cause is that SGLang changed the MambaPool constructor signature:

  - v0.5.14 added speculative_eagle_topk. [code](https://github.com/sgl-project/sglang/blob/v0.5.14/python/sglang/srt/mem_cache/memory_pool.py#L299)
  - v0.5.15 added enable_linear_replayssm, linear_replayssm_cache_len, and envelope_layout [code](https://github.com/sgl-project/sglang/blob/v0.5.15/python/sglang/srt/mem_cache/memory_pool.py#L354)

  This PR updates ElasticMambaPool to accept the new parameters for compatibility. `speculative_eagle_topk` is accepted but not used yet, since kvcached keeps the existing dense speculative buffer layout.

  `enable_linear_replayssm` and `envelope_layout` require additional state/layout support that kvcached does not implement yet, so they now fail explicitly with NotImplementedError instead of silently running with unsupported behavior.


## Test

Test with SGLang v0.5.14 and v0.5.15. 
All passed.


