### PR TITLE
fix(vllm): bind cross-layer KV sharing layers to their target's cache

### DIFF
--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -11,7 +11,7 @@ import inspect
 import math
 import types
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, Iterable, Optional
+from typing import TYPE_CHECKING, Any, Collection, Iterable, Mapping, Optional
 
 from kvcached.integration.patch_base import BasePatch, enable_kvcached
 from kvcached.integration.version_utils import VersionAwarePatch, VersionRange, version_range
@@ -71,13 +71,70 @@ def _get_first_attention_group(kv_cache_config: Any) -> Any:
     return None
 
 
-def _get_group_size(kv_cache_config: Any) -> int:
-    """Return the maximum number of layers across all KV cache groups.
+def _get_runner_only_attn_layers(model_runner: Any) -> frozenset:
+    """Return layer names that appear in KV cache groups without a KV tensor.
+
+    vLLM's ``maybe_add_kv_sharing_layers_to_kv_cache_groups`` appends
+    cross-layer KV sharing layers (e.g. gemma E2B) to
+    ``kv_cache_groups[*].layer_names`` and records them in the runner's
+    ``runner_only_attn_layers`` WITHOUT adding them to any
+    ``kv_cache_tensors[*].shared_by`` (issue #417). vLLM versions without
+    the attribute have no such layers; treat that as empty.
+    """
+    return frozenset(getattr(model_runner, "runner_only_attn_layers", None) or ())
+
+
+def _tensor_backed_layer_names(
+    kv_cache_group: Any, runner_only_attn_layers: Collection[str] = ()
+) -> list:
+    """Return the group layer names that own a slot in a KVCacheTensor.
+
+    Skips runner-only layers, mirroring vanilla vLLM's
+    ``_allocate_kv_cache_tensors`` / ``_reshape_kv_cache_tensors``: those
+    layers are registered for attention-metadata assignment only and are
+    aliased to their KV-sharing target's cache after allocation.
+    """
+    if not runner_only_attn_layers:
+        return list(kv_cache_group.layer_names)
+    return [
+        ln for ln in kv_cache_group.layer_names if ln not in runner_only_attn_layers
+    ]
+
+
+def _get_group_size(
+    kv_cache_config: Any, runner_only_attn_layers: Collection[str] = ()
+) -> int:
+    """Return the maximum number of tensor-backed layers across all groups.
 
     This matches vLLM's shared memory pool count: ``group_size`` pools
-    are created, each shared by one layer from every group.
+    are created, each shared by one layer from every group. Runner-only
+    layers (cross-layer KV sharing) own no pool and are excluded so the
+    worker-side pool count stays equal to the scheduler-side ``num_layers``
+    (the scheduler's config never contains the appended sharing layers).
     """
-    return max(len(g.layer_names) for g in kv_cache_config.kv_cache_groups)
+    return max(
+        len(_tensor_backed_layer_names(g, runner_only_attn_layers))
+        for g in kv_cache_config.kv_cache_groups
+    )
+
+
+def _alias_shared_kv_layers(
+    kv_caches: dict, shared_kv_cache_layers: Mapping[str, str]
+) -> None:
+    """Bind cross-layer KV sharing layers to their target layer's cache.
+
+    Mirrors the aliasing loop in vanilla vLLM's
+    ``initialize_kv_cache_tensors``. On vLLM versions where that loop also
+    runs after the patched reshape returns, it re-assigns the same objects,
+    which is harmless.
+    """
+    for layer_name, target_layer_name in shared_kv_cache_layers.items():
+        if target_layer_name not in kv_caches:
+            raise RuntimeError(
+                f"KV sharing target layer {target_layer_name!r} (shared by "
+                f"{layer_name!r}) has no allocated KV cache to alias."
+            )
+        kv_caches[layer_name] = kv_caches[target_layer_name]
 
 
 def _validate_kv_cache_groups(kv_cache_config: Any) -> None:
@@ -1431,6 +1488,14 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
 
             _validate_kv_cache_groups(kv_cache_config)
 
+            # Cross-layer KV sharing (issue #417): vLLM appends sharing
+            # layers to group layer_names without adding them to any
+            # tensor's shared_by. Resolve layers against kv_cache_tensors
+            # only for tensor-backed names, exactly like vanilla vLLM's
+            # _allocate_kv_cache_tensors; sharing layers are aliased to
+            # their target's cache in the reshape step.
+            runner_only_attn_layers = _get_runner_only_attn_layers(self)
+
             layer_to_tensor_cfg: dict[str, KVCacheTensor] = {}
             for tensor_cfg in kv_cache_config.kv_cache_tensors:
                 for ln in tensor_cfg.shared_by:
@@ -1438,7 +1503,8 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
 
             for grp in kv_cache_config.kv_cache_groups:
                 layer_spec = grp.kv_cache_spec
-                for layer_name in grp.layer_names:
+                for layer_name in _tensor_backed_layer_names(
+                        grp, runner_only_attn_layers):
                     tensor_cfg = layer_to_tensor_cfg[layer_name]
                     assert tensor_cfg.size % layer_spec.page_size_bytes == 0, (
                         f"Tensor size for layer {layer_name} ({tensor_cfg.size}) "
@@ -1454,7 +1520,8 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             first_attn_group_id = None
             first_attn_group = None
             for idx, grp in enumerate(kv_cache_config.kv_cache_groups):
-                if _is_attention_spec(grp.kv_cache_spec):
+                if _is_attention_spec(grp.kv_cache_spec) and _tensor_backed_layer_names(
+                        grp, runner_only_attn_layers):
                     first_attn_group_id = idx
                     first_attn_group = grp
                     break
@@ -1462,13 +1529,15 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             if first_attn_group is None or first_attn_group_id is None:
                 raise RuntimeError(
                     "kvcached is enabled but the KV cache config contains no "
-                    "attention groups; nothing to allocate."
+                    "attention groups with tensor-backed layers; nothing to "
+                    "allocate."
                 )
 
             kv_cache_spec = first_attn_group.kv_cache_spec
             attention_type = _infer_attention_type(kv_cache_config)
 
-            first_layer_name = first_attn_group.layer_names[0]
+            first_layer_name = _tensor_backed_layer_names(
+                first_attn_group, runner_only_attn_layers)[0]
             rep_tensor_cfg = layer_to_tensor_cfg[first_layer_name]
             num_blocks = rep_tensor_cfg.size // kv_cache_spec.page_size_bytes
 
@@ -1532,7 +1601,7 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
             # KVCacheTensor sharing: pool i is shared by layer i from each
             # group, and different groups use different block IDs within the
             # same pool.
-            group_size = _get_group_size(kv_cache_config)
+            group_size = _get_group_size(kv_cache_config, runner_only_attn_layers)
             dtype = kv_cache_spec.dtype
             device_type = getattr(self, "device", torch.device("cuda")).type
 
@@ -1658,7 +1727,8 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                         meta["gpu_mem_bytes_per_layer_k_or_v"], meta["num_layers"],
                         kernel_block_size=gkbs,
                     )
-                    for pool_idx, layer_name in enumerate(grp.layer_names):
+                    for pool_idx, layer_name in enumerate(
+                            _tensor_backed_layer_names(grp, runner_only_attn_layers)):
                         layer_views[layer_name] = gviews[pool_idx]
                 self._kvcached_attn_layer_views = layer_views
             else:
@@ -1709,6 +1779,12 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
 
             kv_caches: dict[str, torch.Tensor] = {}
 
+            # Cross-layer KV sharing layers own no pool tensor: skip them in
+            # the pool-index mapping and alias them to their target's cache
+            # afterwards (issue #417), mirroring vanilla vLLM's
+            # _reshape_kv_cache_tensors / initialize_kv_cache_tensors.
+            runner_only_attn_layers = _get_runner_only_attn_layers(self)
+
             mamba_info = getattr(self, "_kvcached_mamba_raw_info", None)
             # Per-group attention views for heterogeneous hybrids (Gemma). None
             # for homogeneous / single-group models, which use the raw-tensor
@@ -1717,6 +1793,8 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
 
             for kv_cache_group in kv_cache_config.kv_cache_groups:
                 kv_cache_spec = kv_cache_group.kv_cache_spec
+                bound_layer_names = _tensor_backed_layer_names(
+                    kv_cache_group, runner_only_attn_layers)
 
                 if _is_mamba_spec(kv_cache_spec):
                     if mamba_info is None:
@@ -1724,7 +1802,7 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                             "Mamba layers found but no raw buffer info "
                             "available from kvcached"
                         )
-                    for pool_idx, layer_name in enumerate(kv_cache_group.layer_names):
+                    for pool_idx, layer_name in enumerate(bound_layer_names):
                         if mamba_info.get("is_contiguous"):
                             state_tensors = _reshape_mamba_contiguous(
                                 mamba_info, kv_cache_spec, pool_idx,
@@ -1737,11 +1815,14 @@ class GPUModelRunnerPatch(VersionAwarePatch, BasePatch):
                             )
                         kv_caches[layer_name] = state_tensors  # type: ignore[assignment]
                 else:
-                    for pool_idx, layer_name in enumerate(kv_cache_group.layer_names):
+                    for pool_idx, layer_name in enumerate(bound_layer_names):
                         if attn_layer_views is not None and layer_name in attn_layer_views:
                             kv_caches[layer_name] = attn_layer_views[layer_name]
                         else:
                             kv_caches[layer_name] = kv_cache_raw_tensors[pool_idx]
+
+            _alias_shared_kv_layers(
+                kv_caches, getattr(self, "shared_kv_cache_layers", None) or {})
 
             return kv_caches
 

--- a/tests/manifests/cpu.txt
+++ b/tests/manifests/cpu.txt
@@ -13,6 +13,7 @@ tests/test_resize_reserved_order.py
 tests/test_sglang_allocator_patch.py
 tests/test_sglang_autopatch_order.py
 tests/test_sglang_virtual_kv_capacity.py
+tests/test_shared_kv_layer_binding.py
 tests/test_shm_info_tracker.py
 tests/test_sleep_manager.py
 tests/test_test_classification.py

--- a/tests/test_shared_kv_layer_binding.py
+++ b/tests/test_shared_kv_layer_binding.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for cross-layer KV sharing support in the vLLM patches (#417).
+
+GPU-free: exercises the module-level helpers in
+``kvcached.integration.vllm.patches`` that the KV cache allocation and
+reshape closures use to handle layers vLLM registers in
+``kv_cache_groups[*].layer_names`` without a backing ``KVCacheTensor``
+(cross-layer KV sharing, e.g. gemma E2B). vLLM records those names in the
+runner's ``runner_only_attn_layers`` and never adds them to any tensor's
+``shared_by``; direct-indexing them against the layer-to-tensor map was the
+KeyError reported in issue #417.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from kvcached.integration.vllm.patches import (
+    _alias_shared_kv_layers,
+    _get_group_size,
+    _get_runner_only_attn_layers,
+    _tensor_backed_layer_names,
+)
+
+
+def _group(layer_names):
+    return SimpleNamespace(layer_names=list(layer_names), kv_cache_spec=None)
+
+
+def _config(groups):
+    return SimpleNamespace(kv_cache_groups=list(groups))
+
+
+class TestGetRunnerOnlyAttnLayers:
+
+    def test_missing_attribute_is_empty(self):
+        assert _get_runner_only_attn_layers(SimpleNamespace()) == frozenset()
+
+    def test_none_attribute_is_empty(self):
+        runner = SimpleNamespace(runner_only_attn_layers=None)
+        assert _get_runner_only_attn_layers(runner) == frozenset()
+
+    def test_populated_set_is_returned(self):
+        runner = SimpleNamespace(runner_only_attn_layers={"a", "b"})
+        assert _get_runner_only_attn_layers(runner) == frozenset({"a", "b"})
+
+
+class TestTensorBackedLayerNames:
+
+    def test_no_runner_only_layers_keeps_all_names_in_order(self):
+        grp = _group(["l0", "l1", "l2"])
+        assert _tensor_backed_layer_names(grp) == ["l0", "l1", "l2"]
+        assert _tensor_backed_layer_names(grp, frozenset()) == ["l0", "l1", "l2"]
+
+    def test_appended_sharing_layers_are_skipped(self):
+        # vLLM appends sharing layers after the tensor-backed ones.
+        grp = _group(["l0", "l1", "shared0", "shared1"])
+        assert _tensor_backed_layer_names(grp, {"shared0", "shared1"}) == ["l0", "l1"]
+
+    def test_group_with_only_runner_only_layers_is_empty(self):
+        grp = _group(["enc0", "enc1"])
+        assert _tensor_backed_layer_names(grp, {"enc0", "enc1"}) == []
+
+
+class TestGetGroupSize:
+
+    def test_without_runner_only_matches_raw_max(self):
+        cfg = _config([_group(["a0", "a1", "a2"]), _group(["b0", "b1"])])
+        assert _get_group_size(cfg) == 3
+
+    def test_sharing_layers_do_not_inflate_pool_count(self):
+        # gemma-E2B-style config: sharing layers appended to their target
+        # group must not increase the number of allocated pools, which has
+        # to stay equal to the scheduler-side num_layers (the scheduler's
+        # config never contains the appended names).
+        cfg = _config([
+            _group(["a0", "a1", "shared0", "shared1"]),
+            _group(["b0", "b1"]),
+        ])
+        assert _get_group_size(cfg) == 4
+        assert _get_group_size(cfg, {"shared0", "shared1"}) == 2
+
+
+class TestAliasSharedKvLayers:
+
+    def test_aliases_to_the_same_object(self):
+        target = object()
+        kv_caches = {"tgt": target}
+        _alias_shared_kv_layers(kv_caches, {"shared": "tgt"})
+        assert kv_caches["shared"] is target
+
+    def test_multiple_layers_share_one_target(self):
+        target = object()
+        kv_caches = {"tgt": target}
+        _alias_shared_kv_layers(kv_caches, {"s0": "tgt", "s1": "tgt"})
+        assert kv_caches["s0"] is target
+        assert kv_caches["s1"] is target
+
+    def test_empty_mapping_is_a_no_op(self):
+        kv_caches = {"tgt": object()}
+        _alias_shared_kv_layers(kv_caches, {})
+        assert set(kv_caches) == {"tgt"}
+
+    def test_missing_target_fails_loud(self):
+        with pytest.raises(RuntimeError, match="'gone'.*'shared'"):
+            _alias_shared_kv_layers({"tgt": object()}, {"shared": "gone"})
+
+
+class TestSharingScenario:
+    """End-to-end over the helpers, shaped like the #417 report.
+
+    Two attention groups of two tensor-backed layers each; vLLM appended two
+    sharing layers to group 0's layer_names and registered them as
+    runner-only, without touching any tensor's shared_by.
+    """
+
+    def setup_method(self):
+        self.tensors = [
+            SimpleNamespace(size=1024, shared_by=["a0", "b0"]),
+            SimpleNamespace(size=1024, shared_by=["a1", "b1"]),
+        ]
+        self.cfg = _config([
+            _group(["a0", "a1", "s0", "s1"]),
+            _group(["b0", "b1"]),
+        ])
+        self.runner = SimpleNamespace(
+            runner_only_attn_layers={"s0", "s1"},
+            shared_kv_cache_layers={"s0": "a0", "s1": "a1"},
+        )
+
+    def test_every_tensor_backed_layer_resolves(self):
+        # The exact lookup pattern that raised KeyError in #417: build the
+        # layer-to-tensor map from shared_by, then resolve every group layer.
+        layer_to_tensor_cfg = {}
+        for tensor_cfg in self.tensors:
+            for ln in tensor_cfg.shared_by:
+                layer_to_tensor_cfg[ln] = tensor_cfg
+
+        runner_only = _get_runner_only_attn_layers(self.runner)
+        resolved = []
+        for grp in self.cfg.kv_cache_groups:
+            for layer_name in _tensor_backed_layer_names(grp, runner_only):
+                resolved.append(layer_to_tensor_cfg[layer_name])  # must not raise
+        assert len(resolved) == 4
+        # Without the filter the same loop raises KeyError on the appended name.
+        with pytest.raises(KeyError):
+            for grp in self.cfg.kv_cache_groups:
+                for layer_name in grp.layer_names:
+                    layer_to_tensor_cfg[layer_name]
+
+    def test_pool_binding_and_aliasing_cover_all_layers(self):
+        runner_only = _get_runner_only_attn_layers(self.runner)
+        pools = [object(), object()]
+        assert _get_group_size(self.cfg, runner_only) == len(pools)
+
+        kv_caches = {}
+        for grp in self.cfg.kv_cache_groups:
+            for pool_idx, layer_name in enumerate(
+                    _tensor_backed_layer_names(grp, runner_only)):
+                kv_caches[layer_name] = pools[pool_idx]
+        _alias_shared_kv_layers(kv_caches, self.runner.shared_kv_cache_layers)
+
+        assert set(kv_caches) == {"a0", "a1", "b0", "b1", "s0", "s1"}
+        assert kv_caches["s0"] is kv_caches["a0"]
+        assert kv_caches["s1"] is kv_caches["a1"]
+        # Pool i is shared by layer i of each group.
+        assert kv_caches["a0"] is pools[0] and kv_caches["b0"] is pools[0]
+        assert kv_caches["a1"] is pools[1] and kv_caches["b1"] is pools[1]


### PR DESCRIPTION
## Summary

Fixes #417. Models with cross-layer KV sharing (gemma E2B) crashed at startup with `KeyError: '...self_attn.attn'` in kvcached's layer-to-tensor binding. Skip the sharing layers wherever a layer is resolved against `kv_cache_tensors`, then alias each one to its target layer's cache, mirroring vanilla vLLM's `initialize_kv_cache_tensors`.

## Root cause

vLLM's `maybe_add_kv_sharing_layers_to_kv_cache_groups` appends sharing-layer names to `kv_cache_groups[*].layer_names` and records them in the runner's `runner_only_attn_layers` WITHOUT adding them to any `kv_cache_tensors[*].shared_by` (verified identical on 0.22.1/0.23.0/0.24.0, `v1/worker/utils.py`). Vanilla vLLM copes by skipping `runner_only_attn_layers` in `_allocate_kv_cache_tensors` / `_reshape_kv_cache_tensors` and aliasing `kv_caches[layer] = kv_caches[target]` after allocation (`gpu_model_runner.py:7064/:7115/:7266` at v0.24.0). kvcached's `_allocate_kv_cache_from_kvcached` did neither and direct-indexed every `grp.layer_names` entry, which is the KeyError site.

The appended names also inflated `_get_group_size`, so the worker would have allocated more pools than the scheduler-side `num_layers` (the scheduler's config never contains the appended names, the append is runner-side only).

## Changes

`kvcached/integration/vllm/patches.py`:
- New helpers `_get_runner_only_attn_layers`, `_tensor_backed_layer_names`, `_alias_shared_kv_layers`; `_get_group_size` takes an optional runner-only set (default keeps the old behavior; the scheduler-side call is unchanged).
- `_allocate_kv_cache_from_kvcached`: resolve only tensor-backed layer names in the validation loop, representative-layer selection, pool count, and the per-group hetero views.
- `_reshape_kv_cache_tensors_from_kvcached`: bind pools to tensor-backed names only, then alias sharing layers to their target's cache (fail-loud if the target has no cache). On vLLM releases whose vanilla `initialize_kv_cache_tensors` also aliases after the patched reshape returns, the second pass re-assigns the same objects.
- The V8 path (`kv_cache_config.tensors` schema) predates cross-layer sharing and is untouched.

`tests/test_shared_kv_layer_binding.py` (added to `tests/manifests/cpu.txt`): 14 CPU tests over the helpers, including a scenario shaped like the #417 report that reproduces the KeyError without the filter and a full binding+aliasing pass with it.

## Validation

- `python3.11 -m pytest tests/test_shared_kv_layer_binding.py`: 14 passed.
- Full CPU manifest: 190 passed (176 on main + 14 new); the 10 local errors are the pre-existing macOS /dev/shm + posix_ipc environment issues, unchanged from main.
- `tools/check_test_classification.py`: valid (cpu=23).
- ruff 0.11.7, isort 6.0.1 clean; `mypy --python-version 3.10` introduces no new errors vs main (error set identical).
- `git merge-tree --write-tree`: merges clean against open PRs #418/#455/#465 (2026-08-26).
- GPU, 1x L40S, vLLM 0.24.0, transformers 5.14.1, google/gemma-4-E2B-it, autopatch engaged (all 9 patches logged; note the issue's earlier PASS reports were measured with autopatch silently inactive, see #470):
  - main + a diagnostic log at the KeyError site: `sharing_active=True num_shared=20`, `group_layer_names=35 tensor_backed(shared_by)=15`, 20 layer names in groups but absent from every `shared_by`, then startup dies with `KeyError: 'language_model.model.layers.15.self_attn.attn'` in EngineCore.
  - this branch, same env and run: starts and completes the generation cell cleanly, zero KeyErrors.
  - Byte-level output parity vs vanilla was not re-measured in this session (main cannot start at all, so there is no kvcached-on baseline to compare before this fix); happy to add a parity run if wanted.
