### PR TITLE
fix(sglang): Patch MambaSlotAllocator on sglang 0.5.13+ 

### DIFF
--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -12,7 +12,10 @@ import types
 from typing import Any, Callable, List, Optional, Tuple, Union, cast
 
 from kvcached.integration.patch_base import BasePatch, enable_kvcached
-from kvcached.integration.version_utils import VersionAwarePatch, version_range
+from kvcached.integration.version_utils import (
+    VersionAwarePatch,
+    version_range,
+)
 from kvcached.utils import MAX_CACHED_TOKENS, get_kvcached_logger
 
 BYTES_PER_GB = 1024**3
@@ -869,6 +872,8 @@ class ElasticMambaPoolPatch(VersionAwarePatch, BasePatch):
         success = self.inject_elastic_mamba_pool(mem_pool_mod)
         if success:
             success &= self.alias_mamba_pool_to_elastic(mem_pool_mod)
+        if success and self.patch_mamba_slot_allocator in self.applicable_methods:
+            success &= self.patch_mamba_slot_allocator(mem_pool_mod)
         return success
 
     @version_range(SGLANG_ALL_RANGE)
@@ -1271,6 +1276,127 @@ class ElasticMambaPoolPatch(VersionAwarePatch, BasePatch):
             self.logger.warning(
                 f"Failed to alias MambaPool to elastic one: {e}")
             return False
+
+    @version_range(">=0.5.13")
+    def patch_mamba_slot_allocator(self, mem_pool_mod: types.ModuleType) -> bool:
+        """Route SGLang's request-level Mamba slots through kvcached.
+
+        SGLang 0.5.13 split slot ownership out of ``MambaPool`` into a
+        separate ``MambaSlotAllocator``.  Merely aliasing ``MambaPool`` then
+        leaves ``ElasticMambaPool.alloc/free`` dead and never maps the VMM
+        pages for request slots.  Wrap ``HybridReqToTokenPool._init_mamba_pool``
+        so the allocator installed after pool construction owns the same IDs
+        through the pool's ``KVCacheManager``.
+        """
+        HybridReqToTokenPool = getattr(mem_pool_mod, "HybridReqToTokenPool", None)
+        if HybridReqToTokenPool is None:
+            self.logger.debug(
+                "HybridReqToTokenPool not found; skipping Mamba slot allocator patch"
+            )
+            return True
+
+        original_init = getattr(HybridReqToTokenPool, "_init_mamba_pool", None)
+        if original_init is None:
+            self.logger.debug(
+                "HybridReqToTokenPool._init_mamba_pool not found; skipping"
+            )
+            return True
+        if "MambaSlotAllocator" not in getattr(original_init, "__globals__", {}):
+            # SGLang <=0.5.12 keeps allocation on MambaPool.alloc/free, which
+            # ElasticMambaPool already overrides directly.
+            self.logger.debug(
+                "SGLang uses MambaPool-owned slots; no separate allocator patch needed"
+            )
+            return True
+        marker = "__kvcached_mamba_slot_allocator_patched__"
+        if self._is_already_patched(original_init, marker):
+            return True
+
+        import torch
+
+        class ElasticMambaSlotAllocator:
+            """SGLang Mamba-slot interface backed by ``ElasticMambaPool``."""
+
+            def __init__(self, size: int, device: str, mamba_pool: Any) -> None:
+                self.size = size
+                self.device = device
+                self.mamba_pool = mamba_pool
+                self._alloc_iter = None
+                self._free_ids = set(range(1, size + 1))
+
+            @property
+            def free_slots(self):
+                # Compatibility for SGLang's debug invariant checker. Normal
+                # scheduling uses available_size() and does not materialize it.
+                return torch.tensor(
+                    sorted(self._free_ids), dtype=torch.int64, device=self.device
+                )
+
+            def available_size(self) -> int:
+                return self.mamba_pool.available_size()
+
+            def schedulable_available_size(self) -> int:
+                return self.available_size()
+
+            def _do_alloc(self, need_size: int):
+                slots = self.mamba_pool.alloc(need_size)
+                if slots is None:
+                    return None
+                self._free_ids.difference_update(slots.tolist())
+                return slots
+
+            def alloc(self, need_size: int):
+                if self._alloc_iter is not None and need_size == 1:
+                    slot = next(self._alloc_iter, None)
+                    if slot is not None:
+                        return slot
+                return self._do_alloc(need_size)
+
+            def free(self, free_index) -> None:
+                if free_index.numel() == 0:
+                    return
+                block_ids = free_index.tolist()
+                self.mamba_pool.free(free_index)
+                self._free_ids.update(block_ids)
+
+            def alloc_group_begin(self, num_reqs: int) -> None:
+                self._alloc_iter = None
+                if num_reqs > 0:
+                    result = self._do_alloc(num_reqs)
+                    if result is not None:
+                        self._alloc_iter = iter(result.split(1))
+
+            def alloc_group_end(self) -> None:
+                if self._alloc_iter is not None:
+                    remaining = list(self._alloc_iter)
+                    if remaining:
+                        self.free(torch.cat(remaining))
+                self._alloc_iter = None
+
+            def clear(self) -> None:
+                self.mamba_pool.clear()
+                self._alloc_iter = None
+                self._free_ids = set(range(1, self.size + 1))
+
+        def _patched_init_mamba_pool(self, *args: Any, **kwargs: Any) -> None:
+            original_init(self, *args, **kwargs)
+            mamba_pool = getattr(self, "mamba_pool", None)
+            if mamba_pool is None or not hasattr(mamba_pool, "kvcached_allocator"):
+                return
+            self.mamba_allocator = ElasticMambaSlotAllocator(
+                size=mamba_pool.size,
+                device=mamba_pool.device,
+                mamba_pool=mamba_pool,
+            )
+            logger.info(
+                "[kvcached] ElasticMambaSlotAllocator in use: size=%d",
+                mamba_pool.size,
+            )
+
+        self._mark_as_patched(_patched_init_mamba_pool, marker)
+        HybridReqToTokenPool._init_mamba_pool = _patched_init_mamba_pool
+        setattr(mem_pool_mod, "ElasticMambaSlotAllocator", ElasticMambaSlotAllocator)
+        return True
 
 
 class ElasticHybridLinearKVPoolPatch(VersionAwarePatch, BasePatch):

--- a/tests/manifests/cpu.txt
+++ b/tests/manifests/cpu.txt
@@ -12,6 +12,7 @@ tests/test_prefix_cache.py
 tests/test_resize_reserved_order.py
 tests/test_sglang_allocator_patch.py
 tests/test_sglang_autopatch_order.py
+tests/test_sglang_mamba_slot_allocator.py
 tests/test_sglang_virtual_kv_capacity.py
 tests/test_shm_info_tracker.py
 tests/test_sleep_manager.py

--- a/tests/test_sglang_mamba_slot_allocator.py
+++ b/tests/test_sglang_mamba_slot_allocator.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from kvcached.integration.sglang.patches import ElasticMambaPoolPatch
+
+torch = pytest.importorskip("torch")
+memory_pool = pytest.importorskip("sglang.srt.mem_cache.memory_pool")
+
+
+class FakeManager:
+    def __init__(self, size):
+        self.free_ids = list(range(1, size + 1))
+        self.alloc_calls = []
+        self.free_calls = []
+        self.clear_calls = 0
+
+    def available_size(self):
+        return len(self.free_ids)
+
+    def alloc(self, count):
+        self.alloc_calls.append(count)
+        if count > len(self.free_ids):
+            return None
+        result, self.free_ids = self.free_ids[:count], self.free_ids[count:]
+        return result
+
+    def free(self, ids):
+        self.free_calls.append(ids)
+        self.free_ids.extend(ids)
+
+    def clear(self):
+        self.clear_calls += 1
+        size = len(self.free_ids) + sum(self.alloc_calls) - sum(map(len, self.free_calls))
+        self.free_ids = list(range(1, size + 1))
+
+
+class FakePool:
+    def __init__(self, size):
+        self.kvcached_allocator = FakeManager(size)
+        self.alloc_calls = []
+        self.free_calls = []
+        self.clear_calls = 0
+
+    def available_size(self):
+        return self.kvcached_allocator.available_size()
+
+    def alloc(self, count):
+        self.alloc_calls.append(count)
+        result = self.kvcached_allocator.alloc(count)
+        if result is None:
+            return None
+        return torch.tensor(result, dtype=torch.int64)
+
+    def free(self, slots):
+        self.free_calls.append(slots.tolist())
+        self.kvcached_allocator.free(slots.tolist())
+
+    def clear(self):
+        self.clear_calls += 1
+        self.kvcached_allocator.clear()
+
+
+@pytest.fixture
+def allocator_cls():
+    patch = ElasticMambaPoolPatch()
+    assert patch.apply(memory_pool)
+    return memory_pool.ElasticMambaSlotAllocator
+
+
+def test_alloc_and_free_delegate_to_kvcached(allocator_cls):
+    pool = FakePool(4)
+    manager = pool.kvcached_allocator
+    allocator = allocator_cls(4, "cpu", pool)
+
+    slots = allocator.alloc(2)
+
+    assert slots.tolist() == [1, 2]
+    assert manager.alloc_calls == [2]
+    assert pool.alloc_calls == [2]
+    assert allocator.available_size() == 2
+
+    allocator.free(slots)
+    assert manager.free_calls == [[1, 2]]
+    assert pool.free_calls == [[1, 2]]
+    assert allocator.available_size() == 4
+
+
+def test_group_allocation_returns_unused_slots(allocator_cls):
+    pool = FakePool(4)
+    manager = pool.kvcached_allocator
+    allocator = allocator_cls(4, "cpu", pool)
+
+    allocator.alloc_group_begin(3)
+    assert allocator.alloc(1).tolist() == [1]
+    allocator.alloc_group_end()
+
+    assert manager.alloc_calls == [3]
+    assert manager.free_calls == [[2, 3]]
+    assert allocator.available_size() == 3
+
+
+def test_exhaustion_and_reuse_preserve_slot_identity(allocator_cls):
+    pool = FakePool(4)
+    allocator = allocator_cls(4, "cpu", pool)
+
+    first = allocator.alloc(4)
+    assert first.tolist() == [1, 2, 3, 4]
+    assert len(set(first.tolist())) == 4
+    assert allocator.available_size() == 0
+    assert allocator.alloc(1) is None
+
+    allocator.free(first[1:3])
+    reused = allocator.alloc(2)
+    assert reused.tolist() == [2, 3]
+    assert allocator.available_size() == 0
+
+
+def test_free_slots_debug_view_matches_manager_ownership(allocator_cls):
+    pool = FakePool(4)
+    allocator = allocator_cls(4, "cpu", pool)
+
+    slots = allocator.alloc(2)
+    assert allocator.free_slots.tolist() == [3, 4]
+
+    allocator.free(slots[:1])
+    assert allocator.free_slots.tolist() == [1, 3, 4]


### PR DESCRIPTION
## Summary

SGLang 0.5.13 moved Mamba slot allocation from `MambaPool` to a separate `MambaSlotAllocator`. [code](https://github.com/sgl-project/sglang/blob/v0.5.13/python/sglang/srt/mem_cache/memory_pool.py#L546)
 As a result, patching only `MambaPool.alloc/free` no longer routes active slots through kvcached.

The alloc, free, available_size, and clear methods were removed from [MambaPool](https://github.com/sgl-project/sglang/blob/v0.5.13/python/sglang/srt/mem_cache/memory_pool.py#L216) .

v0.5.12
```
self.mamba_pool.alloc(...)
self.mamba_pool.free(...)
```

v0.5.13
```
self.mamba_allocator.alloc(...)
self.mamba_allocator.free(...)
```

This PR adds an `ElasticMambaSlotAllocator` for SGLang 0.5.13+ and delegates allocation, release, and clearing to `ElasticMambaPool`. Older SGLang versions keep the existing path.


## Test

- 7 targeted tests passed.
- SGLang 0.5.15 with Qwen3.5-4B on A2000.
- SGLang serving benchmark: 16/16 requests succeeded at peak concurrency 16.
- Verified Mamba memory is mapped on allocation and released on free.