### PR TITLE
fix(sglang): Fix SGLang SWA models 0.5.13+

### DIFF
--- a/kvcached/integration/sglang/autopatch.py
+++ b/kvcached/integration/sglang/autopatch.py
@@ -14,6 +14,7 @@ from kvcached.integration.sglang.patches import (
     ElasticMambaPoolPatch,
     ElasticMemoryPoolPatch,
     ElasticMLAMemoryPoolPatch,
+    ElasticSWAAllocatorPatch,
     RadixCacheLimitPatch,
     SchedulerMemoryLeakPatch,
     SGLangVirtualKVCapacityPatch,
@@ -39,6 +40,9 @@ def _patch_sglang(_sglang: types.ModuleType) -> None:
     patch_manager.register_patches_with_versions(
         [
             (ElasticAllocatorPatch(), SGLANG_ALL_RANGE),
+            # SWATokenToKVPoolAllocator captures allocator classes from its
+            # implementation modules, not from the package aliases above.
+            (ElasticSWAAllocatorPatch(), ">=0.5.13"),
             (ElasticMemoryPoolPatch(), SGLANG_ALL_RANGE),
             (ElasticMLAMemoryPoolPatch(), SGLANG_ALL_RANGE),
             (ElasticMambaPoolPatch(), SGLANG_ALL_RANGE),

--- a/kvcached/integration/sglang/patches.py
+++ b/kvcached/integration/sglang/patches.py
@@ -477,6 +477,51 @@ class ElasticAllocatorPatch(VersionAwarePatch, BasePatch):
             return False
 
 
+class ElasticSWAAllocatorPatch(VersionAwarePatch, BasePatch):
+    """Make SGLang's composite SWA allocator use elastic sub-allocators.
+
+    SGLang's ``allocator.swa`` module imports the token and paged allocator
+    classes directly from their implementation modules.  Replacing only the
+    re-exports on ``sglang.srt.mem_cache.allocator`` therefore does not affect
+    the classes captured by ``SWATokenToKVPoolAllocator``.
+    """
+
+    library = "sglang"
+    target_module = "sglang.srt.mem_cache.allocator.swa"
+    patch_name = "elastic_swa_allocator"
+
+    def apply(self, swa_alloc_mod: types.ModuleType) -> bool:
+        if not self.initialize_version_info():
+            return False
+        return self.alias_swa_sub_allocators(swa_alloc_mod)
+
+    @version_range(">=0.5.13")
+    def alias_swa_sub_allocators(self, swa_alloc_mod: types.ModuleType) -> bool:
+        marker = "__kvcached_swa_sub_allocators_aliased__"
+        if self._is_already_patched(swa_alloc_mod, marker):
+            return True
+
+        try:
+            from sglang.srt.mem_cache import allocator as alloc_mod
+
+            elastic_token_allocator = getattr(
+                alloc_mod, "ElasticTokenToKVPoolAllocator"
+            )
+            elastic_paged_allocator = getattr(
+                alloc_mod, "ElasticPagedTokenToKVPoolAllocator"
+            )
+        except (ImportError, AttributeError) as exc:
+            self.logger.warning(
+                "Failed to resolve elastic allocators for SGLang SWA: %s", exc
+            )
+            return False
+
+        setattr(swa_alloc_mod, "TokenToKVPoolAllocator", elastic_token_allocator)
+        setattr(swa_alloc_mod, "PagedTokenToKVPoolAllocator", elastic_paged_allocator)
+        self._mark_as_patched(swa_alloc_mod, marker)
+        return True
+
+
 class ElasticMemoryPoolPatch(VersionAwarePatch, BasePatch):
     """Inject ElasticMHATokenToKVPool into SGLang's memory pool module"""
 

--- a/tests/test_sglang_allocator_patch.py
+++ b/tests/test_sglang_allocator_patch.py
@@ -8,7 +8,10 @@ from typing import Any
 
 import pytest
 
-from kvcached.integration.sglang.patches import ElasticAllocatorPatch
+from kvcached.integration.sglang.patches import (
+    ElasticAllocatorPatch,
+    ElasticSWAAllocatorPatch,
+)
 
 
 class FakeTensor:
@@ -223,3 +226,37 @@ def test_alloc_extend_kernel(
     )
     if "max_num_extend_tokens" in kwargs:
         assert kwargs["max_num_extend_tokens"] == 8
+
+
+def test_swa_allocator_uses_elastic_sub_allocators(monkeypatch):
+    allocator_mod: Any = types.ModuleType("sglang.srt.mem_cache.allocator")
+
+    class ElasticTokenAllocator:
+        pass
+
+    class ElasticPagedAllocator:
+        pass
+
+    allocator_mod.ElasticTokenToKVPoolAllocator = ElasticTokenAllocator
+    allocator_mod.ElasticPagedTokenToKVPoolAllocator = ElasticPagedAllocator
+
+    mem_cache_mod: Any = types.ModuleType("sglang.srt.mem_cache")
+    mem_cache_mod.allocator = allocator_mod
+    monkeypatch.setitem(sys.modules, "sglang.srt.mem_cache", mem_cache_mod)
+    monkeypatch.setitem(
+        sys.modules, "sglang.srt.mem_cache.allocator", allocator_mod
+    )
+
+    swa_mod: Any = types.ModuleType("sglang.srt.mem_cache.allocator.swa")
+    swa_mod.TokenToKVPoolAllocator = object()
+    swa_mod.PagedTokenToKVPoolAllocator = object()
+
+    patch = ElasticSWAAllocatorPatch()
+    assert patch.alias_swa_sub_allocators(swa_mod) is True
+    assert swa_mod.TokenToKVPoolAllocator is ElasticTokenAllocator
+    assert swa_mod.PagedTokenToKVPoolAllocator is ElasticPagedAllocator
+
+    # Applying the alias twice must preserve the installed classes.
+    assert patch.alias_swa_sub_allocators(swa_mod) is True
+    assert swa_mod.TokenToKVPoolAllocator is ElasticTokenAllocator
+    assert swa_mod.PagedTokenToKVPoolAllocator is ElasticPagedAllocator

--- a/tests/test_sglang_autopatch_order.py
+++ b/tests/test_sglang_autopatch_order.py
@@ -49,6 +49,10 @@ def test_virtual_capacity_patch_runs_after_memory_pool_aliases():
             patch_versions[patch_name] = version.value
 
     virtual_index = patch_names.index("SGLangVirtualKVCapacityPatch")
+    assert patch_names.index("ElasticAllocatorPatch") < patch_names.index(
+        "ElasticSWAAllocatorPatch"
+    )
+    assert patch_versions["ElasticSWAAllocatorPatch"] == ">=0.5.13"
     for pool_patch in (
         "ElasticMemoryPoolPatch",
         "ElasticMLAMemoryPoolPatch",


### PR DESCRIPTION
## Summary

Fix SGLang SWA models using native token allocators instead of kvcached allocators on SGLang 0.5.13+.

SGLang moved `SWATokenToKVPoolAllocator` into `allocator.swa`, where it imports token and paged allocators directly from their implementation modules. This bypasses kvcached's package-level aliases.

This PR:

- adds `ElasticSWAAllocatorPatch`;
- aliases both token and paged allocators captured by `allocator.swa`;
- applies the patch before ModelRunner imports the allocator classes;
- adds alias and patch-order regression tests.

## Testing

- Test `google/gemma-4-E2B-it` with the verification script to confirm that `alloc` and `free` go through kvcached.
