### PR TITLE
fix: remove TP worker socket dirs on shutdown and in kvctl delete

### DIFF
--- a/kvcached/cli/kvctl.py
+++ b/kvcached/cli/kvctl.py
@@ -74,7 +74,7 @@ Available commands:
   kvtop [ipc ...] [--refresh r]  Launch curses kvtop UI (q to quit)
   !<shell cmd>                 Run command in system shell
   help                         Show this help message
-  delete <ipc>                 Delete IPC segment and its limit entry
+  delete <ipc>                 Delete IPC segment and its worker socket dir
   exit | quit                  Exit the shell
 """
 
@@ -309,11 +309,15 @@ def cmd_top(ipcs: Optional[List[str]] = None, refresh: float = 1.0):
 
 
 def cmd_delete(ipc: str):
-    from kvcached.cli.utils import delete_kv_cache_segment
+    from kvcached.cli.utils import delete_kv_cache_segment, delete_tp_socket_dir
 
-    if delete_kv_cache_segment(ipc):
+    removed_segment = delete_kv_cache_segment(ipc)
+    removed_socket_dir = delete_tp_socket_dir(ipc)
+    if removed_segment:
         print(_clr(f"Deleted IPC '{ipc}'.", 'green'))
-    else:
+    if removed_socket_dir:
+        print(_clr(f"Removed worker socket dir for IPC '{ipc}'.", 'green'))
+    if not removed_segment and not removed_socket_dir:
         print(_clr(f"IPC '{ipc}' not found.", 'red', bold=True),
               file=sys.stderr)
 
@@ -451,7 +455,8 @@ def main():
     p_kvtop.add_argument('ipc', nargs='*', help='IPC names (optional)')
 
     # delete
-    p_del = sub.add_parser('delete', help='Delete IPC segment')
+    p_del = sub.add_parser('delete',
+                           help='Delete IPC segment and its worker socket dir')
     p_del.add_argument('ipc')
 
     # shell

--- a/kvcached/cli/utils.py
+++ b/kvcached/cli/utils.py
@@ -4,13 +4,14 @@
 import fcntl
 import mmap
 import os
+import shutil
 from dataclasses import dataclass
 from typing import Optional
 
 import numpy as np
 import posix_ipc
 
-from kvcached.utils import SHM_DIR
+from kvcached.utils import SHM_DIR, get_tp_socket_dir
 
 
 def get_ipc_path(ipc_name: str) -> str:
@@ -183,6 +184,19 @@ def delete_kv_cache_segment(ipc_name: str) -> bool:
         pass
 
     return removed
+
+
+def delete_tp_socket_dir(ipc_name: str) -> bool:
+    """Remove the TP worker socket directory an engine instance using
+    *ipc_name* created under /tmp (see kvcached.tp_ipc_util).
+
+    Returns True if the directory existed and was removed, False otherwise.
+    """
+    socket_dir = get_tp_socket_dir(get_ipc_name(ipc_name))
+    if not os.path.isdir(socket_dir):
+        return False
+    shutil.rmtree(socket_dir)
+    return True
 
 
 def get_total_gpu_memory() -> int:

--- a/kvcached/integration/sglang/interfaces.py
+++ b/kvcached/integration/sglang/interfaces.py
@@ -16,7 +16,7 @@ from kvcached.pool_registry import (
     clear_registered_kv_cache_pools,
     register_kv_cache_pool,
 )
-from kvcached.tp_ipc_util import start_worker_listener_thread
+from kvcached.tp_ipc_util import start_worker_listener_thread, stop_worker_listener_threads
 from kvcached.utils import CONTIGUOUS_LAYOUT, PAGE_SIZE, get_kvcached_logger, normalize_gpu_device
 from kvcached.vmm_ops import (
     create_kv_tensors,
@@ -67,6 +67,7 @@ def shutdown_kvcached() -> None:
         clear_registered_kv_cache_pools(integration="sglang")
         return
 
+    stop_worker_listener_threads()
     _shutdown_kvcached_impl()
     clear_registered_kv_cache_pools(integration="sglang")
     _kvcached_initialized = False

--- a/kvcached/integration/vllm/interfaces.py
+++ b/kvcached/integration/vllm/interfaces.py
@@ -16,7 +16,7 @@ from kvcached.pool_registry import (
     clear_registered_kv_cache_pools,
     register_kv_cache_pool,
 )
-from kvcached.tp_ipc_util import start_worker_listener_thread
+from kvcached.tp_ipc_util import start_worker_listener_thread, stop_worker_listener_threads
 from kvcached.utils import CONTIGUOUS_LAYOUT, PAGE_SIZE, get_kvcached_logger, normalize_gpu_device
 from kvcached.vmm_ops import (
     create_kv_tensors,
@@ -94,16 +94,18 @@ def init_kvcached(
 
 
 def shutdown_kvcached() -> None:
-    global _kvcached_initialized, _kvcached_device, _async_sched
+    global _kvcached_initialized, _kvcached_device, _async_sched, _is_worker
     if not _kvcached_initialized:
         clear_registered_kv_cache_pools(integration="vllm")
         return
 
+    stop_worker_listener_threads()
     _shutdown_kvcached_impl()
     clear_registered_kv_cache_pools(integration="vllm")
     _kvcached_initialized = False
     _kvcached_device = None
     _async_sched = False
+    _is_worker = False
 
 
 def build_kv_views(

--- a/kvcached/integration/vllm/patches.py
+++ b/kvcached/integration/vllm/patches.py
@@ -1912,7 +1912,51 @@ class GPUWorkerPatch(VersionAwarePatch, BasePatch):
         memory_profile_patched = self.patch_worker_determine_available_memory(
             gpuworker_mod
         )
-        return init_device_patched and memory_profile_patched
+        shutdown_patched = self.patch_worker_shutdown(gpuworker_mod)
+        return init_device_patched and memory_profile_patched and shutdown_patched
+
+    @version_range(VLLM_ALL_RANGE)
+    def patch_worker_shutdown(self, gpuworker_mod: types.ModuleType) -> bool:
+        """Patch Worker.shutdown to stop this worker's kvcached IPC listener.
+
+        vLLM runs Worker.shutdown() on every exit path that reaches
+        EngineCore.shutdown(): in-process through UniProcExecutor.shutdown()
+        and in each WorkerProc from worker_main()'s finally block. Stopping
+        the listener there unlinks the worker socket and removes the
+        /tmp/kvcached-tp-* directory instead of leaking it (issue #476).
+        """
+        Worker = self._get_target_class(gpuworker_mod)
+        if Worker is None:
+            return False
+
+        original_shutdown = getattr(Worker, "shutdown", None)
+        if original_shutdown is None:
+            # Releases without Worker.shutdown(): cleanup is left to
+            # shutdown_kvcached() and the interpreter-exit hook.
+            self.logger.debug("Worker.shutdown not found; skipping listener cleanup patch")
+            return True
+
+        if self._is_already_patched(original_shutdown, "shutdown"):
+            self.logger.debug("Worker.shutdown already patched")
+            return True
+
+        logger = self.logger  # Capture logger in closure
+
+        def _patched_shutdown(self, *args: Any, **kwargs: Any):
+            try:
+                return original_shutdown(self, *args, **kwargs)
+            finally:
+                if enable_kvcached():
+                    try:
+                        from kvcached.tp_ipc_util import stop_worker_listener_threads
+
+                        stop_worker_listener_threads()
+                    except Exception as e:
+                        logger.warning("Failed to stop the kvcached worker IPC listener: %s", e)
+
+        self._mark_as_patched(_patched_shutdown, "shutdown")
+        Worker.shutdown = _patched_shutdown  # type: ignore[assignment]
+        return True
 
     @version_range(VLLM_ALL_RANGE)
     def patch_worker_init_device(self, gpuworker_mod: types.ModuleType) -> bool:

--- a/kvcached/tp_ipc_util.py
+++ b/kvcached/tp_ipc_util.py
@@ -2,34 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import atexit
 import os
 import pickle
 import socket
 import threading
-import uuid
-from typing import Any, Dict, cast
+from typing import Any, Dict, Optional, Tuple, cast
 
-from kvcached.utils import DEFAULT_IPC_NAME
+from kvcached.utils import get_tp_socket_dir
 from kvcached.vmm_ops import kv_tensors_created, map_to_kv_tensors, unmap_from_kv_tensors
 
-
-def _get_socket_dir_name() -> str:
-    """
-    Build a human-readable, IPC-name-based directory with a short hash suffix.
-
-    This keeps the original text-based IPC name visible while adding a hash
-    for extra uniqueness. The hash is deterministic so all workers in the same
-    engine instance agree on the directory.
-    """
-    # Deterministic short hash derived from the base name
-    suffix = uuid.uuid5(uuid.NAMESPACE_DNS, DEFAULT_IPC_NAME).hex[:8]
-    return f"kvcached-tp-{DEFAULT_IPC_NAME}-{suffix}"
-
-
-# Socket directory for tensor parallel (TP) worker communication.
-# Unix domain socket paths are limited to 108 characters on Linux, so we keep
-# the directory name short and validate the final socket path length below.
-SOCKET_DIR = os.path.join("/tmp", _get_socket_dir_name())
+# Socket directory for tensor parallel (TP) worker communication:
+# /tmp/kvcached-tp-<ipc_name>-<hash>. Unix domain socket paths are limited to
+# 108 characters on Linux, so the name is kept short and the final socket path
+# length is validated below.
+SOCKET_DIR = get_tp_socket_dir()
 
 
 def get_worker_socket_path(rank: int, pp_rank: int = 0) -> str:
@@ -93,13 +80,90 @@ def recv_msg(sock: socket.socket) -> Message:
     return cast(Message, pickle.loads(data))
 
 
+class _WorkerListener:
+    """One worker's IPC listener: its bound socket, the directory holding it,
+    and the thread serving it."""
+
+    def __init__(self, rank: int, pp_rank: int, root_dir: str, socket_dir: str,
+                 socket_path: str, server_sock: socket.socket) -> None:
+        self.rank = rank
+        self.pp_rank = pp_rank
+        self.root_dir = root_dir
+        self.socket_dir = socket_dir
+        self.socket_path = socket_path
+        self.server_sock = server_sock
+        self.stop_event = threading.Event()
+        self.thread: Optional[threading.Thread] = None
+
+    def stop(self) -> None:
+        """Stop serving, unlink the socket, and remove the directory once no
+        other worker's socket is left in it."""
+        self.stop_event.set()
+        # accept() only returns on a connection, so make one to let the loop
+        # observe stop_event. If that fails the daemon thread simply dies
+        # with the process; the socket file is unlinked either way.
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as wake:
+                wake.settimeout(1.0)
+                wake.connect(self.socket_path)
+        except OSError:
+            pass
+        if self.thread is not None:
+            self.thread.join(timeout=1.0)
+        self.server_sock.close()
+        try:
+            os.unlink(self.socket_path)
+        except FileNotFoundError:
+            pass
+        _remove_dir_if_empty(self.socket_dir)
+        if self.socket_dir != self.root_dir:
+            _remove_dir_if_empty(self.root_dir)
+        print(f"Worker {self.rank} IPC listener stopped, removed {self.socket_path}")
+
+
+def _remove_dir_if_empty(path: str) -> None:
+    try:
+        os.rmdir(path)
+    except OSError:
+        # Still holds another worker's socket, or already gone.
+        pass
+
+
+_listeners: Dict[Tuple[int, int], _WorkerListener] = {}
+_listeners_lock = threading.Lock()
+_atexit_registered = False
+
+
+def stop_worker_listener_threads() -> None:
+    """Stop every worker IPC listener started in this process: close its
+    socket, unlink it, and remove the per-instance socket directory
+    (issue #476). Safe to call repeatedly and when nothing was started.
+    """
+    with _listeners_lock:
+        listeners = list(_listeners.values())
+        _listeners.clear()
+    for listener in listeners:
+        listener.stop()
+
+
 def start_worker_listener_thread(rank: int, pp_rank: int = 0):
     """
     Start a thread that listens for messages on the worker socket.
     pp_rank is used to create a PP-stage-specific subdirectory so that
     concurrent SGLang PP stages do not bind the same socket path.
+
+    The listener is registered so that stop_worker_listener_threads() (called
+    from the integrations' shutdown paths and at interpreter exit) can unlink
+    the socket and remove the directory again.
     """
-    socket_dir = os.path.join(SOCKET_DIR, f"pp{pp_rank}") if pp_rank > 0 else SOCKET_DIR
+    global _atexit_registered
+    with _listeners_lock:
+        previous = _listeners.pop((rank, pp_rank), None)
+    if previous is not None:
+        previous.stop()
+
+    root_dir = SOCKET_DIR
+    socket_dir = os.path.join(root_dir, f"pp{pp_rank}") if pp_rank > 0 else root_dir
     os.makedirs(socket_dir, exist_ok=True)
     socket_path = get_worker_socket_path(rank, pp_rank)
 
@@ -112,11 +176,19 @@ def start_worker_listener_thread(rank: int, pp_rank: int = 0):
     server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     server_sock.bind(socket_path)
     server_sock.listen()
+    listener = _WorkerListener(rank, pp_rank, root_dir, socket_dir, socket_path,
+                               server_sock)
 
     def listen_loop():
         print(f"Worker {rank} IPC listener started at {socket_path}")
         while True:
-            conn, _ = server_sock.accept()
+            try:
+                conn, _ = server_sock.accept()
+            except OSError:
+                break  # socket closed by stop()
+            if listener.stop_event.is_set():
+                conn.close()
+                break
             try:
                 msg: Message = recv_msg(conn)
                 # print(f"Worker {rank} received message: {msg}")
@@ -142,7 +214,13 @@ def start_worker_listener_thread(rank: int, pp_rank: int = 0):
                 conn.close()
 
     t = threading.Thread(target=listen_loop, daemon=True)
+    listener.thread = t
     t.start()
+    with _listeners_lock:
+        _listeners[(rank, pp_rank)] = listener
+        if not _atexit_registered:
+            atexit.register(stop_worker_listener_threads)
+            _atexit_registered = True
 
 
 # How long one worker-IPC exchange may take before it is treated as a failure.

--- a/kvcached/utils.py
+++ b/kvcached/utils.py
@@ -4,6 +4,8 @@
 import importlib.util
 import logging
 import os
+import uuid
+from typing import Optional
 
 
 class KVCachedConfigError(RuntimeError):
@@ -178,6 +180,25 @@ CONTIGUOUS_LAYOUT = _default_contiguous_layout()
 
 DEFAULT_IPC_NAME = _obtain_default_ipc_name()
 SHM_DIR = "/dev/shm"
+
+# Root of the per-instance TP worker socket directories (kvcached.tp_ipc_util).
+# The naming rule lives here, next to the IPC name, so tools that never load
+# the compiled extension (kvctl) can derive the directory from an IPC name.
+TP_SOCKET_DIR_ROOT = "/tmp"
+
+
+def get_tp_socket_dir(ipc_name: Optional[str] = None) -> str:
+    """Return the TP worker socket directory for *ipc_name* (default: this
+    instance's DEFAULT_IPC_NAME).
+
+    The directory keeps the IPC name readable and appends a short
+    deterministic hash, so every worker of one engine instance agrees on it.
+    Unix domain socket paths are limited to 108 characters on Linux; the
+    caller validates the final socket path length.
+    """
+    name = DEFAULT_IPC_NAME if ipc_name is None else ipc_name
+    suffix = uuid.uuid5(uuid.NAMESPACE_DNS, name).hex[:8]
+    return os.path.join(TP_SOCKET_DIR_ROOT, f"kvcached-tp-{name}-{suffix}")
 
 LOG_USE_COLOR = os.getenv("KVCACHED_LOG_COLOR", "true").lower() == "true"
 _UNIFORM_COLOR = os.getenv("KVCACHED_LOG_COLOR_CODE", "\033[36m")

--- a/tests/manifests/cpu.txt
+++ b/tests/manifests/cpu.txt
@@ -16,6 +16,7 @@ tests/test_sglang_virtual_kv_capacity.py
 tests/test_shm_info_tracker.py
 tests/test_sleep_manager.py
 tests/test_test_classification.py
+tests/test_tp_socket_cleanup.py
 tests/test_vllm_nixl_compat.py
 tests/test_vllm_pool_exhaustion.py
 tests/test_vllm_tp_world_size.py

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -270,6 +270,7 @@ def test_sglang_manager_factory_registers_and_shutdown_clears_pool(monkeypatch):
 
     tp_ipc_module = types.ModuleType("kvcached.tp_ipc_util")
     setattr(tp_ipc_module, "start_worker_listener_thread", lambda *args: None)
+    setattr(tp_ipc_module, "stop_worker_listener_threads", lambda: None)
 
     utils_module = types.ModuleType("kvcached.utils")
     setattr(utils_module, "CONTIGUOUS_LAYOUT", False)
@@ -355,6 +356,7 @@ def test_vllm_manager_factory_registers_and_shutdown_clears_pool(monkeypatch):
 
     tp_ipc_module = types.ModuleType("kvcached.tp_ipc_util")
     setattr(tp_ipc_module, "start_worker_listener_thread", lambda *args: None)
+    setattr(tp_ipc_module, "stop_worker_listener_threads", lambda: None)
 
     utils_module = types.ModuleType("kvcached.utils")
     setattr(utils_module, "CONTIGUOUS_LAYOUT", False)

--- a/tests/test_tp_socket_cleanup.py
+++ b/tests/test_tp_socket_cleanup.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""TP worker socket directories must not outlive the worker (issue #476).
+
+Every engine launch created /tmp/kvcached-tp-<ipc>-<hash>/w<rank>.sock, at
+TP=1 too, and nothing removed it: the listener served the socket until the
+process died and kvctl delete only knew about /dev/shm. These tests pin down
+the fix from three sides: stopping the listener unlinks the socket and the
+directory, vLLM's Worker.shutdown() stops it, and kvctl delete removes the
+directory derived from an IPC name.
+
+CPU-only: the compiled extension is stubbed if absent.
+"""
+
+import os
+import shutil
+import socket
+import sys
+import tempfile
+import types
+from unittest import mock
+
+import pytest
+
+
+def _install_fake_vmm_ops():
+    """Only when the compiled extension is unavailable (CPU-only CI): stub the
+    names tp_ipc_util imports for its worker side."""
+    fake = types.ModuleType("kvcached.vmm_ops")
+    fake.kv_tensors_created = lambda *a, **kw: True  # type: ignore[attr-defined]
+    fake.map_to_kv_tensors = lambda *a, **kw: None  # type: ignore[attr-defined]
+    fake.unmap_from_kv_tensors = lambda *a, **kw: None  # type: ignore[attr-defined]
+    sys.modules["kvcached.vmm_ops"] = fake
+
+
+try:
+    import kvcached.vmm_ops  # noqa: F401
+except Exception:  # noqa: BLE001 - any import failure means no GPU build
+    _install_fake_vmm_ops()
+
+import kvcached.utils  # noqa: E402
+from kvcached import tp_ipc_util  # noqa: E402
+from kvcached.cli import utils as cli_utils  # noqa: E402
+from kvcached.utils import get_tp_socket_dir  # noqa: E402
+
+IPC_NAME = "t"
+
+
+@pytest.fixture
+def socket_root(monkeypatch):
+    """A throwaway stand-in for /tmp. Deliberately not tmp_path: unix socket
+    paths are limited to ~104 characters on macOS."""
+    root = tempfile.mkdtemp(prefix="kvcached-test-",
+                            dir="/tmp" if os.path.isdir("/tmp") else None)
+    monkeypatch.setattr(kvcached.utils, "TP_SOCKET_DIR_ROOT", root)
+    monkeypatch.setattr(tp_ipc_util, "SOCKET_DIR", get_tp_socket_dir(IPC_NAME))
+    yield root
+    tp_ipc_util.stop_worker_listener_threads()
+    shutil.rmtree(root, ignore_errors=True)
+
+
+def _ask(socket_path, msg):
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+        s.settimeout(5)
+        s.connect(socket_path)
+        tp_ipc_util.send_msg(s, msg)
+        return tp_ipc_util.recv_msg(s)
+
+
+def test_socket_dir_is_derived_from_the_ipc_name(monkeypatch):
+    monkeypatch.setattr(kvcached.utils, "TP_SOCKET_DIR_ROOT", "/tmp")
+    first = get_tp_socket_dir("kvcached_vLLM_1234")
+    assert first.startswith("/tmp/kvcached-tp-kvcached_vLLM_1234-")
+    assert len(os.path.basename(first)) == len("kvcached-tp-kvcached_vLLM_1234-") + 8
+    assert get_tp_socket_dir("kvcached_vLLM_1234") == first
+    assert get_tp_socket_dir("kvcached_vLLM_1235") != first
+
+
+def test_stop_unlinks_socket_and_removes_directory(socket_root):
+    tp_ipc_util.start_worker_listener_thread(0)
+    path = tp_ipc_util.get_worker_socket_path(0)
+    listener = tp_ipc_util._listeners[(0, 0)]
+    assert os.path.exists(path)
+    assert _ask(path, {"cmd": "kv_tensors_created"})["status"] == "success"
+
+    tp_ipc_util.stop_worker_listener_threads()
+
+    assert listener.thread is not None and not listener.thread.is_alive()
+    assert not os.path.exists(path)
+    assert not os.path.exists(tp_ipc_util.SOCKET_DIR)
+    assert os.listdir(socket_root) == []
+
+
+def test_stop_removes_pp_stage_subdirectory(socket_root):
+    tp_ipc_util.start_worker_listener_thread(0, pp_rank=1)
+    path = tp_ipc_util.get_worker_socket_path(0, 1)
+    assert os.path.dirname(path) == os.path.join(tp_ipc_util.SOCKET_DIR, "pp1")
+    assert os.path.exists(path)
+
+    tp_ipc_util.stop_worker_listener_threads()
+
+    assert not os.path.exists(os.path.dirname(path))
+    assert not os.path.exists(tp_ipc_util.SOCKET_DIR)
+
+
+def test_stop_keeps_directory_while_another_worker_socket_remains(socket_root):
+    tp_ipc_util.start_worker_listener_thread(0)
+    other = tp_ipc_util.get_worker_socket_path(1)
+    open(other, "w").close()  # rank 1 lives in another process
+
+    tp_ipc_util.stop_worker_listener_threads()
+
+    assert not os.path.exists(tp_ipc_util.get_worker_socket_path(0))
+    assert os.path.exists(other)
+    assert os.path.isdir(tp_ipc_util.SOCKET_DIR)
+
+
+def test_restart_replaces_the_previous_listener(socket_root):
+    tp_ipc_util.start_worker_listener_thread(0)
+    first = tp_ipc_util._listeners[(0, 0)]
+    tp_ipc_util.start_worker_listener_thread(0)
+    second = tp_ipc_util._listeners[(0, 0)]
+
+    assert second is not first
+    assert first.thread is not None and not first.thread.is_alive()
+    assert _ask(tp_ipc_util.get_worker_socket_path(0),
+                {"cmd": "kv_tensors_created"})["status"] == "success"
+
+
+def test_stop_is_safe_without_listeners(socket_root):
+    tp_ipc_util.stop_worker_listener_threads()
+    tp_ipc_util.stop_worker_listener_threads()
+    assert os.listdir(socket_root) == []
+
+
+def test_worker_shutdown_stops_the_listener(monkeypatch):
+    from kvcached.integration.vllm import patches
+
+    monkeypatch.setattr(patches, "enable_kvcached", lambda: True)
+    stop = mock.Mock()
+    monkeypatch.setattr(tp_ipc_util, "stop_worker_listener_threads", stop)
+    calls = []
+
+    class Worker:
+        def shutdown(self):
+            stop.assert_not_called()  # vLLM's own teardown runs first
+            calls.append("shutdown")
+
+    gpu_worker_mod = types.ModuleType("mock_gpu_worker")
+    setattr(gpu_worker_mod, "Worker", Worker)
+    assert patches.GPUWorkerPatch().patch_worker_shutdown(gpu_worker_mod)
+    assert patches.GPUWorkerPatch().patch_worker_shutdown(gpu_worker_mod)  # idempotent
+
+    Worker().shutdown()
+
+    assert calls == ["shutdown"]
+    stop.assert_called_once_with()
+
+
+def test_worker_shutdown_stops_the_listener_even_if_vllm_teardown_raises(monkeypatch):
+    from kvcached.integration.vllm import patches
+
+    monkeypatch.setattr(patches, "enable_kvcached", lambda: True)
+    stop = mock.Mock()
+    monkeypatch.setattr(tp_ipc_util, "stop_worker_listener_threads", stop)
+
+    class Worker:
+        def shutdown(self):
+            raise RuntimeError("kv transfer teardown failed")
+
+    gpu_worker_mod = types.ModuleType("mock_gpu_worker")
+    setattr(gpu_worker_mod, "Worker", Worker)
+    assert patches.GPUWorkerPatch().patch_worker_shutdown(gpu_worker_mod)
+
+    with pytest.raises(RuntimeError, match="kv transfer"):
+        Worker().shutdown()
+    stop.assert_called_once_with()
+
+
+def test_worker_shutdown_patch_is_inert_when_kvcached_is_disabled(monkeypatch):
+    from kvcached.integration.vllm import patches
+
+    monkeypatch.setattr(patches, "enable_kvcached", lambda: False)
+    stop = mock.Mock()
+    monkeypatch.setattr(tp_ipc_util, "stop_worker_listener_threads", stop)
+
+    class Worker:
+        def shutdown(self):
+            pass
+
+    gpu_worker_mod = types.ModuleType("mock_gpu_worker")
+    setattr(gpu_worker_mod, "Worker", Worker)
+    assert patches.GPUWorkerPatch().patch_worker_shutdown(gpu_worker_mod)
+
+    Worker().shutdown()
+    stop.assert_not_called()
+
+
+def test_worker_without_shutdown_is_left_alone():
+    from kvcached.integration.vllm import patches
+
+    class Worker:
+        pass
+
+    gpu_worker_mod = types.ModuleType("mock_gpu_worker")
+    setattr(gpu_worker_mod, "Worker", Worker)
+    assert patches.GPUWorkerPatch().patch_worker_shutdown(gpu_worker_mod)
+    assert not hasattr(Worker, "shutdown")
+
+
+def test_delete_tp_socket_dir_removes_the_directory_by_ipc_name(socket_root):
+    socket_dir = get_tp_socket_dir(IPC_NAME)
+    os.makedirs(os.path.join(socket_dir, "pp1"))
+    open(os.path.join(socket_dir, "w0.sock"), "w").close()
+    open(os.path.join(socket_dir, "pp1", "w0.sock"), "w").close()
+
+    assert cli_utils.delete_tp_socket_dir(IPC_NAME) is True
+    assert not os.path.exists(socket_dir)
+    assert cli_utils.delete_tp_socket_dir(IPC_NAME) is False
+
+
+def test_delete_tp_socket_dir_accepts_a_shm_path(socket_root):
+    socket_dir = get_tp_socket_dir(IPC_NAME)
+    os.makedirs(socket_dir)
+
+    assert cli_utils.delete_tp_socket_dir(f"/dev/shm/{IPC_NAME}") is True
+    assert not os.path.exists(socket_dir)
+
+
+def test_kvctl_delete_reports_the_socket_dir(socket_root, monkeypatch, capsys):
+    from kvcached.cli import kvctl
+
+    monkeypatch.setattr(cli_utils, "delete_kv_cache_segment", lambda name: False)
+    os.makedirs(get_tp_socket_dir(IPC_NAME))
+
+    kvctl.cmd_delete(IPC_NAME)
+
+    out = capsys.readouterr()
+    assert "Removed worker socket dir" in out.out
+    assert "not found" not in out.err
+    assert not os.path.exists(get_tp_socket_dir(IPC_NAME))
+
+
+def test_kvctl_delete_reports_not_found_when_nothing_exists(socket_root, monkeypatch, capsys):
+    from kvcached.cli import kvctl
+
+    monkeypatch.setattr(cli_utils, "delete_kv_cache_segment", lambda name: False)
+
+    kvctl.cmd_delete(IPC_NAME)
+
+    assert "not found" in capsys.readouterr().err
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Every engine launch creates `/tmp/kvcached-tp-<ipc>-<hash>/w<rank>.sock`, at TP=1 too, and nothing removed it: the listener thread served the socket until the process died, and `kvctl delete` only knew about `/dev/shm`. One directory accumulates per launch (listing in #476).

## Root cause

`start_worker_listener_thread()` binds the socket in a daemon thread with no stop path, `shutdown_kvcached()` never touched it, and `kvctl delete` (`delete_kv_cache_segment()`) unlinks only the shm segment.

## Changes

- `kvcached/tp_ipc_util.py`: track each listener. `stop_worker_listener_threads()` wakes the accept loop, closes and unlinks the socket, and removes the directory (and the `pp<N>` subdirectory) once no other worker's socket is left in it. Also registered with `atexit` for clean exits.
- `kvcached/integration/vllm/patches.py`: `GPUWorkerPatch` also wraps `Worker.shutdown()`, which vLLM runs on every exit path that reaches `EngineCore.shutdown()`: in-process via `UniProcExecutor.shutdown()` at TP=1, and in each `WorkerProc` from `worker_main()`'s `finally` block. Releases without `Worker.shutdown` are left alone.
- `shutdown_kvcached()` (vLLM and SGLang) stops the listeners too.
- `kvcached/utils.py`: the directory naming rule moves next to `DEFAULT_IPC_NAME` as `get_tp_socket_dir(ipc_name)` so `kvctl` can derive it without loading the compiled extension. `kvctl delete <ipc>` now removes the directory as well and says so.

## Validation

- `tests/test_tp_socket_cleanup.py` (new, in the CPU manifest, 14 tests): stop unlinks the socket and removes the dir and the pp subdir, keeps the dir while another rank's socket is still in it, restart replaces the previous listener, the `Worker.shutdown` patch runs after vLLM's own teardown (also when that raises), is inert when kvcached is disabled and skipped when `Worker` has no `shutdown`; `delete_tp_socket_dir` by name and by `/dev/shm/<name>` path; `kvctl delete` output.
- `tools/run_cpu_tests.sh`: 190 passed locally (the 10 errors are the pre-existing macOS ones). ruff, isort, mypy 3.10 clean (same 13 pre-existing mypy notes as main).
- Fork CI: CPU Tests 3.9-3.13 https://github.com/rishabhsinha17/kvcached/actions/runs/33645641599, Pre-commit/MyPy https://github.com/rishabhsinha17/kvcached/actions/runs/33645641540
- Not yet run end to end on a GPU (`vllm serve`, SIGTERM, `ls /tmp/kvcached-tp-*`). The hooked path is the one vLLM 0.24 takes on SIGTERM (`run_engine_core` finally -> `EngineCore.shutdown` -> executor -> `Worker.shutdown`); I will add the on-pod check when I am back on the L40S.

Found while testing kvcached for vllm-project/aibrix#2419. The shm segment half of the same shutdown gap is #477.

Fixes #476
