### PR TITLE
[DO NOT MERGE] fix: compare resize target against current allocator capacity

### DIFF
--- a/csrc/inc/page_allocator.hpp
+++ b/csrc/inc/page_allocator.hpp
@@ -93,7 +93,8 @@ public:
 
   // Poll the shared-memory MemInfoStruct to see if an external controller
   // (e.g. `kvctl limit`) has written a new total_size. Returns the new
-  // per-layer mem_size if it differs from current_mem_size, otherwise -1.
+  // per-layer mem_size if it resolves to a different page count, otherwise
+  // -1.
   int64_t check_and_get_resize_target(int64_t current_mem_size) const;
 
   // Fast atomic read of the resize target (updated by background watcher

--- a/csrc/page_allocator.cpp
+++ b/csrc/page_allocator.cpp
@@ -502,8 +502,20 @@ PageAllocator::check_and_get_resize_target(int64_t current_mem_size) const {
   if (!mem_info_tracker_) {
     return -1;
   }
-  return mem_info_tracker_->check_and_get_resize_target(
+  const int64_t target = mem_info_tracker_->check_and_get_resize_target(
       current_mem_size, num_layers_, num_kv_buffers_);
+  if (target < 0) {
+    return -1;
+  }
+
+  const int64_t current_num_pages =
+      num_total_pages_.load(std::memory_order_relaxed);
+  // resize() floors byte targets to whole pages, so an unaligned target is
+  // satisfied once its page count matches the allocator's live capacity.
+  if (target / page_size_ == current_num_pages) {
+    return -1;
+  }
+  return target;
 }
 
 std::unordered_map<page_id_t, std::vector<int64_t>>
@@ -842,8 +854,7 @@ void PageAllocator::resize_watcher() {
     if (mem_info_tracker_) {
       const int64_t current_mem_size =
           num_total_pages_.load(std::memory_order_relaxed) * page_size_;
-      int64_t target = mem_info_tracker_->check_and_get_resize_target(
-          current_mem_size, num_layers_, num_kv_buffers_);
+      int64_t target = check_and_get_resize_target(current_mem_size);
       resize_target_.store(target, std::memory_order_relaxed);
     }
   }

--- a/csrc/page_allocator.cpp
+++ b/csrc/page_allocator.cpp
@@ -840,8 +840,10 @@ void PageAllocator::resize_watcher() {
       break;
     }
     if (mem_info_tracker_) {
+      const int64_t current_mem_size =
+          num_total_pages_.load(std::memory_order_relaxed) * page_size_;
       int64_t target = mem_info_tracker_->check_and_get_resize_target(
-          mem_size_per_layer_, num_layers_, num_kv_buffers_);
+          current_mem_size, num_layers_, num_kv_buffers_);
       resize_target_.store(target, std::memory_order_relaxed);
     }
   }

--- a/tests/test_kvcache_manager.py
+++ b/tests/test_kvcache_manager.py
@@ -161,6 +161,36 @@ def test_resize_smaller_and_larger(setup_kvcache):
     assert expand_total_pages == initial_total_pages
 
 
+def test_resize_watcher_can_restore_initial_capacity(setup_kvcache):
+    manager = setup_kvcache
+    initial_total_pages = manager.page_allocator.get_num_total_pages()
+    initial_mem_size = initial_total_pages * manager.page_size
+    initial_limit = initial_mem_size * NUM_LAYERS * 2
+    shrink_mem_size = initial_mem_size // 2
+    shrink_limit = shrink_mem_size * NUM_LAYERS * 2
+
+    def wait_for_target(expected):
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            if manager.page_allocator.get_resize_target() == expected:
+                return
+            time.sleep(0.05)
+        pytest.fail(f"resize target did not become {expected}")
+
+    try:
+        update_kv_cache_limit(IPC_NAME, shrink_limit)
+        wait_for_target(shrink_mem_size)
+        assert manager.resize(shrink_mem_size)
+        wait_for_target(-1)
+
+        update_kv_cache_limit(IPC_NAME, initial_limit)
+        wait_for_target(initial_mem_size)
+        assert manager.resize(initial_mem_size)
+        assert manager.page_allocator.get_num_total_pages() == initial_total_pages
+    finally:
+        update_kv_cache_limit(IPC_NAME, initial_limit)
+
+
 def test_trim(setup_kvcache):
     # instantiate a kv cache manager with known size
     manager = setup_kvcache

--- a/tests/test_kvcache_manager.py
+++ b/tests/test_kvcache_manager.py
@@ -161,12 +161,18 @@ def test_resize_smaller_and_larger(setup_kvcache):
     assert expand_total_pages == initial_total_pages
 
 
-def test_resize_watcher_can_restore_initial_capacity(setup_kvcache):
+def test_resize_watcher_restores_capacity_after_unaligned_shrink(setup_kvcache):
     manager = setup_kvcache
     initial_total_pages = manager.page_allocator.get_num_total_pages()
+    assert initial_total_pages > 1
     initial_mem_size = initial_total_pages * manager.page_size
     initial_limit = initial_mem_size * NUM_LAYERS * 2
-    shrink_mem_size = initial_mem_size // 2
+    # Use a deliberately unaligned target. resize() floors it to whole pages,
+    # and the watcher must then recognize that the target has been satisfied.
+    shrink_mem_size = (
+        (initial_total_pages - 1) * manager.page_size
+        + manager.page_size // 2
+    )
     shrink_limit = shrink_mem_size * NUM_LAYERS * 2
 
     def wait_for_target(expected):


### PR DESCRIPTION
## Summary

Fix the resize watcher failing to restore an allocator to its initial capacity after shrinking.

`mem_size_per_layer_` stores the startup capacity and is not updated by `resize()`. The watcher therefore treated the initial limit as unchanged even when the allocator was currently smaller.

Use `num_total_pages_ * page_size_` as the current allocator capacity instead.

## Test

Added a regression test covering:

1. Shrink from the initial capacity.
2. Restore the original limit.
3. Verify the watcher produces the expansion target.
4. Verify the allocator returns to its initial page count.

```bash
python -m pytest -v  tests/test_kvcache_manager.py::test_resize_watcher_can_restore_initial_capacity
```