### PR TITLE
fix: ship kvcached_autopatch.pth in editable installs and warn when it is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,12 @@ pip install kvcached --no-build-isolation
 # under the project root folder
 
 pip install -e . --no-build-isolation --no-cache-dir
-python tools/dev_copy_pth.py
 ```
+
+Both install `kvcached_autopatch.pth` into site-packages. That file registers
+the vLLM/SGLang import hooks; without it the engines run without kvcached and
+`import kvcached` warns. `python tools/dev_copy_pth.py --check` shows whether
+it is present and `python tools/dev_copy_pth.py` copies it by hand if needed.
 
 ### Using Docker
 

--- a/kvcached/__init__.py
+++ b/kvcached/__init__.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the kvcached project
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+import site
+import warnings
+
 # Version information
 from importlib.metadata import version
 
@@ -20,3 +24,47 @@ except ImportError as e:
             "  pip install torch>=2.6.0")
     else:
         raise
+
+AUTOPATCH_PTH = "kvcached_autopatch.pth"
+
+
+def _autopatch_requested() -> bool:
+    return any(
+        os.getenv(name, "false").lower() in ("true", "1")
+        for name in ("ENABLE_KVCACHED", "KVCACHED_AUTOPATCH"))
+
+
+def _autopatch_pth_installed() -> bool:
+    """True if the .pth that registers the engine import hooks is in a
+    directory whose .pth files the interpreter executes at startup."""
+    site_dirs = []
+    try:
+        site_dirs.extend(site.getsitepackages())
+    except Exception:
+        pass
+    try:
+        site_dirs.append(site.getusersitepackages())
+    except Exception:
+        pass
+    return any(os.path.isfile(os.path.join(d, AUTOPATCH_PTH)) for d in site_dirs)
+
+
+def _warn_if_autopatch_pth_missing() -> None:
+    """The engines are patched by import hooks that kvcached_autopatch.pth
+    registers at interpreter startup. Without it, ENABLE_KVCACHED and
+    KVCACHED_AUTOPATCH do nothing and vLLM/SGLang run vanilla without any
+    error (issue #470). Say so loudly whenever kvcached is imported with the
+    knobs set but the .pth absent."""
+    if not _autopatch_requested() or _autopatch_pth_installed():
+        return
+    warnings.warn(
+        "ENABLE_KVCACHED/KVCACHED_AUTOPATCH is set but kvcached_autopatch.pth "
+        "is not installed in site-packages, so vLLM/SGLang will not be patched "
+        "and will run without kvcached. Reinstall kvcached (pip install -e . or "
+        "a wheel) or run `python tools/dev_copy_pth.py` from a kvcached checkout.",
+        RuntimeWarning,
+        stacklevel=2,
+    )
+
+
+_warn_if_autopatch_pth_missing()

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,19 @@
 # SPDX-FileCopyrightText: Copyright contributors to the kvcached project
 # SPDX-License-Identifier: Apache-2.0
 
+import base64
+import hashlib
 import os
 import shutil
 import sys
+import zipfile
 from pathlib import Path
 from typing import List
 
 from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py
 from setuptools.command.develop import develop
+from setuptools.command.editable_wheel import editable_wheel
 from setuptools.command.install import install
 
 try:
@@ -156,9 +160,51 @@ class DevelopWithPth(develop):
         print(f"Installed {PTH_FILE} for editable install to: {pth_dst}")
 
 
+def add_pth_to_wheel(wheel_path: str) -> None:
+    """Append the .pth (and its RECORD entry) to the root of a built wheel.
+
+    Files at the root of a wheel are installed into site-packages, which is
+    the only place the interpreter executes .pth files.
+    """
+    pth_src = os.path.join(SCRIPT_PATH, PTH_FILE)
+    with open(pth_src, "rb") as f:
+        data = f.read()
+    digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest())
+    record_line = f"{PTH_FILE},sha256={digest.rstrip(b'=').decode()},{len(data)}\n"
+
+    tmp_path = wheel_path + ".tmp"
+    with zipfile.ZipFile(wheel_path) as src, zipfile.ZipFile(
+            tmp_path, "w", zipfile.ZIP_DEFLATED) as dst:
+        record_found = False
+        for item in src.infolist():
+            payload = src.read(item.filename)
+            if item.filename.endswith(".dist-info/RECORD"):
+                record_found = True
+                payload += record_line.encode()
+            dst.writestr(item, payload)
+        if not record_found:
+            raise RuntimeError(f"no RECORD in {wheel_path}")
+        dst.writestr(PTH_FILE, data)
+    os.replace(tmp_path, wheel_path)
+
+
+# PEP 660 editable installs (pip install -e . with setuptools>=64) build an
+# editable wheel and never run the legacy develop command, so DevelopWithPth
+# does not fire for them. Ship the .pth inside the editable wheel instead.
+class EditableWheelWithPth(editable_wheel):
+    def run(self):
+        editable_wheel.run(self)
+        wheels = sorted(Path(self.dist_dir).glob("*.whl"), key=os.path.getmtime)
+        if not wheels:
+            raise RuntimeError(f"no editable wheel found in {self.dist_dir}")
+        add_pth_to_wheel(str(wheels[-1]))
+        print(f"Added {PTH_FILE} to editable wheel: {wheels[-1]}")
+
+
 cmdclass["build_py"] = BuildPyWithPth
 cmdclass["install"] = InstallWithPth
 cmdclass["develop"] = DevelopWithPth
+cmdclass["editable_wheel"] = EditableWheelWithPth
 
 setup(
     packages=find_packages(),

--- a/tests/manifests/cpu.txt
+++ b/tests/manifests/cpu.txt
@@ -1,4 +1,5 @@
 tests/test_alloc_rollback.py
+tests/test_autopatch_pth.py
 tests/test_bestfit_page_selection.py
 tests/test_get_max_cached_blocks.py
 tests/test_ipc_name.py

--- a/tests/test_autopatch_pth.py
+++ b/tests/test_autopatch_pth.py
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: Copyright contributors to the kvcached project
+# SPDX-License-Identifier: Apache-2.0
+"""kvcached_autopatch.pth must reach site-packages, or say so (issue #470).
+
+The vLLM/SGLang import hooks are registered by kvcached_autopatch.pth, which
+the interpreter only executes from site-packages. PEP 660 editable installs
+never ran the legacy develop command that used to copy it, so
+ENABLE_KVCACHED / KVCACHED_AUTOPATCH silently did nothing. These tests pin
+down the two halves of the fix: the .pth is appended to the editable wheel
+(with a valid RECORD entry, so pip installs it), and importing kvcached with
+the knobs set but the .pth absent warns.
+
+CPU-only: setup.py is not imported (it needs a GPU toolchain); the wheel
+helper is loaded from its source.
+"""
+
+import ast
+import base64
+import hashlib
+import os
+import subprocess
+import sys
+import warnings
+import zipfile
+from pathlib import Path
+
+import pytest
+
+import kvcached
+
+ROOT = Path(__file__).resolve().parents[1]
+PTH_FILE = "kvcached_autopatch.pth"
+
+
+def _load_add_pth_to_wheel():
+    """Load setup.py's add_pth_to_wheel without executing setup.py."""
+    tree = ast.parse((ROOT / "setup.py").read_text())
+    func = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "add_pth_to_wheel"
+    )
+    namespace = {
+        "base64": base64,
+        "hashlib": hashlib,
+        "os": os,
+        "zipfile": zipfile,
+        "SCRIPT_PATH": str(ROOT),
+        "PTH_FILE": PTH_FILE,
+    }
+    exec(compile(ast.Module(body=[func], type_ignores=[]), "setup.py", "exec"), namespace)
+    return namespace["add_pth_to_wheel"]
+
+
+def _record_entry(name: str, data: bytes) -> str:
+    digest = base64.urlsafe_b64encode(hashlib.sha256(data).digest()).rstrip(b"=")
+    return f"{name},sha256={digest.decode()},{len(data)}"
+
+
+def _write_minimal_wheel(path: Path) -> dict:
+    """A tiny but valid wheel: one module, METADATA, WHEEL, RECORD."""
+    files = {
+        "kvctest.py": b"VALUE = 1\n",
+        "kvctest-0.1.dist-info/METADATA": b"Metadata-Version: 2.1\nName: kvctest\nVersion: 0.1\n",
+        "kvctest-0.1.dist-info/WHEEL": (
+            b"Wheel-Version: 1.0\nGenerator: test\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        ),
+    }
+    record = "".join(f"{_record_entry(name, data)}\n" for name, data in files.items())
+    record += "kvctest-0.1.dist-info/RECORD,,\n"
+    files["kvctest-0.1.dist-info/RECORD"] = record.encode()
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as wheel:
+        for name, data in files.items():
+            wheel.writestr(name, data)
+    return files
+
+
+def test_add_pth_to_wheel_appends_pth_and_record_entry(tmp_path):
+    wheel_path = tmp_path / "kvctest-0.1-py3-none-any.whl"
+    original = _write_minimal_wheel(wheel_path)
+    pth_data = (ROOT / PTH_FILE).read_bytes()
+
+    _load_add_pth_to_wheel()(str(wheel_path))
+
+    with zipfile.ZipFile(wheel_path) as wheel:
+        assert wheel.testzip() is None
+        names = wheel.namelist()
+        assert names.count(PTH_FILE) == 1
+        assert wheel.read(PTH_FILE) == pth_data
+        for name, data in original.items():
+            if not name.endswith("RECORD"):
+                assert wheel.read(name) == data
+        record = wheel.read("kvctest-0.1.dist-info/RECORD").decode().splitlines()
+    assert _record_entry(PTH_FILE, pth_data) in record
+    assert record[:-1] == original["kvctest-0.1.dist-info/RECORD"].decode().splitlines()
+    assert not (tmp_path / "kvctest-0.1-py3-none-any.whl.tmp").exists()
+
+
+def test_add_pth_to_wheel_rejects_a_wheel_without_record(tmp_path):
+    wheel_path = tmp_path / "broken-0.1-py3-none-any.whl"
+    with zipfile.ZipFile(wheel_path, "w") as wheel:
+        wheel.writestr("broken.py", b"")
+
+    with pytest.raises(RuntimeError, match="RECORD"):
+        _load_add_pth_to_wheel()(str(wheel_path))
+
+
+def test_pip_installs_the_appended_pth_into_the_target_root(tmp_path):
+    """pip must accept the rewritten wheel and place the .pth at the install
+    root (site-packages for a real install), where the interpreter runs it."""
+    wheel_path = tmp_path / "kvctest-0.1-py3-none-any.whl"
+    _write_minimal_wheel(wheel_path)
+    _load_add_pth_to_wheel()(str(wheel_path))
+    target = tmp_path / "target"
+
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "--quiet", "--no-index",
+         "--no-deps", "--target", str(target), str(wheel_path)],
+        check=True,
+    )
+
+    assert (target / PTH_FILE).read_bytes() == (ROOT / PTH_FILE).read_bytes()
+    assert (target / "kvctest.py").exists()
+
+
+@pytest.fixture
+def site_dirs(monkeypatch, tmp_path):
+    system = tmp_path / "site-packages"
+    user = tmp_path / "user-site"
+    system.mkdir()
+    user.mkdir()
+    monkeypatch.setattr(kvcached.site, "getsitepackages", lambda: [str(system)])
+    monkeypatch.setattr(kvcached.site, "getusersitepackages", lambda: str(user))
+    monkeypatch.delenv("ENABLE_KVCACHED", raising=False)
+    monkeypatch.delenv("KVCACHED_AUTOPATCH", raising=False)
+    return system, user
+
+
+def _assert_no_warning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        kvcached._warn_if_autopatch_pth_missing()
+
+
+@pytest.mark.parametrize("knob", ["ENABLE_KVCACHED", "KVCACHED_AUTOPATCH"])
+def test_import_warns_when_autopatch_is_requested_but_pth_is_missing(site_dirs, monkeypatch, knob):
+    monkeypatch.setenv(knob, "1")
+
+    with pytest.warns(RuntimeWarning, match="kvcached_autopatch.pth is not installed"):
+        kvcached._warn_if_autopatch_pth_missing()
+
+
+def test_no_warning_when_pth_is_in_site_packages(site_dirs, monkeypatch):
+    system, _ = site_dirs
+    (system / PTH_FILE).write_text("")
+    monkeypatch.setenv("ENABLE_KVCACHED", "true")
+
+    _assert_no_warning()
+
+
+def test_no_warning_when_pth_is_in_user_site(site_dirs, monkeypatch):
+    _, user = site_dirs
+    (user / PTH_FILE).write_text("")
+    monkeypatch.setenv("KVCACHED_AUTOPATCH", "1")
+
+    _assert_no_warning()
+
+
+def test_no_warning_when_autopatch_is_not_requested(site_dirs, monkeypatch):
+    monkeypatch.setenv("ENABLE_KVCACHED", "false")
+
+    _assert_no_warning()
+
+
+def test_warning_survives_site_lookup_failures(site_dirs, monkeypatch):
+    def boom():
+        raise AttributeError("no getsitepackages in this virtualenv")
+
+    monkeypatch.setattr(kvcached.site, "getsitepackages", boom)
+    monkeypatch.setenv("ENABLE_KVCACHED", "1")
+
+    with pytest.warns(RuntimeWarning):
+        kvcached._warn_if_autopatch_pth_missing()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

`pip install -e .` never installed `kvcached_autopatch.pth`, so on editable installs `ENABLE_KVCACHED` / `KVCACHED_AUTOPATCH` did nothing and vLLM/SGLang ran vanilla with no error. The editable wheel now carries the `.pth`, and `import kvcached` warns when the knobs are set but the `.pth` is not in a site directory.

## Root cause

With `build-backend = "setuptools.build_meta"` and setuptools>=64, `pip install -e .` goes through the PEP 660 `build_editable` hook. `DevelopWithPth` in setup.py hooks the legacy `develop` command, which that path never runs. The `.pth` is the only thing that registers the engine import hooks, so nothing in kvcached executed at all (#470).

## Changes

- `setup.py`: `EditableWheelWithPth` runs setuptools' `editable_wheel` and appends `kvcached_autopatch.pth` (with a RECORD entry) to the root of the built wheel. Root-level wheel files land in site-packages, so pip installs and uninstalls it like any other file. It fails loudly if no wheel is found instead of silently skipping.
- `kvcached/__init__.py`: with `ENABLE_KVCACHED` or `KVCACHED_AUTOPATCH` set and no `kvcached_autopatch.pth` in `site.getsitepackages()` / `site.getusersitepackages()`, emit a `RuntimeWarning` that names the fix. This only helps processes that import kvcached (a vanilla engine never does), which is why the packaging change is the real fix.
- README: the manual `python tools/dev_copy_pth.py` step is no longer needed; the tool stays for `--check` / `--remove` and as a fallback.

`data_files` was tried first and cannot work: setuptools installs `data_files` under `<dist>.data/data`, which pip places relative to `sys.prefix`, never in site-packages.

## Validation

Scratch venv on this host (Python 3.11.2, pip 26.2.1, setuptools 84.0.0). The repo was copied from main with one deviation: the `get_extensions()` call in setup.py replaced by `[], {}`, since there is no CUDA toolchain here; the `.pth` handling does not depend on the extension.

- main: `pip install -e . --no-build-isolation` gives `__editable__.kvcached-0.1.5.pth` but no `kvcached_autopatch.pth` in site-packages. With a stub `vllm` package and `ENABLE_KVCACHED=true`, `import vllm` succeeds and `kvcached.integration.vllm.autopatch` is never imported.
- main + `data_files=[("", ["kvcached_autopatch.pth"])]`: the `.pth` is nowhere under the venv.
- this branch, same command: `kvcached_autopatch.pth` is in site-packages, `RECORD` has `kvcached_autopatch.pth,sha256=McWKfjYxcxl6VZKcXni_mACnLrjLywEJJczPJZdNVZU,492`, bytes identical to the repo copy. `import vllm` now runs the hook (`kvcached.integration.vllm.autopatch` imported, patch manager logs appear). `pip uninstall kvcached` removes the `.pth`.
- `.pth` removed by hand, `ENABLE_KVCACHED=true`: `import kvcached` prints the RuntimeWarning; copied back: `python -W error -c "import kvcached"` is silent.
- `tests/test_autopatch_pth.py` (new, CPU manifest, 9 tests): wheel injection (entries preserved, RECORD line, no temp file left, wheel without RECORD rejected), `pip install --target` of the rewritten wheel places the `.pth` at the install root, and the warning (either knob; quiet with the `.pth` in site or user site or with the knobs unset; still warns when `site.getsitepackages` raises).
- `tools/run_cpu_tests.sh`: 185 passed locally (10 pre-existing macOS errors). ruff, isort, mypy 3.10 clean.
- Fork CI: CPU Tests 3.9-3.13 https://github.com/rishabhsinha17/kvcached/actions/runs/33646859752, Pre-commit/MyPy https://github.com/rishabhsinha17/kvcached/actions/runs/33646859624

Not run: `pip install -e .` with the real CUDA extension build. The editable_wheel step runs after the build and only touches the produced wheel, so I do not expect a difference; I will confirm on the L40S when I am back on it.

Found while producing the MLA rows for #425 and testing kvcached for vllm-project/aibrix#2419.

Fixes #470
