### PR TITLE
fix: decouple virtual KV capacity from shared-GPU profiling

### DIFF
--- a/kvcached/integration/sglang/autopatch.py
+++ b/kvcached/integration/sglang/autopatch.py
@@ -16,6 +16,7 @@ from kvcached.integration.sglang.patches import (
     ElasticMLAMemoryPoolPatch,
     RadixCacheLimitPatch,
     SchedulerMemoryLeakPatch,
+    SGLangVirtualKVCapacityPatch,
 )
 from kvcached.utils import get_kvcached_logger
 
@@ -42,6 +43,9 @@ def _patch_sglang(_sglang: types.ModuleType) -> None:
             (ElasticMLAMemoryPoolPatch(), SGLANG_ALL_RANGE),
             (ElasticMambaPoolPatch(), SGLANG_ALL_RANGE),
             (ElasticHybridLinearKVPoolPatch(), SGLANG_ALL_RANGE),
+            # Importing ModelRunner captures memory-pool classes in module
+            # globals, so apply this only after every pool alias is installed.
+            (SGLangVirtualKVCapacityPatch(), ">=0.5.11"),
             (SchedulerMemoryLeakPatch(), SGLANG_ALL_RANGE),
             (RadixCacheLimitPatch(), SGLANG_ALL_RANGE),
         ]

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -5,6 +5,7 @@
 SGLang-specific patches using unified patch infrastructure.
 """
 
+import functools
 import inspect
 import math
 import types
@@ -15,6 +16,7 @@ from kvcached.integration.version_utils import VersionAwarePatch, version_range
 from kvcached.utils import MAX_CACHED_TOKENS, get_kvcached_logger
 
 BYTES_PER_GB = 1024**3
+_CAPACITY_QUERY_FAILED = -(1 << 63)
 
 # Version ranges for SGLang support
 SGLANG_ALL_RANGE = ">=0.4.9"  # All supported versions
@@ -25,6 +27,120 @@ logger = get_kvcached_logger()
 def _is_supported_gpu_device(device: str) -> bool:
     device_str = str(device).lower()
     return device_str.startswith("cuda") or device_str.startswith("hip")
+
+
+def _reduce_sglang_world_min_bytes(torch: Any, local_bytes: int) -> int:
+    """Return one capacity shared by every rank in the SGLang world group."""
+    from sglang.srt.distributed.parallel_state import get_world_group
+
+    world_group = get_world_group()
+    if int(world_group.world_size) <= 1:
+        return local_bytes
+
+    capacity = torch.tensor(local_bytes, dtype=torch.int64)
+    torch.distributed.all_reduce(
+        capacity,
+        op=torch.distributed.ReduceOp.MIN,
+        group=world_group.cpu_group,
+    )
+    return int(capacity.item())
+
+
+class SGLangVirtualKVCapacityPatch(VersionAwarePatch, BasePatch):
+    """Keep SGLang's logical KV capacity independent of peer processes."""
+
+    library = "sglang"
+    target_module = "sglang.srt.model_executor.model_runner"
+    target_class = "ModelRunner"
+    patch_name = "virtual_kv_capacity"
+
+    def apply(self, model_runner_mod: types.ModuleType) -> bool:
+        if not self.initialize_version_info():
+            return False
+        return self.patch_profile_available_bytes(model_runner_mod)
+
+    @version_range(">=0.5.11")
+    def patch_profile_available_bytes(self, model_runner_mod: types.ModuleType) -> bool:
+        ModelRunner = self._get_target_class(model_runner_mod)
+        if ModelRunner is None:
+            return False
+
+        original_profile = getattr(ModelRunner, "_profile_available_bytes", None)
+        if original_profile is None:
+            self.logger.warning(
+                "SGLang ModelRunner does not expose _profile_available_bytes"
+            )
+            return False
+        if self._is_already_patched(original_profile, "virtual_kv_capacity"):
+            return True
+
+        @functools.wraps(original_profile)
+        def _patched_profile_available_bytes(runner, pre_model_load_memory: int) -> int:
+            if not enable_kvcached() or not _is_supported_gpu_device(runner.device):
+                return original_profile(runner, pre_model_load_memory)
+
+            import torch
+
+            query_error = None
+            try:
+                total_memory = int(
+                    torch.cuda.get_device_properties(runner.gpu_id).total_memory
+                )
+                mem_fraction_static = float(runner.mem_fraction_static)
+                logical_budget = math.ceil(total_memory * mem_fraction_static)
+                process_local_reserved = int(
+                    torch.cuda.memory_reserved(runner.gpu_id)
+                )
+                local_available_bytes = logical_budget - process_local_reserved
+            except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+                query_error = exc
+                total_memory = 0
+                logical_budget = 0
+                process_local_reserved = 0
+                local_available_bytes = _CAPACITY_QUERY_FAILED
+
+            try:
+                available_bytes = _reduce_sglang_world_min_bytes(
+                    torch, local_available_bytes
+                )
+            except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
+                logger.warning(
+                    "Unable to synchronize SGLang virtual KV capacity; "
+                    "falling back to SGLang profiling: %s",
+                    exc,
+                )
+                return original_profile(runner, pre_model_load_memory)
+
+            if available_bytes == _CAPACITY_QUERY_FAILED:
+                logger.warning(
+                    "Unable to derive stable SGLang virtual KV capacity on "
+                    "at least one rank; falling back to SGLang profiling: %s",
+                    query_error or "peer rank query failed",
+                )
+                return original_profile(runner, pre_model_load_memory)
+
+            if runner.mambaish_config is not None:
+                available_gib = available_bytes / BYTES_PER_GB
+                available_bytes = int(
+                    runner.handle_max_mamba_cache(available_gib) * BYTES_PER_GB
+                )
+
+            logger.info(
+                "Using kvcached process-local KV capacity for SGLang: "
+                "budget=%d bytes, pytorch_reserved=%d bytes, "
+                "world_min_available=%d bytes (device_total=%d, "
+                "mem_fraction_static=%.4f)",
+                logical_budget,
+                process_local_reserved,
+                available_bytes,
+                total_memory,
+                mem_fraction_static,
+            )
+            return available_bytes
+
+        self._mark_as_patched(_patched_profile_available_bytes, "virtual_kv_capacity")
+        ModelRunner._profile_available_bytes = _patched_profile_available_bytes
+        return True
 
 
 class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -8,6 +8,7 @@ vLLM-specific patches using unified patch infrastructure.
 from __future__ import annotations
 
 import inspect
+import math
 import types
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Iterable, Optional
@@ -1747,8 +1748,86 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             raise ValueError(f"Unsupported vLLM version: {self.detected_version}")
 
 
+def _is_vllm_startup_memory_guard(error: ValueError) -> bool:
+    """Return whether *error* is vLLM's initial whole-device memory guard."""
+    message = str(error)
+    return (
+        "Free memory on device" in message
+        and "on startup is less than desired GPU memory utilization" in message
+    )
+
+
+def _get_virtual_kv_capacity_bytes(init_snapshot: Any, cache_config: Any) -> int:
+    """Derive the scheduler-visible KV capacity from virtual pool geometry.
+
+    kvcached reserves a full-device-sized KV virtual address range and backs it
+    lazily. Preserve vLLM's gpu_memory_utilization setting as the logical upper
+    bound, but do not reduce it based on physical memory consumed by peers.
+    """
+    return math.ceil(
+        init_snapshot.total_memory * cache_config.gpu_memory_utilization
+    )
+
+
+def _get_worker_total_memory_bytes(worker: Any) -> int:
+    """Read device geometry without using mutable whole-device free memory."""
+    import torch
+
+    try:
+        properties = torch.cuda.get_device_properties(worker.device)
+        return int(properties.total_memory)
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return int(torch.cuda.mem_get_info()[1])
+
+
+def _should_profile_cudagraph_memory(worker: Any) -> bool:
+    profile_cudagraph = getattr(
+        worker.model_runner, "profile_cudagraph_memory", None
+    )
+    if not callable(profile_cudagraph):
+        return False
+    model_config = getattr(worker, "model_config", None)
+    if bool(getattr(model_config, "enforce_eager", False)):
+        return False
+
+    vllm_config = getattr(worker, "vllm_config", None)
+    compilation_config = getattr(vllm_config, "compilation_config", None)
+    if compilation_config is not None and hasattr(
+        compilation_config, "cudagraph_mode"
+    ):
+        cudagraph_mode = compilation_config.cudagraph_mode
+        mode_name = str(
+            getattr(cudagraph_mode, "name", cudagraph_mode)
+        ).upper()
+        if mode_name == "NONE":
+            return False
+
+    try:
+        from vllm.platforms import current_platform
+
+        is_cuda = getattr(current_platform, "is_cuda", None)
+        if callable(is_cuda) and not bool(is_cuda()):
+            return False
+        is_rocm = getattr(current_platform, "is_rocm", None)
+        if callable(is_rocm) and bool(is_rocm()):
+            return False
+    except ImportError:
+        pass
+    return True
+
+
+def _get_process_local_torch_peak_bytes(device: Any) -> int:
+    import torch
+
+    accelerator = getattr(torch, "accelerator", None)
+    memory_stats = getattr(accelerator, "memory_stats", None)
+    if callable(memory_stats):
+        return int(memory_stats(device).get("allocated_bytes.all.peak", 0))
+    return int(torch.cuda.memory_stats()["allocated_bytes.all.peak"])
+
+
 class GPUWorkerPatch(VersionAwarePatch, BasePatch):
-    """Patch Worker.init_device to ignore GPU free-memory check when kvcached is enabled"""
+    """Decouple kvcached virtual KV capacity from whole-device free memory."""
 
     library = "vllm"
     target_module = "vllm.v1.worker.gpu_worker"
@@ -1761,11 +1840,47 @@ class GPUWorkerPatch(VersionAwarePatch, BasePatch):
             return False
 
         # Apply version-specific patches
-        return self.patch_worker_init_device(gpuworker_mod)
+        init_device_patched = self.patch_worker_init_device(gpuworker_mod)
+        memory_profile_patched = self.patch_worker_determine_available_memory(
+            gpuworker_mod
+        )
+        return init_device_patched and memory_profile_patched
 
     @version_range(VLLM_ALL_RANGE)
     def patch_worker_init_device(self, gpuworker_mod: types.ModuleType) -> bool:
         """Patch Worker.init_device"""
+        original_request_memory = getattr(gpuworker_mod, "request_memory", None)
+        if original_request_memory is not None:
+            if self._is_already_patched(original_request_memory, "request_memory"):
+                self.logger.debug("gpu_worker.request_memory already patched")
+                return True
+
+            logger = self.logger
+
+            def _patched_request_memory(init_snapshot: Any, cache_config: Any) -> int:
+                if not enable_kvcached():
+                    return int(original_request_memory(init_snapshot, cache_config))
+
+                requested_memory = _get_virtual_kv_capacity_bytes(
+                    init_snapshot, cache_config
+                )
+                if int(init_snapshot.free_memory) < requested_memory:
+                    logger.warning(
+                        "Ignoring vLLM's whole-device startup memory guard "
+                        "because kvcached provides virtual KV capacity: free=%d "
+                        "bytes, requested=%d bytes",
+                        int(init_snapshot.free_memory),
+                        requested_memory,
+                    )
+                return requested_memory
+
+            self._mark_as_patched(_patched_request_memory, "request_memory")
+            setattr(gpuworker_mod, "request_memory", _patched_request_memory)
+            return True
+
+        # vLLM releases before request_memory() was factored out perform the
+        # same guard inside Worker.init_device(). Keep a narrow compatibility
+        # fallback for those releases and never swallow unrelated ValueErrors.
         Worker = self._get_target_class(gpuworker_mod)
         if Worker is None:
             return False
@@ -1782,11 +1897,17 @@ class GPUWorkerPatch(VersionAwarePatch, BasePatch):
                 return original_init_device(self, *args, **kwargs)
 
             try:
-                return original_init_device(self, *args, **kwargs)
+                result = original_init_device(self, *args, **kwargs)
             except ValueError as e:
+                if not _is_vllm_startup_memory_guard(e):
+                    raise
                 # If the original impl still raises due to insufficient memory,
                 # replicate the remainder of its logic while skipping the guard.
-                logger.warning("Ignoring GPU free-memory check: %s", e)
+                logger.warning(
+                    "Ignoring vLLM's whole-device startup memory guard because "
+                    "kvcached provides virtual KV capacity: %s",
+                    e,
+                )
 
                 # The steps below mirror the tail of vLLM's Worker.init_device
                 # after the memory-utilization check.
@@ -1808,13 +1929,15 @@ class GPUWorkerPatch(VersionAwarePatch, BasePatch):
                 )
                 set_random_seed(self.model_config.seed)
 
-                # Set init_snapshot and requested_memory so later code
-                # (e.g. determine_available_memory) can access them.
+                # Set init_snapshot and requested_memory so later vLLM code can
+                # access a coherent logical budget. Do not use current free
+                # memory: it includes allocations made by colocated engines.
                 if not hasattr(self, "init_snapshot"):
                     self.init_snapshot = MemorySnapshot(device=self.device)
                 if not hasattr(self, "requested_memory"):
-                    # With kvcached, claim all available free memory.
-                    self.requested_memory = self.init_snapshot.free_memory
+                    self.requested_memory = _get_virtual_kv_capacity_bytes(
+                        self.init_snapshot, self.cache_config
+                    )
 
                 # Initialize workspace manager
                 try:
@@ -1831,8 +1954,126 @@ class GPUWorkerPatch(VersionAwarePatch, BasePatch):
 
                 return None
 
+            # vLLM 0.8.x predates MemorySnapshot/request_memory but is still
+            # supported by kvcached. Persist the same logical budget after its
+            # original init_device() succeeds so the patched profiler can use
+            # process-local accounting.
+            if not hasattr(self, "requested_memory"):
+                total_memory = _get_worker_total_memory_bytes(self)
+                snapshot = types.SimpleNamespace(total_memory=total_memory)
+                self.requested_memory = _get_virtual_kv_capacity_bytes(
+                    snapshot, self.cache_config
+                )
+            return result
+
         self._mark_as_patched(_patched_init_device, "init_device")
         Worker.init_device = _patched_init_device  # type: ignore[assignment]
+        return True
+
+    @version_range(VLLM_ALL_RANGE)
+    def patch_worker_determine_available_memory(
+        self, gpuworker_mod: types.ModuleType
+    ) -> bool:
+        """Use vLLM's explicit-capacity branch with an automatic virtual budget."""
+        Worker = self._get_target_class(gpuworker_mod)
+        if Worker is None:
+            return False
+
+        original_determine = getattr(Worker, "determine_available_memory", None)
+        if original_determine is None:
+            self.logger.error("Worker.determine_available_memory was not found")
+            return False
+        if self._is_already_patched(original_determine, "determine_available_memory"):
+            self.logger.debug("Worker.determine_available_memory already patched")
+            return True
+
+        logger = self.logger
+
+        def _patched_determine_available_memory(
+            self, *args: Any, **kwargs: Any
+        ) -> int:
+            if not enable_kvcached():
+                return original_determine(self, *args, **kwargs)
+
+            cache_config = self.cache_config
+            configured_budget = getattr(cache_config, "kv_cache_memory_bytes", None)
+            if configured_budget is not None:
+                return original_determine(self, *args, **kwargs)
+
+            virtual_budget = int(self.requested_memory)
+            init_snapshot = getattr(self, "init_snapshot", None)
+            if init_snapshot is None:
+                # vLLM 0.8.x has no MemorySnapshot. Resetting peak stats after
+                # model load makes this peak process-local and includes both
+                # resident model weights and the profiling activation peak.
+                import torch
+
+                torch.cuda.empty_cache()
+                torch.cuda.reset_peak_memory_stats()
+                self.model_runner.profile_run()
+                weights_memory = 0
+                torch_peak_increase = int(
+                    torch.cuda.memory_stats()["allocated_bytes.all.peak"]
+                )
+                cudagraph_memory_estimate = 0
+            else:
+                from vllm.utils.mem_utils import memory_profiling
+
+                weights_memory = int(self.model_runner.model_memory_usage)
+                profile_torch_peak = None
+                cudagraph_memory_estimate = 0
+                with memory_profiling(
+                    init_snapshot, weights_memory=weights_memory
+                ) as profile_result:
+                    self.model_runner.profile_run()
+                    if _should_profile_cudagraph_memory(self):
+                        profile_torch_peak = _get_process_local_torch_peak_bytes(
+                            self.device
+                        )
+                        cudagraph_memory_estimate = int(
+                            self.model_runner.profile_cudagraph_memory()
+                        )
+
+                torch_peak_increase = int(profile_result.torch_peak_increase)
+                if profile_torch_peak is not None:
+                    before_profile = getattr(profile_result, "before_profile", None)
+                    before_torch_peak = getattr(
+                        before_profile, "torch_peak", None
+                    )
+                    if before_torch_peak is not None:
+                        torch_peak_increase = max(
+                            0, profile_torch_peak - int(before_torch_peak)
+                        )
+            available_memory = (
+                virtual_budget
+                - weights_memory
+                - torch_peak_increase
+            )
+
+            self.available_kv_cache_memory_bytes = available_memory
+            # vLLM 0.24 reads this field during compile_or_warm_up_model().
+            # Keep the worker contract without reintroducing the device-wide
+            # non-torch delta that colocated processes can corrupt.
+            self.non_torch_memory = 0
+            self.peak_activation_memory = torch_peak_increase
+            self.cudagraph_memory_estimate = cudagraph_memory_estimate
+            logger.warning(
+                "Using kvcached process-local KV capacity: budget=%d bytes, "
+                "weights=%d bytes, torch_peak=%d bytes, cudagraph=%d bytes "
+                "(ignored), available=%d bytes; "
+                "whole-device non-torch and CUDA Graph deltas are ignored",
+                virtual_budget,
+                weights_memory,
+                torch_peak_increase,
+                cudagraph_memory_estimate,
+                available_memory,
+            )
+            return available_memory
+
+        self._mark_as_patched(
+            _patched_determine_available_memory, "determine_available_memory"
+        )
+        Worker.determine_available_memory = _patched_determine_available_memory
         return True
 
 

--- a/kvcached/kv_cache_manager.py
+++ b/kvcached/kv_cache_manager.py
@@ -243,13 +243,87 @@ class KVCacheManager:
         """
         Reserve the first block as null block for padding tokens.
         """
-        if self.reserve_null_block:
-            self.null_block = self._alloc(1, _skip_wait=True)
-            if self.null_block != [0]:
-                logger.error(f"Failed to reserve null block, got {self.null_block}")
-                raise RuntimeError("Failed to reserve null block at index 0")
-        else:
+        if not self.reserve_null_block:
             self.null_block = None
+            return
+
+        wait_started = time.monotonic()
+        last_log_at = 0.0
+        last_reason: Optional[str] = None
+        loop_count = 0
+        alloc_attempts = 0
+
+        def _log_wait(reason: str, available_before: int) -> None:
+            nonlocal last_log_at, last_reason
+
+            now = time.monotonic()
+            if reason == last_reason and now - last_log_at < 10.0:
+                return
+
+            last_log_at = now
+            last_reason = reason
+            try:
+                allocator = self.page_allocator
+                allocator_state = (
+                    f"available_before={available_before}, "
+                    f"available_now={self.available_size()}, "
+                    f"num_avail_blocks={self.num_avail_blocks}, "
+                    f"reserved_blocks={len(self.reserved_blocks)}, "
+                    f"avail_pages={len(self.avail_pages)}, "
+                    "virtual_free_pages="
+                    f"{allocator.get_num_free_pages()}, "
+                    "physical_free_pages="
+                    f"{allocator.get_avail_physical_pages()}, "
+                    "reserved_physical_pages="
+                    f"{allocator.get_num_reserved_pages()}"
+                )
+            except Exception as exc:
+                # Diagnostics must never turn a recoverable capacity wait into
+                # a startup failure.
+                allocator_state = (
+                    f"available_before={available_before}, "
+                    f"state_snapshot_error={exc!r}"
+                )
+
+            logger.warning(
+                "Waiting for physical KV capacity to reserve null block: "
+                f"reason={reason}, elapsed={now - wait_started:.1f}s, "
+                f"loops={loop_count}, alloc_attempts={alloc_attempts}, "
+                f"group_id={getattr(self, 'group_id', None)}, "
+                f"pp_rank={getattr(self, 'pp_rank', None)}, "
+                f"{allocator_state}")
+
+        while True:
+            loop_count += 1
+            available_before = self.available_size()
+            if available_before < 1:
+                _log_wait("no_effective_capacity", available_before)
+                time.sleep(0.01)
+                continue
+
+            alloc_attempts += 1
+            null_block = self._alloc(1, _skip_wait=True)
+            if null_block is None:
+                # Another colocated engine may consume the last physical page
+                # between available_size() and alloc_page(), or alloc_page()
+                # may fail after the capacity check. Keep the engine alive and
+                # make the stalled startup state visible in pod logs.
+                _log_wait("alloc_returned_none_after_capacity_check",
+                          available_before)
+                time.sleep(0.01)
+                continue
+            if null_block != [0]:
+                logger.error(f"Failed to reserve null block, got {null_block}")
+                raise RuntimeError("Failed to reserve null block at index 0")
+
+            self.null_block = null_block
+            elapsed = time.monotonic() - wait_started
+            if loop_count > 1:
+                logger.info(
+                    "Reserved null block after waiting for physical KV "
+                    f"capacity: elapsed={elapsed:.1f}s, loops={loop_count}, "
+                    f"alloc_attempts={alloc_attempts}")
+            return
 
 
     def alloc(self, need_size: int) -> Optional[List[int]]:

--- a/tests/manifests/cpu.txt
+++ b/tests/manifests/cpu.txt
@@ -10,8 +10,11 @@ tests/test_page_aware_eviction.py
 tests/test_prefix_cache.py
 tests/test_resize_reserved_order.py
 tests/test_sglang_allocator_patch.py
+tests/test_sglang_autopatch_order.py
+tests/test_sglang_virtual_kv_capacity.py
 tests/test_shm_info_tracker.py
 tests/test_sleep_manager.py
 tests/test_test_classification.py
 tests/test_vllm_nixl_compat.py
 tests/test_vllm_tp_world_size.py
+tests/test_vllm_virtual_kv_capacity.py

--- a/tests/test_sglang_autopatch_order.py
+++ b/tests/test_sglang_autopatch_order.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+from pathlib import Path
+
+
+def test_virtual_capacity_patch_runs_after_memory_pool_aliases():
+    autopatch_path = (
+        Path(__file__).parents[1]
+        / "kvcached"
+        / "integration"
+        / "sglang"
+        / "autopatch.py"
+    )
+    tree = ast.parse(autopatch_path.read_text(encoding="utf-8"))
+
+    patch_sglang = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_patch_sglang"
+    )
+    registration_calls = [
+        node
+        for node in ast.walk(patch_sglang)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "register_patches_with_versions"
+    ]
+    assert len(registration_calls) == 1
+
+    registration = registration_calls[0]
+    assert len(registration.args) == 1
+    patch_list = registration.args[0]
+    assert isinstance(patch_list, ast.List)
+
+    patch_names = []
+    patch_versions = {}
+    for entry in patch_list.elts:
+        assert isinstance(entry, ast.Tuple) and len(entry.elts) == 2
+        constructor = entry.elts[0]
+        assert isinstance(constructor, ast.Call)
+        assert isinstance(constructor.func, ast.Name)
+        patch_name = constructor.func.id
+        patch_names.append(patch_name)
+
+        version = entry.elts[1]
+        if isinstance(version, ast.Constant):
+            patch_versions[patch_name] = version.value
+
+    virtual_index = patch_names.index("SGLangVirtualKVCapacityPatch")
+    for pool_patch in (
+        "ElasticMemoryPoolPatch",
+        "ElasticMLAMemoryPoolPatch",
+        "ElasticMambaPoolPatch",
+        "ElasticHybridLinearKVPoolPatch",
+    ):
+        assert patch_names.index(pool_patch) < virtual_index
+
+    assert patch_versions["SGLangVirtualKVCapacityPatch"] == ">=0.5.11"

--- a/tests/test_sglang_virtual_kv_capacity.py
+++ b/tests/test_sglang_virtual_kv_capacity.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import sys
+import types
+from typing import Any, Optional
+
+from kvcached.integration.sglang.patches import (
+    SGLangVirtualKVCapacityPatch,
+)
+
+
+def _make_model_runner_module():
+    class FakeModelRunner:
+        device = "cuda"
+        gpu_id = 0
+        mem_fraction_static = 0.75
+        mambaish_config = None
+
+        def _profile_available_bytes(self, pre_model_load_memory: int) -> int:
+            return pre_model_load_memory
+
+    module: Any = types.ModuleType("sglang.srt.model_executor.model_runner")
+    module.ModelRunner = FakeModelRunner
+    return module
+
+
+def _install_fake_torch(
+    monkeypatch,
+    total_memory: int,
+    reserved_memory: int = 0,
+    *,
+    world_size: int = 1,
+    reduced_capacity: Optional[int] = None,
+):
+    monkeypatch.setenv("ENABLE_KVCACHED", "true")
+
+    class FakeTensor:
+        def __init__(self, value):
+            self.value = value
+
+        def item(self):
+            return self.value
+
+    def all_reduce(tensor, *, op, group):
+        assert op == "min"
+        assert group == "cpu-group"
+        if reduced_capacity is not None:
+            tensor.value = min(tensor.value, reduced_capacity)
+
+    torch: Any = types.ModuleType("torch")
+    torch.cuda = types.SimpleNamespace(
+        get_device_properties=lambda _device: types.SimpleNamespace(
+            total_memory=total_memory
+        ),
+        memory_reserved=lambda _device: reserved_memory,
+    )
+    torch.int64 = "int64"
+    torch.tensor = lambda value, dtype: FakeTensor(value)
+    torch.distributed = types.SimpleNamespace(
+        ReduceOp=types.SimpleNamespace(MIN="min"),
+        all_reduce=all_reduce,
+    )
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    world_group = types.SimpleNamespace(
+        world_size=world_size,
+        cpu_group="cpu-group",
+    )
+    modules = {
+        "sglang": {},
+        "sglang.srt": {},
+        "sglang.srt.distributed": {},
+        "sglang.srt.distributed.parallel_state": {
+            "get_world_group": lambda: world_group,
+        },
+    }
+    for name, attributes in modules.items():
+        module = types.ModuleType(name)
+        for key, value in attributes.items():
+            setattr(module, key, value)
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+def test_virtual_capacity_deducts_process_local_reserved_memory(
+    monkeypatch,
+):
+    total_memory = 16 * 1024**3
+    reserved_memory = 3 * 1024**3
+    _install_fake_torch(monkeypatch, total_memory, reserved_memory)
+    module = _make_model_runner_module()
+
+    patch = SGLangVirtualKVCapacityPatch()
+    assert patch.patch_profile_available_bytes(module) is True
+
+    runner = module.ModelRunner()
+    expected = (
+        math.ceil(total_memory * runner.mem_fraction_static) - reserved_memory
+    )
+    assert runner._profile_available_bytes(14) == expected
+    assert runner._profile_available_bytes(7) == expected
+
+
+def test_virtual_capacity_preserves_mamba_reservation(monkeypatch):
+    total_memory = 16 * 1024**3
+    reserved_memory = 2 * 1024**3
+    _install_fake_torch(monkeypatch, total_memory, reserved_memory)
+    module = _make_model_runner_module()
+
+    patch = SGLangVirtualKVCapacityPatch()
+    assert patch.patch_profile_available_bytes(module) is True
+
+    runner = module.ModelRunner()
+    runner.mambaish_config = object()
+    runner.handle_max_mamba_cache = lambda capacity_gib: capacity_gib - 1
+
+    expected = (
+        math.ceil(total_memory * runner.mem_fraction_static)
+        - reserved_memory
+        - 1024**3
+    )
+    assert runner._profile_available_bytes(3) == expected
+
+
+def test_virtual_capacity_uses_world_group_minimum(monkeypatch):
+    total_memory = 16 * 1024**3
+    reserved_memory = 2 * 1024**3
+    peer_capacity = 7 * 1024**3
+    _install_fake_torch(
+        monkeypatch,
+        total_memory,
+        reserved_memory,
+        world_size=2,
+        reduced_capacity=peer_capacity,
+    )
+    module = _make_model_runner_module()
+
+    patch = SGLangVirtualKVCapacityPatch()
+    assert patch.patch_profile_available_bytes(module) is True
+
+    runner = module.ModelRunner()
+    assert runner._profile_available_bytes(3) == peer_capacity
+
+
+def test_virtual_capacity_falls_back_when_peer_query_fails(monkeypatch):
+    total_memory = 16 * 1024**3
+    _install_fake_torch(
+        monkeypatch,
+        total_memory,
+        world_size=2,
+        reduced_capacity=-(1 << 63),
+    )
+    module = _make_model_runner_module()
+
+    patch = SGLangVirtualKVCapacityPatch()
+    assert patch.patch_profile_available_bytes(module) is True
+
+    runner = module.ModelRunner()
+    assert runner._profile_available_bytes(1234) == 1234
+
+
+def test_virtual_capacity_falls_back_when_reserved_memory_query_fails(
+    monkeypatch,
+):
+    total_memory = 16 * 1024**3
+    _install_fake_torch(monkeypatch, total_memory)
+    torch = sys.modules["torch"]
+
+    def _raise_memory_query_error(_device):
+        raise RuntimeError("memory query failed")
+
+    torch.cuda.memory_reserved = _raise_memory_query_error
+    module = _make_model_runner_module()
+
+    patch = SGLangVirtualKVCapacityPatch()
+    assert patch.patch_profile_available_bytes(module) is True
+
+    runner = module.ModelRunner()
+    assert runner._profile_available_bytes(1234) == 1234
+
+
+def test_virtual_capacity_falls_back_for_non_gpu_device(monkeypatch):
+    _install_fake_torch(monkeypatch, 16 * 1024**3)
+    module = _make_model_runner_module()
+
+    patch = SGLangVirtualKVCapacityPatch()
+    assert patch.patch_profile_available_bytes(module) is True
+
+    runner = module.ModelRunner()
+    runner.device = "cpu"
+    assert runner._profile_available_bytes(1234) == 1234
+
+
+def test_virtual_capacity_patch_is_idempotent(monkeypatch):
+    _install_fake_torch(monkeypatch, 16 * 1024**3)
+    module = _make_model_runner_module()
+
+    patch = SGLangVirtualKVCapacityPatch()
+    assert patch.patch_profile_available_bytes(module) is True
+    first = module.ModelRunner._profile_available_bytes
+    assert patch.patch_profile_available_bytes(module) is True
+    assert module.ModelRunner._profile_available_bytes is first

--- a/tests/test_vllm_virtual_kv_capacity.py
+++ b/tests/test_vllm_virtual_kv_capacity.py
@@ -1,0 +1,542 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import contextlib
+import importlib
+import sys
+import types
+from typing import Any
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture
+def patches(monkeypatch):
+    torch = mock.MagicMock()
+    torch.__version__ = "2.6.0"
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "torch.cuda", torch.cuda)
+    monkeypatch.setitem(sys.modules, "torch.utils", torch.utils)
+    monkeypatch.setitem(
+        sys.modules, "torch.utils.cpp_extension", torch.utils.cpp_extension
+    )
+    monkeypatch.setitem(sys.modules, "posix_ipc", mock.MagicMock())
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", mock.MagicMock())
+    monkeypatch.delitem(
+        sys.modules, "kvcached.integration.vllm.interfaces", raising=False
+    )
+    monkeypatch.delitem(
+        sys.modules, "kvcached.integration.vllm.patches", raising=False
+    )
+    importlib.import_module("kvcached.integration.vllm.interfaces")
+    return importlib.import_module("kvcached.integration.vllm.patches")
+
+
+def _worker_config(*, utilization=0.9, explicit_budget=None):
+    return types.SimpleNamespace(
+        gpu_memory_utilization=utilization,
+        kv_cache_memory_bytes=explicit_budget,
+    )
+
+
+def _patch_worker(patches, monkeypatch, worker_cls, *, enabled=True) -> Any:
+    monkeypatch.setattr(patches, "enable_kvcached", lambda: enabled)
+    module = types.ModuleType("mock_gpu_worker")
+    setattr(module, "Worker", worker_cls)
+    patch = patches.GPUWorkerPatch()
+    assert patch.patch_worker_init_device(module)
+    assert patch.patch_worker_determine_available_memory(module)
+    return getattr(module, "Worker")
+
+
+def _install_memory_profiling(
+    monkeypatch, *, torch_peak_increase, before_torch_peak=0
+):
+    calls = []
+
+    @contextlib.contextmanager
+    def memory_profiling(init_snapshot, *, weights_memory):
+        calls.append((init_snapshot, weights_memory))
+        yield types.SimpleNamespace(
+            weights_memory=weights_memory,
+            torch_peak_increase=torch_peak_increase,
+            non_torch_increase=10_000,
+            before_profile=types.SimpleNamespace(
+                torch_peak=before_torch_peak
+            ),
+        )
+
+    module = types.ModuleType("vllm.utils.mem_utils")
+    setattr(module, "memory_profiling", memory_profiling)
+    monkeypatch.setitem(sys.modules, "vllm.utils.mem_utils", module)
+    return calls
+
+
+def test_virtual_capacity_uses_total_memory_and_utilization(patches):
+    snapshot = types.SimpleNamespace(total_memory=1001)
+    config = _worker_config(utilization=0.9)
+
+    assert patches._get_virtual_kv_capacity_bytes(snapshot, config) == 901
+
+
+def test_request_memory_uses_virtual_budget_and_warns(monkeypatch, patches):
+    original_request_memory = mock.Mock(side_effect=AssertionError("must not run"))
+
+    class Worker:
+        def determine_available_memory(self):
+            return 1
+
+    module = types.ModuleType("mock_gpu_worker")
+    setattr(module, "Worker", Worker)
+    setattr(module, "request_memory", original_request_memory)
+    monkeypatch.setattr(patches, "enable_kvcached", lambda: True)
+
+    patch = patches.GPUWorkerPatch()
+    warning = mock.Mock()
+    patch.logger.warning = warning
+    assert patch.patch_worker_init_device(module)
+
+    snapshot = types.SimpleNamespace(total_memory=1000, free_memory=100)
+    config = _worker_config(utilization=0.9)
+    assert getattr(module, "request_memory")(snapshot, config) == 900
+    assert "whole-device startup memory guard" in warning.call_args.args[0]
+    original_request_memory.assert_not_called()
+
+
+def test_request_memory_keeps_original_behavior_when_disabled(monkeypatch, patches):
+    original_request_memory = mock.Mock(return_value=123)
+
+    class Worker:
+        def determine_available_memory(self):
+            return 1
+
+    module = types.ModuleType("mock_gpu_worker")
+    setattr(module, "Worker", Worker)
+    setattr(module, "request_memory", original_request_memory)
+    monkeypatch.setattr(patches, "enable_kvcached", lambda: False)
+
+    patch = patches.GPUWorkerPatch()
+    assert patch.patch_worker_init_device(module)
+
+    snapshot = types.SimpleNamespace(total_memory=1000, free_memory=100)
+    config = _worker_config(utilization=0.9)
+    assert getattr(module, "request_memory")(snapshot, config) == 123
+    original_request_memory.assert_called_once_with(snapshot, config)
+
+
+def test_init_device_does_not_hide_unrelated_value_error(monkeypatch, patches):
+    class Worker:
+        def init_device(self):
+            raise ValueError("invalid model configuration")
+
+        def determine_available_memory(self):
+            return 1
+
+    PatchedWorker = _patch_worker(patches, monkeypatch, Worker)
+
+    with pytest.raises(ValueError, match="invalid model configuration"):
+        PatchedWorker().init_device()
+
+
+def test_startup_memory_guard_preserves_requested_memory(monkeypatch, patches):
+    set_seed = mock.Mock()
+    init_dist = mock.Mock()
+    init_workspace = mock.Mock()
+    report_usage = mock.Mock()
+
+    class MemorySnapshot:
+        def __init__(self, device):
+            self.device = device
+            self.total_memory = 1000
+            self.free_memory = 100
+
+    class GPUModelRunner:
+        def __init__(self, config, device):
+            self.config = config
+            self.device = device
+
+    modules: dict[str, dict[str, Any]] = {
+        "vllm.utils.mem_utils": {"MemorySnapshot": MemorySnapshot},
+        "vllm.utils.torch_utils": {"set_random_seed": set_seed},
+        "vllm.v1.utils": {"report_usage_stats": report_usage},
+        "vllm.v1.worker.gpu_model_runner": {"GPUModelRunner": GPUModelRunner},
+        "vllm.v1.worker.gpu_worker": {
+            "init_worker_distributed_environment": init_dist,
+        },
+        "vllm.v1.worker.workspace": {"init_workspace_manager": init_workspace},
+    }
+    for name, attributes in modules.items():
+        module = types.ModuleType(name)
+        for key, value in attributes.items():
+            setattr(module, key, value)
+        monkeypatch.setitem(sys.modules, name, module)
+
+    class Worker:
+        def __init__(self):
+            self.device = "cuda:0"
+            self.cache_config = _worker_config(utilization=0.9)
+            self.vllm_config = types.SimpleNamespace(
+                parallel_config=types.SimpleNamespace(enable_dbo=False)
+            )
+            self.model_config = types.SimpleNamespace(seed=7)
+            self.rank = 0
+            self.local_rank = 0
+            self.distributed_init_method = "mock://"
+
+        def init_device(self):
+            self.init_snapshot = MemorySnapshot(device=self.device)
+            self.requested_memory = 777
+            raise ValueError(
+                "Free memory on device cuda:0 (0.1/1.0 GiB) on startup "
+                "is less than desired GPU memory utilization"
+            )
+
+        def determine_available_memory(self):
+            return 1
+
+    PatchedWorker = _patch_worker(patches, monkeypatch, Worker)
+    worker = PatchedWorker()
+    worker.init_device()
+
+    assert getattr(worker, "requested_memory") == 777
+    assert getattr(worker, "init_snapshot").free_memory == 100
+    assert isinstance(getattr(worker, "model_runner"), GPUModelRunner)
+    init_dist.assert_called_once()
+    set_seed.assert_called_once_with(7)
+    init_workspace.assert_called_once_with("cuda:0", 1)
+    report_usage.assert_called_once_with(worker.vllm_config)
+
+
+def test_legacy_init_device_persists_virtual_budget(monkeypatch, patches):
+    torch = sys.modules["torch"]
+    torch.cuda.get_device_properties.return_value = types.SimpleNamespace(
+        total_memory=1000
+    )
+
+    class Worker:
+        def __init__(self):
+            self.device = "cuda:0"
+            self.cache_config = _worker_config(utilization=0.75)
+
+        def init_device(self):
+            self.init_gpu_memory = 100
+
+        def determine_available_memory(self):
+            return 1
+
+    PatchedWorker = _patch_worker(patches, monkeypatch, Worker)
+    worker = PatchedWorker()
+    worker.init_device()
+
+    assert worker.requested_memory == 750
+    assert not hasattr(worker, "init_snapshot")
+
+
+def test_determine_available_memory_injects_automatic_virtual_budget(
+    monkeypatch, patches
+):
+    profile_run = mock.Mock()
+    profile_calls = _install_memory_profiling(
+        monkeypatch, torch_peak_increase=50
+    )
+
+    class Worker:
+        def __init__(self):
+            self.init_snapshot = types.SimpleNamespace(
+                total_memory=4096, free_memory=200
+            )
+            self.cache_config = _worker_config(utilization=0.8)
+            self.requested_memory = 800
+            self.model_runner = types.SimpleNamespace(
+                model_memory_usage=200, profile_run=profile_run
+            )
+
+        def init_device(self):
+            return None
+
+        def determine_available_memory(self):
+            raise AssertionError("whole-device profiling must not run")
+
+    PatchedWorker = _patch_worker(patches, monkeypatch, Worker)
+    worker = PatchedWorker()
+    capacity = mock.Mock(side_effect=AssertionError("must reuse requested_memory"))
+    monkeypatch.setattr(patches, "_get_virtual_kv_capacity_bytes", capacity)
+
+    assert worker.determine_available_memory() == 550
+    assert profile_calls == [(worker.init_snapshot, 200)]
+    profile_run.assert_called_once_with()
+    assert worker.cache_config.kv_cache_memory_bytes is None
+    assert getattr(worker, "available_kv_cache_memory_bytes") == 550
+    assert worker.non_torch_memory == 0
+    capacity.assert_not_called()
+
+
+def test_determine_available_memory_records_but_ignores_cudagraph_estimate(
+    monkeypatch, patches
+):
+    profile_run = mock.Mock()
+    profile_cudagraph = mock.Mock(return_value=30)
+    _install_memory_profiling(
+        monkeypatch,
+        torch_peak_increase=999,
+        before_torch_peak=10,
+    )
+    torch = sys.modules["torch"]
+    torch.accelerator.memory_stats.return_value = {
+        "allocated_bytes.all.peak": 80
+    }
+    vllm = types.ModuleType("vllm")
+    setattr(
+        vllm,
+        "envs",
+        types.SimpleNamespace(
+            VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=True
+        ),
+    )
+    platforms = types.ModuleType("vllm.platforms")
+    setattr(
+        platforms,
+        "current_platform",
+        types.SimpleNamespace(
+            is_cuda=lambda: True,
+            is_rocm=lambda: False,
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "vllm", vllm)
+    monkeypatch.setitem(sys.modules, "vllm.platforms", platforms)
+
+    class Worker:
+        def __init__(self):
+            self.device = "cuda:0"
+            self.init_snapshot = types.SimpleNamespace(total_memory=1000)
+            self.cache_config = _worker_config(utilization=0.8)
+            self.requested_memory = 800
+            self.model_config = types.SimpleNamespace(enforce_eager=False)
+            self.vllm_config = types.SimpleNamespace(
+                compilation_config=types.SimpleNamespace()
+            )
+            self.model_runner = types.SimpleNamespace(
+                model_memory_usage=200,
+                profile_run=profile_run,
+                profile_cudagraph_memory=profile_cudagraph,
+            )
+
+        def init_device(self):
+            return None
+
+        def determine_available_memory(self):
+            raise AssertionError("whole-device profiling must not run")
+
+    PatchedWorker = _patch_worker(patches, monkeypatch, Worker)
+    worker = PatchedWorker()
+
+    assert worker.determine_available_memory() == 530
+    assert worker.non_torch_memory == 0
+    assert worker.peak_activation_memory == 70
+    assert worker.cudagraph_memory_estimate == 30
+    profile_run.assert_called_once_with()
+    profile_cudagraph.assert_called_once_with()
+
+
+def test_cudagraph_profile_respects_none_mode(patches):
+    worker = types.SimpleNamespace(
+        model_config=types.SimpleNamespace(enforce_eager=False),
+        vllm_config=types.SimpleNamespace(
+            compilation_config=types.SimpleNamespace(cudagraph_mode="NONE")
+        ),
+        model_runner=types.SimpleNamespace(
+            profile_cudagraph_memory=mock.Mock()
+        ),
+    )
+
+    assert patches._should_profile_cudagraph_memory(worker) is False
+
+
+def test_determine_available_memory_preserves_explicit_user_budget(
+    monkeypatch, patches
+):
+    calls = mock.Mock(return_value=321)
+
+    class Worker:
+        def __init__(self):
+            self.init_snapshot = types.SimpleNamespace(total_memory=1000)
+            self.cache_config = _worker_config(explicit_budget=321)
+
+        def init_device(self):
+            return None
+
+        determine_available_memory = calls
+
+    PatchedWorker = _patch_worker(patches, monkeypatch, Worker)
+    worker = PatchedWorker()
+
+    assert worker.determine_available_memory() == 321
+    assert worker.cache_config.kv_cache_memory_bytes == 321
+    calls.assert_called_once()
+
+
+def test_determine_available_memory_propagates_profile_failure(
+    monkeypatch, patches
+):
+    _install_memory_profiling(monkeypatch, torch_peak_increase=25)
+
+    class Worker:
+        def __init__(self):
+            self.init_snapshot = types.SimpleNamespace(total_memory=1000)
+            self.cache_config = _worker_config(utilization=0.5)
+            self.requested_memory = 500
+            self.model_runner = types.SimpleNamespace(
+                model_memory_usage=100,
+                profile_run=mock.Mock(side_effect=RuntimeError("profile run failed")),
+            )
+
+        def init_device(self):
+            return None
+
+        def determine_available_memory(self):
+            raise AssertionError("whole-device profiling must not run")
+
+    PatchedWorker = _patch_worker(patches, monkeypatch, Worker)
+    worker = PatchedWorker()
+
+    with pytest.raises(RuntimeError, match="profile run failed"):
+        worker.determine_available_memory()
+    assert worker.cache_config.kv_cache_memory_bytes is None
+
+
+def test_legacy_determine_available_memory_runs_profile_without_device_delta(
+    monkeypatch, patches
+):
+    profile_run = mock.Mock()
+    torch = sys.modules["torch"]
+    torch.cuda.memory_stats.return_value = {
+        "allocated_bytes.all.peak": 125
+    }
+
+    class Worker:
+        def __init__(self):
+            self.cache_config = types.SimpleNamespace(gpu_memory_utilization=0.75)
+            self.model_runner = types.SimpleNamespace(
+                model_memory_usage=100, profile_run=profile_run
+            )
+            self.requested_memory = 750
+
+        def init_device(self):
+            return None
+
+        def determine_available_memory(self):
+            raise AssertionError("whole-device profiling must not run")
+
+    PatchedWorker = _patch_worker(patches, monkeypatch, Worker)
+    worker = PatchedWorker()
+
+    assert worker.determine_available_memory() == 625
+    assert worker.available_kv_cache_memory_bytes == 625
+    torch.cuda.empty_cache.assert_called_once_with()
+    torch.cuda.reset_peak_memory_stats.assert_called_once_with()
+    profile_run.assert_called_once_with()
+
+
+def test_null_block_reservation_waits_for_physical_capacity(monkeypatch, patches):
+    manager_module = importlib.import_module("kvcached.kv_cache_manager")
+    log = types.SimpleNamespace(warning=mock.Mock(), info=mock.Mock())
+    monkeypatch.setattr(manager_module, "logger", log)
+    manager = object.__new__(manager_module.KVCacheManager)
+    manager.reserve_null_block = True
+    manager.null_block = None
+    manager.available_size = mock.Mock(side_effect=[0, 0, 1])
+    manager._alloc = mock.Mock(return_value=[0])
+    sleep = mock.Mock()
+    monkeypatch.setattr(manager_module.time, "sleep", sleep)
+
+    manager._reserve_null_block()
+
+    assert manager.null_block == [0]
+    assert sleep.call_count == 2
+    manager._alloc.assert_called_once_with(1, _skip_wait=True)
+    assert "reason=no_effective_capacity" in log.warning.call_args.args[0]
+    assert "Reserved null block after waiting" in log.info.call_args.args[0]
+
+
+def test_null_block_reservation_retries_allocator_race(monkeypatch, patches):
+    manager_module = importlib.import_module("kvcached.kv_cache_manager")
+    log = types.SimpleNamespace(warning=mock.Mock(), info=mock.Mock())
+    monkeypatch.setattr(manager_module, "logger", log)
+    manager = object.__new__(manager_module.KVCacheManager)
+    manager.reserve_null_block = True
+    manager.null_block = None
+    manager.available_size = mock.Mock(return_value=1)
+    manager._alloc = mock.Mock(side_effect=[None, [0]])
+    sleep = mock.Mock()
+    monkeypatch.setattr(manager_module.time, "sleep", sleep)
+
+    manager._reserve_null_block()
+
+    assert manager.null_block == [0]
+    assert sleep.call_count == 1
+    assert manager._alloc.call_count == 2
+    manager._alloc.assert_called_with(1, _skip_wait=True)
+    assert (
+        "reason=alloc_returned_none_after_capacity_check"
+        in log.warning.call_args.args[0]
+    )
+
+
+def test_null_block_wait_log_is_rate_limited(monkeypatch, patches):
+    manager_module = importlib.import_module("kvcached.kv_cache_manager")
+    log = types.SimpleNamespace(warning=mock.Mock(), info=mock.Mock())
+    monkeypatch.setattr(manager_module, "logger", log)
+    monkeypatch.setattr(
+        manager_module.time,
+        "monotonic",
+        mock.Mock(side_effect=[100.0, 100.0, 105.0, 111.0, 112.0]),
+    )
+    monkeypatch.setattr(manager_module.time, "sleep", mock.Mock())
+
+    manager = object.__new__(manager_module.KVCacheManager)
+    manager.reserve_null_block = True
+    manager.null_block = None
+    manager.available_size = mock.Mock(side_effect=[0, 0, 0, 1])
+    manager._alloc = mock.Mock(return_value=[0])
+
+    manager._reserve_null_block()
+
+    assert log.warning.call_count == 2
+    assert "elapsed=0.0s" in log.warning.call_args_list[0].args[0]
+    assert "elapsed=11.0s" in log.warning.call_args_list[1].args[0]
+
+
+def test_null_block_reservation_keeps_wrong_id_fail_loud(monkeypatch, patches):
+    manager_module = importlib.import_module("kvcached.kv_cache_manager")
+    manager = object.__new__(manager_module.KVCacheManager)
+    manager.reserve_null_block = True
+    manager.null_block = None
+    manager.available_size = mock.Mock(return_value=1)
+    manager._alloc = mock.Mock(return_value=[1])
+
+    with pytest.raises(RuntimeError, match="null block at index 0"):
+        manager._reserve_null_block()
+
+
+def test_kvcached_disabled_keeps_original_memory_paths(monkeypatch, patches):
+    init_device = mock.Mock(return_value=None)
+    determine = mock.Mock(return_value=123)
+
+    class Worker:
+        def __init__(self):
+            self.cache_config = _worker_config()
+
+        def init_device(self):
+            return init_device()
+
+        def determine_available_memory(self):
+            return determine()
+
+    PatchedWorker = _patch_worker(patches, monkeypatch, Worker, enabled=False)
+    worker = PatchedWorker()
+
+    assert worker.init_device() is None
+    assert worker.determine_available_memory() == 123
+    init_device.assert_called_once()
+    determine.assert_called_once()


### PR DESCRIPTION
## Summary

Fix the shared-GPU startup capacity failures described in #193 without serializing colocated vLLM or SGLang engines.

When kvcached is enabled, logical KV capacity is derived from stable device geometry and process-local memory costs. It is no longer derived from whole-device free-memory deltas that can change while another process is starting, serving, or exiting.

The known startup free-memory guard becomes a targeted warning in this mode. Explicit `kv_cache_memory_bytes` remains authoritative, kvcached-disabled behavior is unchanged, and unrelated model or CUDA failures still propagate.

Fixes #193.

## Root cause

kvcached reserves CUDA virtual address space for KV tensors, but model weights, CUDA contexts, profiling workloads, activations, communication buffers, CUDA Graph capture, and physical KV page mappings still consume physical GPU memory.

vLLM computes a requested budget from the whole device:

```python
requested_memory = ceil(total_memory * gpu_memory_utilization)
```

It then profiles non-KV costs and calculates the KV remainder:

```python
available_kv_cache_memory_bytes = (
    requested_memory
    - profile_result.non_kv_cache_memory
    - cudagraph_memory_estimate_applied
)
```

This calculation explicitly assumes that other processes sharing the GPU do not change their memory use during profiling:

```python
# Here we assume that the other processes using the same
# GPU did not change their memory usage during the profiling.
```

That assumption does not hold for colocated engines. `MemorySnapshot` observes whole-device free memory, while PyTorch allocator counters are process-local. A peer's allocation or release can therefore be attributed to the worker being profiled.

## Observed failure modes

### Initial free-memory guard

If a peer has already consumed memory before the initial snapshot, startup can fail with:

```text
Free memory on device ... on startup is less than desired GPU memory utilization
```

The previous kvcached patch bypassed this guard but replaced `requested_memory` with current free memory. The subsequent profiling calculation remained sensitive to peer activity.

### Peer allocation during profiling

If another process allocates memory during profiling, that growth can be counted as the current worker's `non_torch_increase`. The resulting KV capacity may become zero or negative:

```text
requested_memory
- non_kv_cache_memory
- cudagraph_memory_estimate_applied
<= 0
```

This can produce `No available memory for the cache blocks`, or a positive capacity too small for one request at `max_model_len`.

### Peer release during profiling

The inverse failure is also possible. An unfixed colocated startup observed free memory increase from `8.57 GiB` to `12.91 GiB` during `determine_available_memory()`. That violated vLLM's assertion:

```python
assert self.init_snapshot.free_memory >= free_gpu_memory
```

EngineCore then terminated with `Error in memory profiling`. The snapshot is device-wide, so the peer does not need to be in the same process or container to invalidate it. See the [vLLM 0.22.1 check](https://github.com/vllm-project/vllm/blob/v0.22.1/vllm/v1/worker/gpu_worker.py#L435-L447).

## Why startup serialization is insufficient

Serializing two initializers prevents simultaneous profiling, but it does not make whole-device deltas process-local:

1. Engine A finishes initialization and releases the lock.
2. A starts serving and changes its physical KV mappings.
3. Engine B acquires the lock and profiles while A continues changing GPU memory.

The same issue remains when engines A and B are serving and engine C starts later. A fully correct lock would require quiescing every running peer, which would stall traffic and make cold-start latency grow with the number of instances.

## Implementation

### vLLM

For supported vLLM releases, the patch:

1. Mirrors vLLM's `ceil(total_memory * gpu_memory_utilization)` formula to establish a stable logical budget.
2. Downgrades only the known whole-device startup guard to a warning when kvcached is enabled.
3. Reuses the budget stored in `self.requested_memory` instead of recomputing it from mutable free memory.
4. Runs the required profile workload, but sizes KV from process-local costs:

   ```text
   requested_memory
   - weights_memory
   - torch_peak_increase
   ```

5. Ignores device-wide `non_torch_increase`, `after_profile.free_memory`, the cross-process free-memory assertion, and the CUDA Graph estimate for KV sizing.
6. Still runs `profile_cudagraph_memory()` when supported and records `self.cudagraph_memory_estimate` for vLLM's later comparison/logging, but does not fold the estimate into `peak_activation_memory` or subtract it from logical KV capacity.
7. Uses runtime feature detection for older supported workers that predate `init_snapshot`: after `init_device()`, it stores the same logical budget and measures the reset process-local PyTorch peak.
8. Leaves explicit `kv_cache_memory_bytes` and kvcached-disabled paths unchanged.

### SGLang

For SGLang 0.5.11 and later, the patch wraps `ModelRunner._profile_available_bytes()`:

```python
logical_budget = ceil(total_memory * mem_fraction_static)
local_available = logical_budget - torch.cuda.memory_reserved(gpu_id)
```

The rank-local result is reduced with `MIN` across the current SGLang world group before pool sizing, preserving identical TP geometry. If any rank cannot query its local capacity, a failure sentinel makes every rank fall back to SGLang's original distributed profiler, so collective order cannot diverge.

Mamba reservation is applied after synchronization. Non-GPU devices and kvcached-disabled runs retain the original profiler. The patch is installed after elastic memory-pool aliases because importing `ModelRunner` caches those pool classes in module globals.

### Temporary physical pressure

The vLLM and SGLang integrations reserve block 0 as a null block during post-initialization. If physical KV capacity is temporarily unavailable, reservation now sleeps and retries instead of terminating EngineCore. It also retries the race where capacity is observed but another engine takes the page before allocation.

The expected block identity remains fail-loud. CUDA allocation failures, unsupported layouts, invalid geometry, and unrelated runtime failures are not converted into warnings.

## Validation

Hardware validation used one NVIDIA Tesla T4.

| Scenario | Result |
| --- | --- |
| vLLM 0.24.0, PyTorch 2.11.0+cu129, Qwen2.5-0.5B-Instruct | CUDA Graph profiling and capture completed; the estimate was retained and logged as ignored for sizing; the service reached health and an OpenAI Chat request returned exactly `OK` |
| SGLang 0.5.15, PyTorch 2.11.0+cu129, `sglang-kernel` 0.4.4+cu129, Qwen2.5-3B-Instruct | All kvcached SGLang patches applied; the process-local logical capacity was reported; with CUDA Graph disabled for the T4 smoke run, the service reached health and an OpenAI Chat request returned exactly `OK` |
| Focused virtual-capacity and patch-order regressions | 25 passed |
| Full Linux CPU manifest | 167 passed on each of Python 3.9, 3.10, 3.11, 3.12, and 3.13 |
| Static and native checks | Five mypy jobs, pre-commit, and the GPU-free C++ tests passed |

The vLLM 0.24.0 run also verifies the worker contract required by `compile_or_warm_up_model()`: `self.non_torch_memory` is initialized without reintroducing the device-wide delta. Separate regressions verify that a large peer-driven `non_torch_increase` and the CUDA Graph estimate do not change logical KV capacity.

## Known limitation

This patch does not make a permanently infeasible configuration runnable. At least one physical page and sufficient non-KV headroom must eventually become available.

While reserving the null block, `_post_init_done` is not set until block 0 is allocated. Temporary pressure can recover, but if no physical KV page ever becomes available, post-initialization keeps waiting instead of failing fast. The retry sleeps and does not busy-spin, but the engine does not become usable.

This PR does not introduce an arbitrary timeout because that would turn temporary pressure back into a timing-dependent startup failure. A follow-up can make the wait lifecycle-aware and cancellable, or connect it to an explicit startup deadline supplied by the caller.

## Design boundary

This is a compatibility fix for the current kvcached integrations. It does not replace vLLM's complete memory profiler or define a shared-GPU physical-memory accounting model.

The selected boundary, rejected alternatives, known limitation, and criteria for reopening the larger design are documented in [Discussion #454](https://github.com/ovg-project/kvcached/discussions/454).
