### PR TITLE
fix(controller): send the vLLM sleep level as a query parameter

### DIFF
--- a/controller/sleep_manager.py
+++ b/controller/sleep_manager.py
@@ -306,14 +306,19 @@ class SleepManager:
                                    host: str,
                                    port: str,
                                    level: int = 1) -> bool:
-        """Call vLLM's sleep API endpoint"""
+        """Call vLLM's sleep API endpoint.
+
+        vLLM reads ``level`` from the query string
+        (``raw_request.query_params.get("level", "1")``) and ignores the
+        request body, so the level must be sent as a query parameter.
+        """
         url = f"http://{host}:{port}/sleep"
-        payload = {"level": str(level)}
+        params = {"level": str(level)}
 
         try:
             async with aiohttp.ClientSession() as session:
                 async with session.post(
-                        url, json=payload,
+                        url, params=params,
                         timeout=aiohttp.ClientTimeout(total=30)) as response:
                     if response.status == 200:
                         logger.info(

--- a/tests/test_sleep_manager.py
+++ b/tests/test_sleep_manager.py
@@ -12,6 +12,8 @@ from pathlib import Path
 from typing import Dict, List
 
 import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
 
 # Add the controller directory to the path
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -346,6 +348,29 @@ async def test_sglang_api_methods_simulation(manager):
         assert is_sglang
     else:
         print("\n⚠ No SGLang models found in config, skipping model detection test")
+
+
+async def test_vllm_sleep_level_is_sent_as_query_parameter(manager):
+    """vLLM's /sleep route reads ``level`` from the query string and never
+    parses the body (``raw_request.query_params.get("level", "1")``), so the
+    level must travel as a query parameter or the engine always sleeps at
+    level 1 (issue #475). The fake server below mirrors the vLLM handler."""
+    seen: Dict[str, object] = {}
+
+    async def sleep(request: web.Request) -> web.Response:
+        seen["level"] = request.query.get("level", "1")
+        seen["body"] = await request.text()
+        return web.Response(status=200)
+
+    app = web.Application()
+    app.router.add_post("/sleep", sleep)
+    async with TestServer(app) as server:
+        ok = await manager._call_vllm_sleep_api(server.host, str(server.port),
+                                                level=2)
+
+    assert ok is True
+    assert seen["level"] == "2"
+    assert seen["body"] == ""
 
 
 async def main():


### PR DESCRIPTION
## Summary

`SleepManager._call_vllm_sleep_api()` posted the sleep level as a JSON body. vLLM reads `level` from the query string and never parses the body, so the engine always slept at level 1 while the controller logged success for whatever level it thought it sent.

## Root cause

`controller/sleep_manager.py` used `session.post(url, json={"level": ...})`. vLLM's `/sleep` handler does `raw_request.query_params.get("level", "1")` in every release from 0.7.3 to main (see #475).

## Changes

- Send the level as `params={"level": str(level)}`.
- `tests/test_sleep_manager.py`: a fake `/sleep` route that mirrors the vLLM handler asserts the query string carries the level and the body is empty. Fails on main (`'1' == '2'`), passes with the fix.

Scope is limited to request construction. Taking the level from `SleepConfig` instead of the hardcoded `level=1` in `put_model_to_sleep` can be a follow-up.

## Validation

- `PYTHONPATH=$PWD python -m pytest tests/test_sleep_manager.py -q`: 10 passed
- `tools/run_cpu_tests.sh`: 177 passed locally (the 10 errors are the pre-existing macOS ones: no `/dev/shm`, long socket paths)
- ruff, isort, mypy 3.10 clean
- Fork CI: CPU Tests 3.9-3.13 https://github.com/rishabhsinha17/kvcached/actions/runs/33644711817, Pre-commit/MyPy https://github.com/rishabhsinha17/kvcached/actions/runs/33644711825

Found while testing kvcached for vllm-project/aibrix#2419.

Fixes #475
