### PR TITLE
feat(vllm): support the contiguous KV layout for heterogeneous attention groups (Gemma)

### DIFF
--- a/examples/08_hybrid_attention_models/README.md
+++ b/examples/08_hybrid_attention_models/README.md
@@ -9,7 +9,7 @@ vLLM uses the term "hybrid" for two very different things, and kvcached needs di
 | Flavor | Examples | vLLM flag | kvcached env |
 |---|---|---|---|
 | **Attention-only hybrid, uniform geometry** (full + sliding window, all attention groups share the same block geometry) | GPT-OSS | `--disable-hybrid-kv-cache-manager` **optional** (see note) | (default; `KVCACHED_CONTIGUOUS_LAYOUT=true`) |
-| **Attention-only hybrid, heterogeneous geometry** (sliding vs full layers have different KV dims / block_size, same block_mem_size) | Gemma 3 / Gemma 4 | **do NOT pass** `--disable-hybrid-kv-cache-manager` | `KVCACHED_CONTIGUOUS_LAYOUT=false` |
+| **Attention-only hybrid, heterogeneous geometry** (sliding vs full layers have different KV dims / block_size, same block_mem_size) | Gemma 3 / Gemma 4 | **do NOT pass** `--disable-hybrid-kv-cache-manager` | (default; either layout³) |
 | **Linear-attention hybrid** (full attention + Mamba/SSM, groups have different specs and cannot be unified) | Qwen3-Next / Qwen3.5-3.6 GDN, Jamba, Bamba, NemotronH, Zamba2, Plamo2 | **do NOT pass** `--disable-hybrid-kv-cache-manager` | `KVCACHED_CONTIGUOUS_LAYOUT=false`² |
 
 > **Note on GPT-OSS / `--disable-hybrid-kv-cache-manager`:** kvcached now supports
@@ -22,7 +22,9 @@ vLLM uses the term "hybrid" for two very different things, and kvcached needs di
 > benefit is runtime block recycling for long-context/high-concurrency workloads.
 > `start_two_models.sh` still passes it for GPT-OSS for backward compatibility.
 
-The `start_two_models.sh` script defaults to GPT-OSS (attention-only). For Jamba/Bamba and other Mamba-hybrid models, drop `--disable-hybrid-kv-cache-manager` from the `vllm serve` command and export `KVCACHED_CONTIGUOUS_LAYOUT=false` before launching. For Gemma 3/4 (heterogeneous attention geometry), likewise do not disable the hybrid manager and export `KVCACHED_CONTIGUOUS_LAYOUT=false`.
+The `start_two_models.sh` script defaults to GPT-OSS (attention-only). For Jamba/Bamba and other Mamba-hybrid models, drop `--disable-hybrid-kv-cache-manager` from the `vllm serve` command and export `KVCACHED_CONTIGUOUS_LAYOUT=false` before launching. For Gemma 3/4 (heterogeneous attention geometry), likewise do not disable the hybrid manager; the layout no longer needs overriding.
+
+> ³ **Contiguous layout for heterogeneous attention geometry is now supported.** It was previously blocked by a startup guard that predated any measurement. On vLLM 0.24 / `google/gemma-4-12B-it` (48 layers: 40 sliding `head_dim=256`×8 KV heads + 8 full `head_dim=512`×1 KV head, both 65536 B/block) the two layouts are token-for-token identical to each other and to the no-kvcached baseline. See the PR that removed the guard for the full matrix.
 
 > ² **Contiguous layout for linear-attention hybrids is newly supported** (code + CPU unit tests landed; see [`docs/HYBRID_LINEAR_CONTIGUOUS_LAYOUT_PLAN.md`](../../docs/HYBRID_LINEAR_CONTIGUOUS_LAYOUT_PLAN.md)). GPU token-parity validated on vLLM 0.22.1 (tiny GDN hybrids, ratio=5, 1- and 2-slot pools): token-for-token identical to the no-kvcached baseline for both layouts. `contiguous + kernel_block_size != block_size` (ratio>1) is supported via kernel-block-granular per-block views.
 

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -125,8 +125,12 @@ def build_kv_views(
     heterogeneous hybrid model (e.g. Gemma: sliding-window + full-attention
     groups with different ``(block_size, num_kv_heads, head_size)`` but identical
     ``block_mem_size``) build a DIFFERENT view per group over the SAME physical
-    pools. Returns ``(kv_tensors, page_size_bytes)``. Non-contiguous layout only
-    for heterogeneous callers.
+    pools. Returns ``(kv_tensors, page_size_bytes)``.
+
+    Both layouts are supported for heterogeneous callers: the shared
+    ``block_mem_size`` means block N occupies the same bytes whichever group's
+    view addresses it, so each branch below only has to re-derive the per-group
+    shape/stride from that one uniform block stride.
     """
     is_mla = attention_type == "MLA"
     unified_pool = attention_type == "HYBRID_LINEAR"

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -130,7 +130,10 @@ def build_kv_views(
     Both layouts are supported for heterogeneous callers: the shared
     ``block_mem_size`` means block N occupies the same bytes whichever group's
     view addresses it, so each branch below only has to re-derive the per-group
-    shape/stride from that one uniform block stride.
+    shape/stride from that one uniform block stride. The one exception is
+    ``contiguous`` + ``kernel_block_size != block_size``, which raises: that
+    branch reshapes at virtual-block granularity and has no kernel-block form
+    yet.
     """
     is_mla = attention_type == "MLA"
     unified_pool = attention_type == "HYBRID_LINEAR"
@@ -201,11 +204,23 @@ def build_kv_views(
             for t in raw_kv_tensors:
                 kv_tensors.append(
                     torch.as_strided(t.view(dtype=dtype), shape, strides))
-    # NOTE: contiguous + HYBRID_LINEAR never reaches build_kv_views today
-    # (heterogeneous grouping requires the non-contiguous layout and
-    # excludes hybrid-linear); the kernel-block-granular contiguous view
-    # for the unified pool lives in alloc_kv_cache.
+    # NOTE: contiguous + HYBRID_LINEAR never reaches build_kv_views (hybrid-linear
+    # is excluded from heterogeneous grouping); the kernel-block-granular
+    # contiguous view for the unified pool lives in alloc_kv_cache.
     else:
+        if ratio > 1:
+            # The branch below reshapes at VIRTUAL block granularity: it never
+            # consults kernel_kvcache_shape, so with ratio > 1 the views would
+            # disagree with the kernel's kernel_bs-token indexing and read
+            # silently wrong KV. The non-contiguous branch above does handle
+            # this. No engine config has produced ratio > 1 here yet (Gemma 3/4
+            # report kernel_block_size == block_size for every group), so rather
+            # than ship an unexercised stride derivation, fail loud.
+            raise NotImplementedError(
+                "kvcached: heterogeneous attention KV groups on the contiguous "
+                f"layout do not support kernel_block_size ({kernel_block_size}) "
+                f"!= block_size ({block_size}). Re-launch with "
+                "KVCACHED_CONTIGUOUS_LAYOUT=false.")
         layer_elem_shape = actual_kvcache_shape[:blocks_dim_idx] + actual_kvcache_shape[blocks_dim_idx + 1:]
         contiguous_shape = [num_blocks_per_layer, num_layers] + layer_elem_shape
         num_eles = math.prod(contiguous_shape)

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -1538,15 +1538,12 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 self._kvcached_mamba_raw_info = raw_info
             elif is_hetero:
                 kv_cache_raw_tensors, meta = alloc_result
-                if getattr(kvi, "_contiguous_layout", False):
-                    raise RuntimeError(
-                        "kvcached: heterogeneous attention KV groups (e.g. Gemma "
-                        "sliding-window + full-attention) currently require the "
-                        "non-contiguous layout. Re-launch with "
-                        "KVCACHED_CONTIGUOUS_LAYOUT=false."
-                    )
                 # Build a per-group view over the shared physical pools using each
-                # group's own (block_size, num_kv_heads, head_size).
+                # group's own (block_size, num_kv_heads, head_size). Both layouts
+                # work: every group has the same block_mem_size (validated
+                # above), so block N sits at the same byte offset whichever
+                # group's view addresses it, and build_kv_views derives the
+                # per-group shape/stride from that one uniform block stride.
                 layer_views: dict = {}
                 for gid, grp in attn_group_list:
                     gspec = grp.kv_cache_spec

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -1540,10 +1540,12 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                 kv_cache_raw_tensors, meta = alloc_result
                 # Build a per-group view over the shared physical pools using each
                 # group's own (block_size, num_kv_heads, head_size). Both layouts
-                # work: every group has the same block_mem_size (validated
-                # above), so block N sits at the same byte offset whichever
-                # group's view addresses it, and build_kv_views derives the
-                # per-group shape/stride from that one uniform block stride.
+                # work at kernel_block_size == block_size: every group has the
+                # same block_mem_size (validated above), so block N sits at the
+                # same byte offset whichever group's view addresses it, and
+                # build_kv_views derives the per-group shape/stride from that one
+                # uniform block stride. build_kv_views still fails loud for
+                # contiguous + kernel_block_size != block_size.
                 layer_views: dict = {}
                 for gid, grp in attn_group_list:
                     gspec = grp.kv_cache_spec

--- a/tests/manifests/gpu.txt
+++ b/tests/manifests/gpu.txt
@@ -1,5 +1,6 @@
 tests/test_ElasticMLAMemoryPool.py
 tests/test_alloc_kv_cache_alignment.py
+tests/test_hetero_contiguous_layout.py
 tests/test_hybrid_contiguous_layout.py
 tests/test_kvcache_manager.py
 tests/test_paged_allocator_aliasing.py

--- a/tests/test_hetero_contiguous_layout.py
+++ b/tests/test_hetero_contiguous_layout.py
@@ -59,11 +59,12 @@ def _raw_pools(contiguous):
     return [torch.zeros(eles_per_layer, dtype=DTYPE) for _ in range(NUM_LAYERS)]
 
 
-def _views(ifc, monkeypatch, group, raw, contiguous):
+def _views(ifc, monkeypatch, group, raw, contiguous, kernel_block_size=None):
     monkeypatch.setattr(ifc, "_contiguous_layout", contiguous)
     views, _ = ifc.build_kv_views(
         raw, _shape(group), group["block_size"], DTYPE, "MHA",
         NUM_BLOCKS, BYTES_PER_LAYER_K_OR_V, NUM_LAYERS,
+        kernel_block_size=kernel_block_size,
     )
     return views
 
@@ -145,3 +146,31 @@ def test_distinct_layers_do_not_overlap(ifc, monkeypatch, contiguous):
     views = _views(ifc, monkeypatch, SLIDING, raw, contiguous)
     ptrs = {views[layer][0][0].data_ptr() for layer in range(NUM_LAYERS)}
     assert len(ptrs) == NUM_LAYERS
+
+
+def test_contiguous_rejects_kernel_block_size_smaller_than_block_size(
+        ifc, monkeypatch):
+    """contiguous + ratio > 1 must fail loud, not build wrong strides.
+
+    The contiguous branch reshapes at virtual-block granularity and never
+    consults kernel_kvcache_shape, so with ratio > 1 its views would disagree
+    with the kernel's kernel_bs-token indexing. No engine config has produced
+    ratio > 1 on this path yet, so it is unexercised rather than known-good.
+    """
+    raw = _raw_pools(True)
+    with pytest.raises(NotImplementedError, match="kernel_block_size"):
+        _views(ifc, monkeypatch, SLIDING, raw, True,
+               kernel_block_size=SLIDING["block_size"] // 2)
+
+
+def test_noncontiguous_accepts_kernel_block_size_smaller_than_block_size(
+        ifc, monkeypatch):
+    """The non-contiguous branch does derive kernel-block-granular views, so it
+    stays available for ratio > 1 -- which is what the guard above points at."""
+    raw = _raw_pools(False)
+    views = _views(ifc, monkeypatch, SLIDING, raw, False,
+                   kernel_block_size=SLIDING["block_size"] // 2)
+    assert len(views) == NUM_LAYERS
+    # Twice as many kernel blocks, each half as many tokens.
+    assert views[0].shape[1] == NUM_BLOCKS * 2
+    assert views[0].shape[2] == SLIDING["block_size"] // 2

--- a/tests/test_hetero_contiguous_layout.py
+++ b/tests/test_hetero_contiguous_layout.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""CPU tests for heterogeneous attention KV groups under BOTH KV layouts.
+
+Background
+----------
+Gemma 3/4 interleave sliding-window and full-attention layers whose per-token
+KV geometry differs -- sliding layers use ``head_dim=256`` over 8 KV heads,
+full-attention layers use ``head_dim=512`` over 1 KV head -- while vLLM equalizes
+the *physical* bytes per block (65536 B in both cases). kvcached therefore
+allocates one uniform pool and gives each group its own ``as_strided`` view over
+it (``build_kv_views``).
+
+Until this test landed, the vLLM patch refused to start when that shape met the
+*contiguous* layout, on the assumption that only the non-contiguous branch could
+express per-group geometry. That assumption was never measured. It is wrong: the
+shared ``block_mem_size`` is exactly what makes both branches work, because block
+N occupies the same bytes whichever group's view addresses it.
+
+These tests pin that property directly -- they are what makes it safe to run
+either layout -- and they run CPU-only over plain tensors, no GPU or VMM.
+The end-to-end token-parity check against vanilla vLLM still needs a GPU.
+"""
+import importlib
+
+import pytest
+import torch
+
+DTYPE = torch.float16
+NUM_LAYERS = 4
+NUM_BLOCKS = 8
+
+# Gemma-shaped pair: different (block_size, num_kv_heads, head_size), identical
+# bytes per block. FlashAttn MHA shape is (2, num_blocks, block_size, H, D).
+SLIDING = {"block_size": 16, "num_kv_heads": 8, "head_size": 256}
+FULL = {"block_size": 64, "num_kv_heads": 1, "head_size": 512}
+
+BLOCK_MEM_BYTES = (SLIDING["block_size"] * SLIDING["num_kv_heads"] *
+                   SLIDING["head_size"] * DTYPE.itemsize)
+BYTES_PER_LAYER_K_OR_V = NUM_BLOCKS * BLOCK_MEM_BYTES
+
+
+def _shape(group):
+    return (2, NUM_BLOCKS, group["block_size"], group["num_kv_heads"],
+            group["head_size"])
+
+
+@pytest.fixture()
+def ifc():
+    return importlib.import_module("kvcached.integration.vllm.interfaces")
+
+
+def _raw_pools(contiguous):
+    """Allocate the raw pool(s) the way alloc_kv_cache would."""
+    eles_per_layer = BYTES_PER_LAYER_K_OR_V * 2 // DTYPE.itemsize
+    if contiguous:
+        # One compound buffer covering every layer.
+        return [torch.zeros(eles_per_layer * NUM_LAYERS, dtype=DTYPE)]
+    return [torch.zeros(eles_per_layer, dtype=DTYPE) for _ in range(NUM_LAYERS)]
+
+
+def _views(ifc, monkeypatch, group, raw, contiguous):
+    monkeypatch.setattr(ifc, "_contiguous_layout", contiguous)
+    views, _ = ifc.build_kv_views(
+        raw, _shape(group), group["block_size"], DTYPE, "MHA",
+        NUM_BLOCKS, BYTES_PER_LAYER_K_OR_V, NUM_LAYERS,
+    )
+    return views
+
+
+def test_the_two_groups_really_are_heterogeneous():
+    """Guard the premise: different geometry, identical bytes per block.
+
+    If a future shape change breaks this, the other tests would still pass while
+    testing nothing interesting.
+    """
+    assert (SLIDING["block_size"], SLIDING["num_kv_heads"],
+            SLIDING["head_size"]) != (FULL["block_size"],
+                                      FULL["num_kv_heads"], FULL["head_size"])
+    full_block_bytes = (FULL["block_size"] * FULL["num_kv_heads"] *
+                        FULL["head_size"] * DTYPE.itemsize)
+    assert full_block_bytes == BLOCK_MEM_BYTES
+
+
+@pytest.mark.parametrize("contiguous", [True, False])
+def test_hetero_groups_alias_the_same_block_bytes(ifc, monkeypatch, contiguous):
+    """Block N of layer L must land on the same bytes in both groups' views.
+
+    This is the whole premise of the shared pool, and it is what the removed
+    contiguous-layout guard was hedging against.
+    """
+    raw = _raw_pools(contiguous)
+    sliding = _views(ifc, monkeypatch, SLIDING, raw, contiguous)
+    full = _views(ifc, monkeypatch, FULL, raw, contiguous)
+
+    assert len(sliding) == len(full) == NUM_LAYERS
+    for layer in range(NUM_LAYERS):
+        for k_or_v in (0, 1):
+            for block in range(NUM_BLOCKS):
+                a = sliding[layer][k_or_v][block]
+                b = full[layer][k_or_v][block]
+                assert a.data_ptr() == b.data_ptr(), (
+                    f"layer={layer} kv={k_or_v} block={block} not aliased "
+                    f"(contiguous={contiguous})")
+                assert a.numel() == b.numel()
+
+
+@pytest.mark.parametrize("contiguous", [True, False])
+def test_writes_through_one_group_are_visible_through_the_other(
+        ifc, monkeypatch, contiguous):
+    """Aliasing is real memory sharing, not just equal addresses."""
+    raw = _raw_pools(contiguous)
+    sliding = _views(ifc, monkeypatch, SLIDING, raw, contiguous)
+    full = _views(ifc, monkeypatch, FULL, raw, contiguous)
+
+    sliding[2][0][5].fill_(0.0)
+    sliding[2][0][5].view(-1)[7] = 1.5
+    assert full[2][0][5].reshape(-1)[7].item() == pytest.approx(1.5)
+
+
+@pytest.mark.parametrize("contiguous", [True, False])
+def test_both_groups_agree_on_the_block_stride(ifc, monkeypatch, contiguous):
+    """Both groups must derive the same inter-block stride.
+
+    The value differs by layout -- non-contiguous packs one layer's blocks back
+    to back, while the contiguous compound page interleaves every layer's K and
+    V, so one layer's blocks are ``num_layers * num_kv_buffers`` further apart.
+    What matters is that the two geometries agree, since that is what lets one
+    physical pool serve both.
+    """
+    expected = BLOCK_MEM_BYTES * (NUM_LAYERS * 2 if contiguous else 1)
+    raw = _raw_pools(contiguous)
+    for group in (SLIDING, FULL):
+        views = _views(ifc, monkeypatch, group, raw, contiguous)
+        v = views[1]
+        step = v[0][3].data_ptr() - v[0][2].data_ptr()
+        assert step == expected, (
+            f"group={group} contiguous={contiguous} stride={step}")
+
+
+@pytest.mark.parametrize("contiguous", [True, False])
+def test_distinct_layers_do_not_overlap(ifc, monkeypatch, contiguous):
+    """Different layers must address disjoint memory for the same block id."""
+    raw = _raw_pools(contiguous)
+    views = _views(ifc, monkeypatch, SLIDING, raw, contiguous)
+    ptrs = {views[layer][0][0].data_ptr() for layer in range(NUM_LAYERS)}
+    assert len(ptrs) == NUM_LAYERS


### PR DESCRIPTION
## What

Removes the startup guard that refused `KVCACHED_CONTIGUOUS_LAYOUT=true` for heterogeneous attention KV groups (Gemma 3/4), plus a CPU test pinning the property that makes both layouts valid.

## Validation

vLLM 0.24.0, `google/gemma-4-12B-it` on an A100-40GB, 23 requests / 22k prompt tokens, greedy, `enforce_eager`.

Baseline is vLLM without kvcached, the number means how many prompts have **different but not garbled** output:

| Config | baseline vs baseline | contiguous vs non-contiguous | contiguous vs baseline |
|---|---|---|---|
| `max_num_seqs=1`, prefix caching off | — | **0/23** | **0/23** |
| `max_num_seqs=1`, prefix caching on | 0/23 | **0/23** | 5/23 |
| concurrent, prefix caching on | 0/23 | **0/23** | 12/23 |
| concurrent, prefix caching off | 0/23 | **0/23** | 0/23 |

Ablation: 
1. `Qwen/Qwen3-8B` (homogeneous, no sliding window) is 0/23 against baseline in both layouts under the same workload, so the divergence above is specific to Gemma.
2. About the `gpt-oss-20b`, which also has sliding window, the baseline itself has indeterministic. So the noise is too big to know whether kvcached has similar problem on gpt-oss model.
