### PR TITLE
feat: add capability discovery to the observability contract

### DIFF
--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -33,6 +33,13 @@ _contiguous_layout = CONTIGUOUS_LAYOUT
 _world_size: int = 1
 _pp_rank: int = 0
 
+# Single source of truth for what this shim accepts. The capability record
+# in kvcached.observability reports these, so the guards below and the
+# reported record cannot drift apart. SUPPORTED_KV_LAYOUTS is enforced for
+# MHA/GQA only; the MLA path ignores the layout argument.
+SUPPORTED_ATTENTION_TYPES = ("MHA", "GQA", "MLA")
+SUPPORTED_KV_LAYOUTS = ("NHD",)
+
 
 def init_kvcached(
     tp_rank: int = 0,
@@ -120,11 +127,11 @@ def alloc_kv_cache(
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
 
-    if attention_type not in ["MHA", "GQA", "MLA"]:
+    if attention_type not in SUPPORTED_ATTENTION_TYPES:
         raise ValueError(f"Attention type {attention_type} is not supported.")
 
     is_mla = attention_type == "MLA"
-    if not is_mla and kv_layout != "NHD":
+    if not is_mla and kv_layout not in SUPPORTED_KV_LAYOUTS:
         raise ValueError(f"KV layout {kv_layout} is not supported.")
 
     num_k_or_v = 1 if is_mla else 2

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -34,6 +34,12 @@ _pp_rank: int = 0
 _contiguous_layout: bool = CONTIGUOUS_LAYOUT
 _is_worker: bool = False
 
+# Single source of truth for what this shim accepts. The capability record
+# in kvcached.observability reports these, so the guards below and the
+# reported record cannot drift apart.
+SUPPORTED_ATTENTION_TYPES = ("MHA", "GQA", "MLA", "HYBRID_LINEAR")
+SUPPORTED_KV_LAYOUTS = ("NHD",)
+
 
 def should_use_worker_ipc() -> bool:
     return _kvcached_initialized and not _is_worker
@@ -313,10 +319,10 @@ def alloc_kv_cache(
     if not _kvcached_initialized:
         raise RuntimeError("kvcached is not initialized. Please call init_kvcached() first.")
 
-    if attention_type not in ["MHA", "GQA", "MLA", "HYBRID_LINEAR"]:
+    if attention_type not in SUPPORTED_ATTENTION_TYPES:
         raise ValueError(f"Attention type {attention_type} is not supported.")
 
-    if kv_layout != "NHD":
+    if kv_layout not in SUPPORTED_KV_LAYOUTS:
         raise ValueError(f"KV layout {kv_layout} is not supported.")
 
     is_mla = attention_type == "MLA"

--- a/kvcached/observability.py
+++ b/kvcached/observability.py
@@ -14,6 +14,7 @@ from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional
 
 from kvcached.pool_registry import get_registered_kv_cache_pools
+from kvcached.utils import CONTIGUOUS_LAYOUT, PAGE_SIZE
 
 SCHEMA_VERSION = "kvcached.observability.v1"
 
@@ -115,8 +116,81 @@ class KVCachePoolSnapshot:
         return asdict(self)
 
 
+def _get_backend_capabilities() -> Dict[str, Any]:
+    """Report allocator-level capabilities shared by every integration.
+
+    These describe the kvcached core, not a particular engine shim. Per-engine
+    differences (which attention types a shim actually accepts, for example)
+    live under ``integrations``.
+    """
+
+    return {
+        "kv_pooling": True,
+        # Physical pages are mapped and unmapped on demand under a virtual
+        # reservation, which is what makes the pool elastic.
+        "elastic_capacity": True,
+        # resize() lowers addressable capacity, draining lazily through the
+        # in_shrink state machine rather than revoking live blocks.
+        "resize": True,
+        # trim() releases pages held by the background pre-allocation thread.
+        "trim": True,
+        "page_size_bytes": PAGE_SIZE,
+        "contiguous_layout_default": CONTIGUOUS_LAYOUT,
+        # kvcached accounts for non-KV device memory but never manages it.
+        "non_kv_memory_management": False,
+    }
+
+
+def _get_integration_capabilities() -> Dict[str, Any]:
+    """Report per-engine capabilities.
+
+    Reported statically from the shim contracts in
+    ``kvcached.integration.<engine>.interfaces`` so the record can be queried
+    without importing torch or attaching to a running engine.
+    """
+
+    return {
+        "vllm": {
+            "attention_types": ["MHA", "GQA", "MLA", "HYBRID_LINEAR"],
+            "kv_layouts": ["NHD"],
+            # Hybrid attention + linear/SSM (mamba) state is carved out of the
+            # same pool via the HYBRID_LINEAR attention type.
+            "hybrid_linear_state_pooling": True,
+            # Prefix-cache blocks are evicted page-aware so eviction actually
+            # releases physical memory.
+            "prefix_caching": True,
+            "page_aware_eviction": True,
+            "worker_ipc": True,
+        },
+        "sglang": {
+            "attention_types": ["MHA", "GQA", "MLA"],
+            "kv_layouts": ["NHD"],
+            # SGLang allocates mamba/linear state through a separate
+            # alloc_mamba_states() entry point rather than the KV pool.
+            "hybrid_linear_state_pooling": True,
+            "prefix_caching": True,
+            "page_aware_eviction": False,
+            "worker_ipc": True,
+        },
+    }
+
+
 def get_capabilities() -> Dict[str, Any]:
-    """Return the stable observability surface currently exposed by kvcached."""
+    """Return the stable extension surface currently exposed by kvcached.
+
+    Consumers should feature-detect against this record rather than pinning a
+    kvcached version or inspecting private allocator/patch attributes.
+
+    Compatibility rule: new optional keys are added without bumping
+    ``schema_version``, so a consumer must treat a missing key as "unsupported"
+    rather than an error. ``schema_version`` only changes when the meaning of
+    an existing key changes incompatibly.
+
+    ``features`` reports surfaces that either exist or are known-planned; a
+    surface that has not landed yet is reported ``False`` instead of being
+    omitted, so a consumer can write the detection once and have it start
+    returning ``True`` when the surface ships.
+    """
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -126,9 +200,22 @@ def get_capabilities() -> Dict[str, Any]:
             "registered_kv_cache_pool_snapshots": True,
             "read_only": True,
             "policy_control": False,
+            # Revisioned instance memory limits. This is the one write path on
+            # the surface: the caller owns quota policy, kvcached only stores
+            # and enforces the assigned cap through the resize()/in_shrink
+            # state machine.
+            "instance_memory_limit": True,
+            # Allocator-owned operation counters. Not landed yet.
+            "operation_counters": False,
+            # Runtime reservation reporting for non-KV memory. Not landed yet.
+            "runtime_reservation_reporting": False,
         },
+        "backends": _get_backend_capabilities(),
+        "integrations": _get_integration_capabilities(),
         "pool_snapshot_fields": list(KVCachePoolSnapshot.__dataclass_fields__.keys()),
         "runtime_snapshot_fields": list(RuntimeSnapshot.__dataclass_fields__.keys()),
+        # Enumerates the counters exposed once operation observability lands.
+        "operation_counters": [],
     }
 
 

--- a/kvcached/observability.py
+++ b/kvcached/observability.py
@@ -134,7 +134,12 @@ def _get_backend_capabilities() -> Dict[str, Any]:
         "resize": True,
         # trim() releases pages held by the background pre-allocation thread.
         "trim": True,
-        "page_size_bytes": PAGE_SIZE,
+        # Both values below are read from the environment when
+        # ``kvcached.utils`` is imported, so they describe THIS process, not a
+        # live engine. A control plane importing kvcached out of process sees
+        # its own environment. For the runtime page size of a specific pool,
+        # read ``KVCachePoolSnapshot.page_size_bytes`` instead.
+        "default_page_size_bytes": PAGE_SIZE,
         "contiguous_layout_default": CONTIGUOUS_LAYOUT,
         # kvcached accounts for non-KV device memory but never manages it.
         "non_kv_memory_management": False,
@@ -146,7 +151,9 @@ def _get_integration_capabilities() -> Dict[str, Any]:
 
     Reported statically from the shim contracts in
     ``kvcached.integration.<engine>.interfaces`` so the record can be queried
-    without importing torch or attaching to a running engine.
+    without importing an engine shim or attaching to a running engine.
+    (Importing ``kvcached`` itself still requires torch; see
+    ``kvcached/__init__.py``.)
     """
 
     return {
@@ -154,8 +161,10 @@ def _get_integration_capabilities() -> Dict[str, Any]:
             "attention_types": ["MHA", "GQA", "MLA", "HYBRID_LINEAR"],
             "kv_layouts": ["NHD"],
             # Hybrid attention + linear/SSM (mamba) state is carved out of the
-            # same pool via the HYBRID_LINEAR attention type.
+            # same pool via the HYBRID_LINEAR attention type, so that state is
+            # visible in this pool's KVCachePoolSnapshot.
             "hybrid_linear_state_pooling": True,
+            "hybrid_linear_state_pooling_mode": "unified_pool",
             # Prefix-cache blocks are evicted page-aware so eviction actually
             # releases physical memory.
             "prefix_caching": True,
@@ -164,10 +173,15 @@ def _get_integration_capabilities() -> Dict[str, Any]:
         },
         "sglang": {
             "attention_types": ["MHA", "GQA", "MLA"],
+            # Validated for MHA/GQA only; the SGLang shim skips the layout
+            # check for MLA, where the argument is ignored rather than
+            # rejected.
             "kv_layouts": ["NHD"],
             # SGLang allocates mamba/linear state through a separate
-            # alloc_mamba_states() entry point rather than the KV pool.
+            # alloc_mamba_states() entry point rather than the KV pool, so
+            # that state does NOT appear in this pool's KVCachePoolSnapshot.
             "hybrid_linear_state_pooling": True,
+            "hybrid_linear_state_pooling_mode": "separate_allocation",
             "prefix_caching": True,
             "page_aware_eviction": False,
             "worker_ipc": True,
@@ -214,8 +228,10 @@ def get_capabilities() -> Dict[str, Any]:
         "integrations": _get_integration_capabilities(),
         "pool_snapshot_fields": list(KVCachePoolSnapshot.__dataclass_fields__.keys()),
         "runtime_snapshot_fields": list(RuntimeSnapshot.__dataclass_fields__.keys()),
-        # Enumerates the counters exposed once operation observability lands.
-        "operation_counters": [],
+        # Names the counters exposed once operation observability lands. Kept
+        # coupled to features["operation_counters"]: this list is non-empty if
+        # and only if that flag is True.
+        "operation_counter_names": [],
     }
 
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -24,6 +24,7 @@ from kvcached.pool_registry import (  # noqa: E402
     clear_registered_kv_cache_pools,
     register_kv_cache_pool,
 )
+from kvcached.utils import PAGE_SIZE  # noqa: E402
 
 
 class FakePageAllocator:
@@ -432,8 +433,11 @@ def test_capabilities_expose_backend_and_integration_records():
     assert backends["elastic_capacity"] is True
     # kvcached accounts for non-KV memory but never manages it.
     assert backends["non_kv_memory_management"] is False
-    assert isinstance(backends["page_size_bytes"], int)
-    assert backends["page_size_bytes"] > 0
+    # Named "default_" because it is this process's import-time env value, not
+    # a live engine's page size; consumers needing the runtime value read
+    # KVCachePoolSnapshot.page_size_bytes.
+    assert backends["default_page_size_bytes"] == PAGE_SIZE
+    assert "page_size_bytes" not in backends
 
     integrations = capabilities["integrations"]
     assert set(integrations) == {"vllm", "sglang"}
@@ -447,6 +451,36 @@ def test_capabilities_expose_backend_and_integration_records():
     # allocates mamba state through a separate entry point.
     assert "HYBRID_LINEAR" in integrations["vllm"]["attention_types"]
     assert "HYBRID_LINEAR" not in integrations["sglang"]["attention_types"]
+
+
+def test_hybrid_linear_pooling_mode_distinguishes_the_two_shapes():
+    """The bool alone cannot answer "is that state in the pool snapshot?".
+
+    Both shims report hybrid_linear_state_pooling True, but vLLM carves the
+    state out of the KV pool (so it shows up in KVCachePoolSnapshot) while
+    SGLang allocates it separately (so it does not). Consumers branch on the
+    mode rather than parsing comments.
+    """
+    integrations = get_capabilities()["integrations"]
+
+    for entry in integrations.values():
+        assert entry["hybrid_linear_state_pooling"] is True
+
+    assert integrations["vllm"]["hybrid_linear_state_pooling_mode"] == "unified_pool"
+    assert (
+        integrations["sglang"]["hybrid_linear_state_pooling_mode"]
+        == "separate_allocation"
+    )
+
+
+def test_operation_counter_names_stay_coupled_to_their_feature_flag():
+    """One flip when #410 lands, not two that can drift apart."""
+    capabilities = get_capabilities()
+
+    flag = capabilities["features"]["operation_counters"]
+    names = capabilities["operation_counter_names"]
+
+    assert bool(names) == flag
 
 
 def test_capabilities_enumerate_snapshot_fields_for_feature_detection():
@@ -463,7 +497,7 @@ def test_capabilities_enumerate_snapshot_fields_for_feature_detection():
     assert set(snapshot.to_dict()) == set(pool_fields)
 
     # No counters until operation observability lands.
-    assert capabilities["operation_counters"] == []
+    assert capabilities["operation_counter_names"] == []
 
 
 def test_capabilities_record_is_json_serializable_and_stable():
@@ -494,3 +528,4 @@ def test_capabilities_need_no_private_field_access():
     assert_public(capabilities)
     for field_name in capabilities["pool_snapshot_fields"]:
         assert not field_name.startswith("_")
+

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -13,6 +13,8 @@ if "torch" not in sys.modules and importlib.util.find_spec("torch") is None:
     sys.modules.setdefault("torch", types.ModuleType("torch"))
 
 from kvcached.observability import (  # noqa: E402
+    KVCachePoolSnapshot,
+    RuntimeSnapshot,
     build_kv_cache_pool_snapshot,
     build_runtime_snapshot,
     get_capabilities,
@@ -406,3 +408,89 @@ def test_vllm_manager_factory_registers_and_shutdown_clears_pool(monkeypatch):
 
     interfaces.shutdown_kvcached()
     assert interfaces.kv_cache_pool_snapshot_dicts() == []
+
+
+def test_capabilities_report_planned_surfaces_as_unsupported():
+    """Unlanded surfaces are reported False, never omitted.
+
+    A consumer writes the detection once against a build that predates the
+    surface; the same code starts returning True when it ships.
+    """
+    features = get_capabilities()["features"]
+
+    assert features["operation_counters"] is False
+    assert features["runtime_reservation_reporting"] is False
+    # Landed in #414: the one write path on the surface.
+    assert features["instance_memory_limit"] is True
+
+
+def test_capabilities_expose_backend_and_integration_records():
+    capabilities = get_capabilities()
+
+    backends = capabilities["backends"]
+    assert backends["kv_pooling"] is True
+    assert backends["elastic_capacity"] is True
+    # kvcached accounts for non-KV memory but never manages it.
+    assert backends["non_kv_memory_management"] is False
+    assert isinstance(backends["page_size_bytes"], int)
+    assert backends["page_size_bytes"] > 0
+
+    integrations = capabilities["integrations"]
+    assert set(integrations) == {"vllm", "sglang"}
+    for entry in integrations.values():
+        assert "MHA" in entry["attention_types"]
+        assert "MLA" in entry["attention_types"]
+        assert entry["kv_layouts"] == ["NHD"]
+
+    # A real, code-level distinction between the two shims: only the vLLM
+    # integration accepts HYBRID_LINEAR through alloc_kv_cache(); SGLang
+    # allocates mamba state through a separate entry point.
+    assert "HYBRID_LINEAR" in integrations["vllm"]["attention_types"]
+    assert "HYBRID_LINEAR" not in integrations["sglang"]["attention_types"]
+
+
+def test_capabilities_enumerate_snapshot_fields_for_feature_detection():
+    """Field lists must match the dataclasses consumers actually receive."""
+    capabilities = get_capabilities()
+
+    pool_fields = capabilities["pool_snapshot_fields"]
+    runtime_fields = capabilities["runtime_snapshot_fields"]
+
+    assert pool_fields == list(KVCachePoolSnapshot.__dataclass_fields__.keys())
+    assert runtime_fields == list(RuntimeSnapshot.__dataclass_fields__.keys())
+
+    snapshot = build_kv_cache_pool_snapshot(FakeManager(), integration="vllm")
+    assert set(snapshot.to_dict()) == set(pool_fields)
+
+    # No counters until operation observability lands.
+    assert capabilities["operation_counters"] == []
+
+
+def test_capabilities_record_is_json_serializable_and_stable():
+    """The whole record must survive an exporter round-trip unchanged."""
+    capabilities = get_capabilities()
+
+    assert json.loads(json.dumps(capabilities)) == capabilities
+    assert get_capabilities() == capabilities
+
+
+def test_capabilities_need_no_private_field_access():
+    """A consumer reads the record through public keys only.
+
+    Guards the contract in #375: integrations must not have to reach into
+    allocator internals or applied-patch attributes to learn what is supported.
+    """
+    capabilities = get_capabilities()
+
+    def assert_public(node):
+        if isinstance(node, dict):
+            for key, value in node.items():
+                assert not key.startswith("_"), f"private key exposed: {key}"
+                assert_public(value)
+        elif isinstance(node, list):
+            for item in node:
+                assert_public(item)
+
+    assert_public(capabilities)
+    for field_name in capabilities["pool_snapshot_fields"]:
+        assert not field_name.startswith("_")

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -529,3 +529,59 @@ def test_capabilities_need_no_private_field_access():
     for field_name in capabilities["pool_snapshot_fields"]:
         assert not field_name.startswith("_")
 
+
+
+def _load_shim_under_stubs(engine, monkeypatch):
+    """Import an engine shim with its heavy deps stubbed out.
+
+    Same approach as the factory tests above, reduced to what module import
+    needs: the shim's module-level constants, not a working engine.
+    """
+    torch = types.ModuleType("torch")
+    setattr(torch, "dtype", object)
+    setattr(torch, "Tensor", object)
+    setattr(torch, "cuda", types.SimpleNamespace(current_device=lambda: 0))
+
+    manager_module = types.ModuleType("kvcached.kv_cache_manager")
+    setattr(manager_module, "KVCacheManager", object)
+
+    tp_ipc_module = types.ModuleType("kvcached.tp_ipc_util")
+    setattr(tp_ipc_module, "start_worker_listener_thread", lambda *args: None)
+
+    vmm_ops_module = types.ModuleType("kvcached.vmm_ops")
+    setattr(vmm_ops_module, "create_kv_tensors", lambda *args, **kwargs: [])
+    setattr(vmm_ops_module, "init_kvcached", lambda *args, **kwargs: None)
+    setattr(vmm_ops_module, "shutdown_kvcached", lambda: None)
+
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "kvcached.kv_cache_manager", manager_module)
+    monkeypatch.setitem(sys.modules, "kvcached.tp_ipc_util", tp_ipc_module)
+    monkeypatch.setitem(sys.modules, "kvcached.vmm_ops", vmm_ops_module)
+
+    module_path = (
+        Path(__file__).parents[1] / "kvcached" / "integration" / engine / "interfaces.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        f"_test_{engine}_interfaces_constants", module_path
+    )
+    assert spec is not None and spec.loader is not None
+    shim = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(shim)
+    return shim
+
+
+def test_reported_attention_types_match_the_shim_guards(monkeypatch):
+    """The record must not drift from the guards it claims to describe.
+
+    Both are derived from the shim's SUPPORTED_* constants, so adding an
+    attention type to a shim without updating the other side fails here
+    instead of silently shipping a stale record.
+    """
+    integrations = get_capabilities()["integrations"]
+
+    for engine in ("vllm", "sglang"):
+        shim = _load_shim_under_stubs(engine, monkeypatch)
+        assert integrations[engine]["attention_types"] == list(
+            shim.SUPPORTED_ATTENTION_TYPES
+        )
+        assert integrations[engine]["kv_layouts"] == list(shim.SUPPORTED_KV_LAYOUTS)


### PR DESCRIPTION
Implements item (3), capability discovery, from #375.

Extends the existing `get_capabilities()` contract from #385 rather than adding a
parallel entry point or a second schema, per the coordination in that thread.

## What it adds

- **`features`** — three additive keys. `instance_memory_limit` reports `True`
  (landed in #414); `operation_counters` and `runtime_reservation_reporting`
  report `False` until #410 and item (4) land. Unlanded surfaces are reported
  `False` rather than omitted, so a consumer writes the detection once and the
  same code starts returning `True` when the surface ships.
- **`backends`** — allocator-level capabilities shared by every integration:
  KV pooling, elastic capacity, resize, trim, page size, the contiguous-layout
  default, and `non_kv_memory_management: False` to record the boundary agreed
  upthread (kvcached accounts for non-KV memory, never manages it).
- **`integrations`** — per-engine entries for vLLM and SGLang covering attention
  types, KV layouts, hybrid/linear state pooling, prefix caching, page-aware
  eviction, and worker IPC. These are real code-level distinctions today: only
  the vLLM shim accepts `HYBRID_LINEAR` through `alloc_kv_cache()`, and only vLLM
  evicts prefix-cache blocks page-aware. Reported statically from the shim
  contracts, so the record is queryable without importing torch or attaching to a
  running engine.
- **`operation_counters`** — empty list, enumerating the counters exposed once
  #410 lands.

Lifecycle/readiness is deliberately not included here: per the split agreed with
@rishabhsinha17, that key belongs to item (5) and lands with it.

## Compatibility

No schema bump. New optional keys are additive, so `schema_version` stays
`kvcached.observability.v1`; consumers must treat a missing key as unsupported.
The rule is documented on `get_capabilities()`. No behavior changes and no new
state — the record is read-only and derived from existing contracts.

## Tests

Five CPU-only contract tests added to `tests/test_observability.py`, following the
existing mocked-extension pattern:

- planned surfaces report `False` rather than being omitted;
- backend and integration records, including the vLLM/SGLang `HYBRID_LINEAR` split;
- enumerated snapshot fields match the dataclasses consumers actually receive;
- the whole record survives a JSON round-trip and is stable across calls;
- no private-field access anywhere in the record (recursive check).

`tests/test_observability.py` passes (14 tests), as do `test_page_allocator_snapshot.py`
and `test_memory_limit_control.py`. ruff, isort, codespell, and mypy pass via
pre-commit.
