### PR TITLE
fix(vllm): correct heterogeneous prefix-cache hashes

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -400,6 +400,25 @@ def _set_block_hash(block: Any, key: Any) -> None:
         block.block_hash = key
 
 
+def _convert_block_hashes(
+    block_hashes: Any,
+    hash_block_size: int,
+    target_block_size: int,
+) -> Any:
+    if target_block_size == hash_block_size:
+        return block_hashes
+
+    import importlib
+
+    kv_cache_utils = importlib.import_module("vllm.v1.core.kv_cache_utils")
+    converter = getattr(kv_cache_utils, "BlockHashListWithBlockSize", None)
+    if converter is None:
+        raise RuntimeError(
+            "This vLLM version does not support heterogeneous block-hash conversion"
+        )
+    return converter(block_hashes, hash_block_size, target_block_size)
+
+
 class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
     """Inject ElasticBlockPool into vLLM's block pool module"""
 
@@ -443,7 +462,8 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 enable_caching: bool,
                 enable_kv_cache_events: bool = False,
                 num_kv_buffers: int = 2,
-                max_cached_blocks: int = 1000
+                max_cached_blocks: int = 1000,
+                hash_block_size: Optional[int] = None,
             ) -> None:
                 assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
                 self.enable_prefix_cache = enable_caching
@@ -456,6 +476,13 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                     "KV cache events are not supported in ElasticBlockPool")
 
                 self.num_gpu_blocks = num_gpu_blocks
+                # Request.block_hashes are computed at hash_block_size, which
+                # can be smaller than a heterogeneous KV group's physical
+                # block_size. Keep this distinct from block_size, which is also
+                # used to configure kvcached's physical allocation geometry.
+                self.hash_block_size = (
+                    block_size if hash_block_size is None else int(hash_block_size)
+                )
                 self.enable_kv_cache_events = enable_kv_cache_events
                 self.kv_event_queue = []  # type: ignore[var-annotated]
                 self.kv_block_pool = [KVCacheBlockClass(i) for i in range(num_gpu_blocks)]
@@ -567,6 +594,7 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                 num_full_blocks = kwargs.pop("num_full_blocks", None)
                 _block_size = kwargs.pop("block_size", None)
                 kv_cache_group_id = kwargs.pop("kv_cache_group_id", 0)
+                block_mask = kwargs.pop("block_mask", None)
                 _hash_fn = kwargs.pop("hash_fn", None)
 
                 remaining_args = list(args)
@@ -581,6 +609,12 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                     _block_size = remaining_args.pop(0)
                 if remaining_args and isinstance(remaining_args[0], int):
                     kv_cache_group_id = remaining_args.pop(0)
+                if (
+                    block_mask is None
+                    and remaining_args
+                    and isinstance(remaining_args[0], (list, tuple))
+                ):
+                    block_mask = remaining_args.pop(0)
                 if remaining_args:
                     # Final positional argument is typically hash_fn; ignored.
                     _hash_fn = remaining_args.pop(0)
@@ -597,15 +631,28 @@ class ElasticBlockPoolPatch(VersionAwarePatch, BasePatch):
                     return
 
                 new_full_blocks = blocks[num_cached_blocks:num_full_blocks]
+                assert block_mask is None or len(block_mask) == len(new_full_blocks)
 
                 if block_hashes is None:
                     assert hasattr(request, "block_hashes"), "Request missing block_hashes attribute"
-                    block_hashes = request.block_hashes
+                    target_block_size = (
+                        self.hash_block_size
+                        if _block_size is None
+                        else int(_block_size)
+                    )
+                    block_hashes = _convert_block_hashes(
+                        request.block_hashes,
+                        self.hash_block_size,
+                        target_block_size,
+                    )
                 assert len(block_hashes) >= num_full_blocks, \
                     f"Request has {len(block_hashes)} hashes but need {num_full_blocks}"
 
                 for i, block in enumerate(new_full_blocks):
-                    if getattr(block, "is_null", False):
+                    if (
+                        getattr(block, "is_null", False)
+                        or (block_mask is not None and not block_mask[i])
+                    ):
                         continue
 
                     block_idx = num_cached_blocks + i
@@ -1006,6 +1053,15 @@ class KVCacheCoordinatorPatch(VersionAwarePatch, BasePatch):
             ElasticBlockPool = getattr(block_pool_mod, "ElasticBlockPool")
 
             group_size = _get_group_size(kv_cache_config)
+            # vLLM computes Request.block_hashes at a shared fine-grained size
+            # (normally the GCD of heterogeneous group block sizes). Preserve
+            # the value from the native pool before replacing it.
+            native_block_pool = getattr(self, "block_pool", None)
+            hash_block_size = getattr(
+                native_block_pool,
+                "hash_block_size",
+                getattr(self, "hash_block_size", block_size),
+            )
             self.block_pool = ElasticBlockPool(
                 kv_cache_config.num_blocks,
                 block_size,
@@ -1013,7 +1069,8 @@ class KVCacheCoordinatorPatch(VersionAwarePatch, BasePatch):
                 num_layers=group_size,
                 enable_caching=getattr(self, "enable_caching", False),
                 num_kv_buffers=num_kv_buffers,
-                max_cached_blocks=_get_max_cached_blocks(block_size)
+                max_cached_blocks=_get_max_cached_blocks(block_size),
+                hash_block_size=hash_block_size,
             )
             for manager in self.single_type_managers:
                 manager.block_pool = self.block_pool

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -117,6 +117,22 @@ class MockRequest:
         self.block_hashes = block_hashes
 
 
+class MockBlockHashListWithBlockSize:
+    def __init__(self, block_hashes, hash_block_size, target_block_size):
+        assert target_block_size % hash_block_size == 0
+        self.block_hashes = block_hashes
+        self.scale_factor = target_block_size // hash_block_size
+
+    def __len__(self):
+        return len(self.block_hashes) // self.scale_factor
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            start, stop, step = index.indices(len(self))
+            return [self[i] for i in range(start, stop, step)]
+        return self.block_hashes[(index + 1) * self.scale_factor - 1]
+
+
 def test_set_block_hash_supports_legacy_writable_property():
     """vLLM before 0.24 uses a writable block_hash property."""
     from kvcached.integration.vllm.patches import _set_block_hash
@@ -134,7 +150,7 @@ def test_set_block_hash_supports_legacy_writable_property():
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-def pool_factory():
+def pool_factory(monkeypatch):
     """Factory that builds an ElasticBlockPool with a given number of blocks.
 
     Returns (pool, manager) so tests can inspect both.
@@ -142,6 +158,16 @@ def pool_factory():
 
     def _make(num_blocks: int = 100, enable_caching: bool = True):
         manager = MockKVCacheManager(num_blocks)
+
+        kv_cache_utils = types.ModuleType("vllm.v1.core.kv_cache_utils")
+        setattr(
+            kv_cache_utils,
+            "BlockHashListWithBlockSize",
+            MockBlockHashListWithBlockSize,
+        )
+        monkeypatch.setitem(
+            sys.modules, "vllm.v1.core.kv_cache_utils", kv_cache_utils
+        )
 
         # Build a mock module that looks like vllm.v1.core.block_pool
         mock_mod = types.ModuleType("mock_block_pool")
@@ -559,6 +585,76 @@ class TestEdgeCases:
         pool.cache_full_blocks(req, blocks, 0, 2, 16, 0)
         pool.cache_full_blocks(req, blocks, 0, 2, 16, 0)
         assert len(pool._cached_blocks) == 2
+
+    def test_heterogeneous_block_size_uses_final_fine_grained_hash(
+        self, pool_and_manager, monkeypatch
+    ):
+        """A 64-token block uses the final hash from its four 16-token chunks."""
+        pool, _ = pool_and_manager
+        blocks = pool.get_new_blocks(2)
+        req = MockRequest([f"h{i}" for i in range(8)])
+
+        kv_cache_utils = sys.modules["vllm.v1.core.kv_cache_utils"]
+        converter = mock.Mock(side_effect=MockBlockHashListWithBlockSize)
+        monkeypatch.setattr(
+            kv_cache_utils, "BlockHashListWithBlockSize", converter
+        )
+
+        pool.cache_full_blocks(req, blocks, 0, 2, 64, 1)
+
+        converter.assert_called_once_with(req.block_hashes, 16, 64)
+        assert pool.get_cached_block("h0", [1]) is None
+        assert pool.get_cached_block("h1", [1]) is None
+        assert pool.get_cached_block("h3", [1]) == [blocks[0]]
+        assert pool.get_cached_block("h7", [1]) == [blocks[1]]
+
+    def test_heterogeneous_block_size_conversion_respects_cached_offset(
+        self, pool_and_manager
+    ):
+        """Incremental caching indexes the converted hash list by physical block."""
+        pool, _ = pool_and_manager
+        blocks = pool.get_new_blocks(2)
+        req = MockRequest([f"h{i}" for i in range(8)])
+
+        pool.cache_full_blocks(req, blocks, 0, 1, 64, 1)
+        pool.cache_full_blocks(req, blocks, 1, 2, 64, 1)
+
+        assert pool.get_cached_block("h3", [1]) == [blocks[0]]
+        assert pool.get_cached_block("h7", [1]) == [blocks[1]]
+
+    def test_heterogeneous_block_size_requires_vllm_converter(
+        self, pool_and_manager, monkeypatch
+    ):
+        pool, _ = pool_and_manager
+        blocks = pool.get_new_blocks(1)
+        req = MockRequest([f"h{i}" for i in range(4)])
+
+        kv_cache_utils = sys.modules["vllm.v1.core.kv_cache_utils"]
+        monkeypatch.delattr(kv_cache_utils, "BlockHashListWithBlockSize")
+
+        with pytest.raises(
+            RuntimeError, match="does not support heterogeneous block-hash conversion"
+        ):
+            pool.cache_full_blocks(req, blocks, 0, 1, 64, 1)
+
+    def test_cache_full_blocks_honors_block_mask(self, pool_and_manager):
+        """Masked physical blocks must not become reusable prefix entries."""
+        pool, _ = pool_and_manager
+        blocks = pool.get_new_blocks(2)
+        req = MockRequest(["h0", "h1"])
+
+        pool.cache_full_blocks(
+            request=req,
+            blocks=blocks,
+            num_cached_blocks=0,
+            num_full_blocks=2,
+            block_size=16,
+            kv_cache_group_id=0,
+            block_mask=[False, True],
+        )
+
+        assert pool.get_cached_block("h0", [0]) is None
+        assert pool.get_cached_block("h1", [0]) == [blocks[1]]
 
     def test_duplicate_hashes_keep_each_block_metadata(self, pool_and_manager):
         """Concurrent requests may materialize the same prefix twice."""

--- a/tests/test_vllm_tp_world_size.py
+++ b/tests/test_vllm_tp_world_size.py
@@ -121,6 +121,7 @@ def test_engine_core_propagates_kvcached_initialization_failure(
 class FakeElasticBlockPool:
     def __init__(self, *args, **kwargs):
         self.null_block = object()
+        self.kwargs = kwargs
 
 
 def test_coordinator_uses_recorded_world_size(monkeypatch, vllm_modules):
@@ -131,7 +132,7 @@ def test_coordinator_uses_recorded_world_size(monkeypatch, vllm_modules):
         patches,
         "_get_first_attention_group",
         lambda cfg: types.SimpleNamespace(
-            kv_cache_spec=types.SimpleNamespace(block_size=16)
+            kv_cache_spec=types.SimpleNamespace(block_size=64)
         ),
     )
     monkeypatch.setattr(patches, "_infer_attention_type", lambda cfg: "MHA")
@@ -159,6 +160,7 @@ def test_coordinator_uses_recorded_world_size(monkeypatch, vllm_modules):
             self.enable_caching = False
             self.kv_cache_config = types.SimpleNamespace(num_blocks=8)
             self.single_type_managers = [types.SimpleNamespace()]
+            self.block_pool = types.SimpleNamespace(hash_block_size=16)
 
     setattr(kvcoord_mod, "KVCacheCoordinator", FakeKVCacheCoordinator)
 
@@ -167,6 +169,7 @@ def test_coordinator_uses_recorded_world_size(monkeypatch, vllm_modules):
 
     assert init_kvcached.call_args.kwargs["world_size"] == 4
     assert isinstance(getattr(coordinator, "block_pool"), FakeElasticBlockPool)
+    assert coordinator.block_pool.kwargs["hash_block_size"] == 16
 
 
 def test_coordinator_propagates_uninitialized_world_size(


### PR DESCRIPTION
## Summary

Fix #446 

Gemma 4 uses different physical block sizes across KV-cache groups, while request hashes are computed at a shared finer granularity. kvcached previously lost vLLM’s hash_block_size when replacing the native block pool, causing physical blocks to be cached under incorrect prefix hashes.

- Preserves the native vLLM hash_block_size.
- Reuses vLLM’s [BlockHashListWithBlockSize](https://github.com/vllm-project/vllm/blob/main/vllm/v1/core/kv_cache_utils.py#L2237) for hash conversion. 

Testing
- 40 passed in targeted prefix-cache and coordinator tests.
- Tested `google/gemma-4-12B-it` with vLLM 0.24.0.
